### PR TITLE
docs: add npm monthly downloads badges to package listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,39 @@
-<p align="center">
-    <img width="350px" src="https://i.imgur.com/OKnr9ns.png" />
-<h3 align="center">
-     <a href="https://starterdocs.vtempest.workers.dev">🎮 Demo</a>
-    <a href="https://starterdocs.js.org">📑 Docs</a>
-    <a href="https://starterdocs.js.org/docs/guides/starter-docs#%EF%B8%8F-installation">⬇️ Install </a>
-    <a href="https://v0.app/templates/dashboard-landing-auth-billing-teams-docs-themes-ExDfusFzX6P"> 🎨 v0 Template </a>
-</h3>
-<p align="center">
-     <a href="https://github.com/OpenSourceAGI/starter-app-dev-tools/discussions">
-     <img alt="GitHub Stars" src="https://img.shields.io/github/stars/OpenSourceAGI/starter-app-dev-tools" /></a>
-     <a href="https://discord.gg/SJdBqBz3tV">
-        <img src="https://img.shields.io/discord/1110227955554209923.svg?label=Chat&logo=Discord&colorB=7289da&style=flat"
-            alt="Join Discord" />
-    </a>
-    <a href="https://github.com/OpenSourceAGI/starter-app-dev-tools/discussions">
-    <img alt="GitHub Discussions"
-        src="https://img.shields.io/github/discussions/OpenSourceAGI/starter-app-dev-tools" />
-    </a>
-    <a href="https://codespaces.new/OpenSourceAGI/starter-app-dev-tools">
-    <img src="https://github.com/codespaces/badge.svg" width="150" height="20" alt="GitHub Codespaces" />
-    </a>
-<br />
-    <a href="https://github.com/OpenSourceAGI/starter-app-dev-tools/pulse" alt="Activity">
-        <img src="https://img.shields.io/github/commit-activity/m/OpenSourceAGI/starter-app-dev-tools" />
-    </a>
-    <img src="https://img.shields.io/github/last-commit/OpenSourceAGI/starter-app-dev-tools.svg" alt="GitHub last commit" />
-    <a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request">
-        <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" />
-    </a>
-    <br />
-    <img src="https://img.shields.io/badge/Claude-D97757?logo=claude&logoColor=fff" alt="Claude AI"> <img src="https://img.shields.io/badge/Cloudflare-F38020?logo=Cloudflare&logoColor=white" alt="Cloudflare"> <img src="https://img.shields.io/badge/shadcn%2Fui-000?logo=shadcnui&logoColor=fff" alt="shadcn/ui"> <img src="https://img.shields.io/badge/Next.js-black" alt="Next.js" />
-    <a href="https://better-auth.com/docs/introduction" target="_blank"><img src="https://i.imgur.com/eaGdjBq.png" alt="better-auth" /></a>
-</p>
+&lt;p align="center"&gt;
+    &lt;img width="350px" src="https://i.imgur.com/OKnr9ns.png" /&gt;
+&lt;h3 align="center"&gt;
+     &lt;a href="https://starterdocs.vtempest.workers.dev"&gt;🎮 Demo&lt;/a&gt;
+    &lt;a href="https://starterdocs.js.org"&gt;📑 Docs&lt;/a&gt;
+    &lt;a href="https://starterdocs.js.org/docs/guides/starter-docs#%EF%B8%8F-installation"&gt;⬇️ Install &lt;/a&gt;
+    &lt;a href="https://v0.app/templates/dashboard-landing-auth-billing-teams-docs-themes-ExDfusFzX6P"&gt; 🎨 v0 Template &lt;/a&gt;
+&lt;/h3&gt;
+&lt;p align="center"&gt;
+     &lt;a href="https://github.com/OpenSourceAGI/starter-app-dev-tools/discussions"&gt;
+     &lt;img alt="GitHub Stars" src="https://img.shields.io/github/stars/OpenSourceAGI/starter-app-dev-tools" /&gt;&lt;/a&gt;
+     &lt;a href="https://discord.gg/SJdBqBz3tV"&gt;
+        &lt;img src="https://img.shields.io/discord/1110227955554209923.svg?label=Chat&amp;logo=Discord&amp;colorB=7289da&amp;style=flat"
+            alt="Join Discord" /&gt;
+    &lt;/a&gt;
+    &lt;a href="https://github.com/OpenSourceAGI/starter-app-dev-tools/discussions"&gt;
+    &lt;img alt="GitHub Discussions"
+        src="https://img.shields.io/github/discussions/OpenSourceAGI/starter-app-dev-tools" /&gt;
+    &lt;/a&gt;
+    &lt;a href="https://codespaces.new/OpenSourceAGI/starter-app-dev-tools"&gt;
+    &lt;img src="https://github.com/codespaces/badge.svg" width="150" height="20" alt="GitHub Codespaces" /&gt;
+    &lt;/a&gt;
+&lt;br /&gt;
+    &lt;a href="https://github.com/OpenSourceAGI/starter-app-dev-tools/pulse" alt="Activity"&gt;
+        &lt;img src="https://img.shields.io/github/commit-activity/m/OpenSourceAGI/starter-app-dev-tools" /&gt;
+    &lt;/a&gt;
+    &lt;img src="https://img.shields.io/github/last-commit/OpenSourceAGI/starter-app-dev-tools.svg" alt="GitHub last commit" /&gt;
+    &lt;a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request"&gt;
+        &lt;img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" /&gt;
+    &lt;/a&gt;
+    &lt;br /&gt;
+    &lt;img src="https://img.shields.io/badge/Claude-D97757?logo=claude&amp;logoColor=fff" alt="Claude AI"&gt; &lt;img src="https://img.shields.io/badge/Cloudflare-F38020?logo=Cloudflare&amp;logoColor=white" alt="Cloudflare"&gt; &lt;img src="https://img.shields.io/badge/shadcn%2Fui-000?logo=shadcnui&amp;logoColor=fff" alt="shadcn/ui"&gt; &lt;img src="https://img.shields.io/badge/Next.js-black" alt="Next.js" /&gt;
+    &lt;a href="https://better-auth.com/docs/introduction" target="_blank"&gt;&lt;img src="https://i.imgur.com/eaGdjBq.png" alt="better-auth" /&gt;&lt;/a&gt;
+&lt;/p&gt;
 
-### 📦 Packages & Apps
+### 📦 Packages &amp; Apps
 
 **[docs](apps/docs/)** - Documentation site built with Next.js featuring AI chat, full-text search, and auto-generated API reference from TypeScript types and OpenAPI specs. Serves as the central hub for all starter template documentation.
 `bun dev` · `npm run dev`
@@ -45,39 +45,49 @@
 `bun deploy` · `wrangler deploy`
 
 **[about-system-info](packages/about-system-info/)** - Cross-platform CLI that prints CPU, memory, disk, uptime, public IP, ISP, and installed tools as a compact emoji line. Add to your shell config (`config.fish`, `.zshrc`) for an instant system snapshot on every terminal launch. Supports Windows, macOS, and Linux.
+[![npm downloads](https://img.shields.io/npm/dm/about-system.svg)](https://www.npmjs.com/package/about-system)
 `npx about-system` · `npm install -g about-system`
 
 **[api2ai-mcp-generator](packages/api2ai-mcp-generator/)** - Generate production-ready MCP servers from any OpenAPI spec using the mcp-use framework (8k+ GitHub stars). Supports HTTP, SSE, and Streamable HTTP transports; includes a built-in inspector UI at `/inspector`, Zod schema validation, bearer/API-key auth, and Docker/PM2/Kubernetes deployment configs.
+[![npm downloads](https://img.shields.io/npm/dm/api2ai.svg)](https://www.npmjs.com/package/api2ai)
 `npx api2ai <openapi-spec-url>` · `npm install -g api2ai`
 
 **[cloudflare-to-claude-fix](packages/cloudflare-to-claude-fix/)** - Cloudflare Workers Queue consumer that fires a Claude Code routine automatically whenever a Workers build fails. Subscribes to Cloudflare build events via a Workers Queue and dead-letter queue, then triggers an AI-powered fix routine. Requires Workers Paid plan and Claude Pro.
 `bun deploy` · `wrangler deploy`
 
 **[create-cloud-db](packages/create-cloud-db/)** - Interactive CLI that creates a Turso edge database and writes `TURSO_DATABASE_URL` and `TURSO_AUTH_TOKEN` directly into your `.env` file. Handles Turso login, database creation, token generation, and env-file patching in one command.
+[![npm downloads](https://img.shields.io/npm/dm/create-cloud-db.svg)](https://www.npmjs.com/package/create-cloud-db)
 `npx create-cloud-db [db-name]` · `npm install -g create-cloud-db`
 
 **[create-starter-app](packages/create-starter-app/)** - Interactive CLI to scaffold a starter app from curated templates. Prompts for framework, auth provider, database, and UI library, then downloads and configures the right template.
+[![npm downloads](https://img.shields.io/npm/dm/create-starter-app.svg)](https://www.npmjs.com/package/create-starter-app)
 `npx create-starter-app` · `bun create starter-app`
 
 **[export-svg-icons-typescript](packages/export-svg-icons-typescript/)** - Convert a folder of SVG icons into a color-customizable, tree-shakable TypeScript `index.ts` that works with any component framework. Exports all icons as named functions for tree shaking, includes JSDoc tooltip previews of each icon, and supports runtime color, size, and dimension changes. Returns SVG strings or IMG tags with inline SVG sources.
+[![npm downloads](https://img.shields.io/npm/dm/export-svg-typescript.svg)](https://www.npmjs.com/package/export-svg-typescript)
 `npx export-svg-typescript -i ./src/icons` · `npm install -g export-svg-typescript`
 
 **[git0-repo-downloader](packages/git0-repo-downloader/)** - CLI to search GitHub repositories by keyword, download source archives or platform-matched release binaries, install dependencies, and open the project in your editor. Short aliases `g` and `gg` for speed.
+[![npm downloads](https://img.shields.io/npm/dm/git0.svg)](https://www.npmjs.com/package/git0)
 `npx git0 <repo>` · `npm install -g git0`
 
 **[manage-storage](packages/manage-storage/)** - Unified storage API for AWS S3, Cloudflare R2, and Backblaze B2 built on AWS SDK v3. Auto-detects the configured provider from environment variables. Single function interface for upload, download, delete, and list — returns data directly with no filesystem dependency, ideal for serverless and edge environments.
+[![npm downloads](https://img.shields.io/npm/dm/manage-storage.svg)](https://www.npmjs.com/package/manage-storage)
 `npm install manage-storage` · `bun add manage-storage`
 
 **[open-when-ready](packages/open-when-ready/)** - Smart dev server wrapper for Next.js, Vite, or any CLI tool. Watches server output, auto-opens the browser when a ready signal is detected, and on error extracts context and launches your AI assistant (Perplexity, ChatGPT, or custom URL) with a pre-filled prompt.
+[![npm downloads](https://img.shields.io/npm/dm/open-ready.svg)](https://www.npmjs.com/package/open-ready)
 `npx open-ready <command>` · `npm install -g open-ready`
 
 **[react-native-app-buttons](packages/react-native-app-buttons/)** - React badge components for 8 app store and platform download links: iOS App Store, Google Play, Chrome Web Store, Mac App Store, Microsoft Store, Linux, and Snap Store. Detects the user's OS and highlights the matching button with a golden glow; generates native deep links (`itms-apps://`, `market://`, `ms-windows-store://`) so the store app opens directly. Badges ship as bundled assets — no CDN required.
+[![npm downloads](https://img.shields.io/npm/dm/react-app-store-buttons.svg)](https://www.npmjs.com/package/react-app-store-buttons)
 `npm install react-native-app-buttons` · `bun add react-native-app-buttons`
 
 **[server-shell-setup](packages/server-shell-setup/)** - One-command bootstrap for a modern dev environment: installs fish, nvim, nushell, bun, node, helix, starship, docker, and more. Offers an interactive menu or a fully unattended `all` mode. Includes fish aliases for `service_manager`, `killport`, and `search`. Supports Arch, Ubuntu/Debian, Android (Termux), macOS, Fedora, and Alpine.
 `wget -qO- tinyurl.com/shellsetup | bash`
 
 **[shadcn-theme-menu](packages/shadcn-theme-menu/)** - Drop-in theme switcher for shadcn/ui with 24+ color themes, dark/light/system mode toggle, and smooth animations. Includes `ThemeToggle`, `ThemeDropdown`, and `CinematicThemeSwitcher` components. Wrap your app with `ThemeProvider` and import the bundled CSS — no extra config required.
+[![npm downloads](https://img.shields.io/npm/dm/shadcn-theme-menu.svg)](https://www.npmjs.com/package/shadcn-theme-menu)
 `npm install shadcn-themes` · `bun add shadcn-themes`
 
 **[verify-phone-sms](packages/verify-phone-sms/)** - SMS phone verification API server built with Hono on Cloudflare Workers, backed by AWS SNS. Sends one-time codes, blocks VoIP numbers, enforces API-key authentication, applies rate limiting, and exposes auto-generated OpenAPI documentation. Includes health-check endpoints and CORS/security-header middleware.

--- a/README.md
+++ b/README.md
@@ -1,39 +1,39 @@
-&lt;p align="center"&gt;
-    &lt;img width="350px" src="https://i.imgur.com/OKnr9ns.png" /&gt;
-&lt;h3 align="center"&gt;
-     &lt;a href="https://starterdocs.vtempest.workers.dev"&gt;🎮 Demo&lt;/a&gt;
-    &lt;a href="https://starterdocs.js.org"&gt;📑 Docs&lt;/a&gt;
-    &lt;a href="https://starterdocs.js.org/docs/guides/starter-docs#%EF%B8%8F-installation"&gt;⬇️ Install &lt;/a&gt;
-    &lt;a href="https://v0.app/templates/dashboard-landing-auth-billing-teams-docs-themes-ExDfusFzX6P"&gt; 🎨 v0 Template &lt;/a&gt;
-&lt;/h3&gt;
-&lt;p align="center"&gt;
-     &lt;a href="https://github.com/OpenSourceAGI/starter-app-dev-tools/discussions"&gt;
-     &lt;img alt="GitHub Stars" src="https://img.shields.io/github/stars/OpenSourceAGI/starter-app-dev-tools" /&gt;&lt;/a&gt;
-     &lt;a href="https://discord.gg/SJdBqBz3tV"&gt;
-        &lt;img src="https://img.shields.io/discord/1110227955554209923.svg?label=Chat&amp;logo=Discord&amp;colorB=7289da&amp;style=flat"
-            alt="Join Discord" /&gt;
-    &lt;/a&gt;
-    &lt;a href="https://github.com/OpenSourceAGI/starter-app-dev-tools/discussions"&gt;
-    &lt;img alt="GitHub Discussions"
-        src="https://img.shields.io/github/discussions/OpenSourceAGI/starter-app-dev-tools" /&gt;
-    &lt;/a&gt;
-    &lt;a href="https://codespaces.new/OpenSourceAGI/starter-app-dev-tools"&gt;
-    &lt;img src="https://github.com/codespaces/badge.svg" width="150" height="20" alt="GitHub Codespaces" /&gt;
-    &lt;/a&gt;
-&lt;br /&gt;
-    &lt;a href="https://github.com/OpenSourceAGI/starter-app-dev-tools/pulse" alt="Activity"&gt;
-        &lt;img src="https://img.shields.io/github/commit-activity/m/OpenSourceAGI/starter-app-dev-tools" /&gt;
-    &lt;/a&gt;
-    &lt;img src="https://img.shields.io/github/last-commit/OpenSourceAGI/starter-app-dev-tools.svg" alt="GitHub last commit" /&gt;
-    &lt;a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request"&gt;
-        &lt;img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" /&gt;
-    &lt;/a&gt;
-    &lt;br /&gt;
-    &lt;img src="https://img.shields.io/badge/Claude-D97757?logo=claude&amp;logoColor=fff" alt="Claude AI"&gt; &lt;img src="https://img.shields.io/badge/Cloudflare-F38020?logo=Cloudflare&amp;logoColor=white" alt="Cloudflare"&gt; &lt;img src="https://img.shields.io/badge/shadcn%2Fui-000?logo=shadcnui&amp;logoColor=fff" alt="shadcn/ui"&gt; &lt;img src="https://img.shields.io/badge/Next.js-black" alt="Next.js" /&gt;
-    &lt;a href="https://better-auth.com/docs/introduction" target="_blank"&gt;&lt;img src="https://i.imgur.com/eaGdjBq.png" alt="better-auth" /&gt;&lt;/a&gt;
-&lt;/p&gt;
+<p align="center">
+    <img width="350px" src="https://i.imgur.com/OKnr9ns.png" />
+<h3 align="center">
+     <a href="https://starterdocs.vtempest.workers.dev">🎮 Demo</a>
+    <a href="https://starterdocs.js.org">📑 Docs</a>
+    <a href="https://starterdocs.js.org/docs/guides/starter-docs#%EF%B8%8F-installation">⬇️ Install </a>
+    <a href="https://v0.app/templates/dashboard-landing-auth-billing-teams-docs-themes-ExDfusFzX6P"> 🎨 v0 Template </a>
+</h3>
+<p align="center">
+     <a href="https://github.com/OpenSourceAGI/starter-app-dev-tools/discussions">
+     <img alt="GitHub Stars" src="https://img.shields.io/github/stars/OpenSourceAGI/starter-app-dev-tools" /></a>
+     <a href="https://discord.gg/SJdBqBz3tV">
+        <img src="https://img.shields.io/discord/1110227955554209923.svg?label=Chat&logo=Discord&colorB=7289da&style=flat"
+            alt="Join Discord" />
+    </a>
+    <a href="https://github.com/OpenSourceAGI/starter-app-dev-tools/discussions">
+    <img alt="GitHub Discussions"
+        src="https://img.shields.io/github/discussions/OpenSourceAGI/starter-app-dev-tools" />
+    </a>
+    <a href="https://codespaces.new/OpenSourceAGI/starter-app-dev-tools">
+    <img src="https://github.com/codespaces/badge.svg" width="150" height="20" alt="GitHub Codespaces" />
+    </a>
+<br />
+    <a href="https://github.com/OpenSourceAGI/starter-app-dev-tools/pulse" alt="Activity">
+        <img src="https://img.shields.io/github/commit-activity/m/OpenSourceAGI/starter-app-dev-tools" />
+    </a>
+    <img src="https://img.shields.io/github/last-commit/OpenSourceAGI/starter-app-dev-tools.svg" alt="GitHub last commit" />
+    <a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request">
+        <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" />
+    </a>
+    <br />
+    <img src="https://img.shields.io/badge/Claude-D97757?logo=claude&logoColor=fff" alt="Claude AI"> <img src="https://img.shields.io/badge/Cloudflare-F38020?logo=Cloudflare&logoColor=white" alt="Cloudflare"> <img src="https://img.shields.io/badge/shadcn%2Fui-000?logo=shadcnui&logoColor=fff" alt="shadcn/ui"> <img src="https://img.shields.io/badge/Next.js-black" alt="Next.js" />
+    <a href="https://better-auth.com/docs/introduction" target="_blank"><img src="https://i.imgur.com/eaGdjBq.png" alt="better-auth" /></a>
+</p>
 
-### 📦 Packages &amp; Apps
+### 📦 Packages & Apps
 
 **[docs](apps/docs/)** - Documentation site built with Next.js featuring AI chat, full-text search, and auto-generated API reference from TypeScript types and OpenAPI specs. Serves as the central hub for all starter template documentation.
 `bun dev` · `npm run dev`


### PR DESCRIPTION
## Summary

- Add a shields.io npm monthly-downloads badge (`img.shields.io/npm/dm/<package>`) under each npm-published package in the "📦 Packages & Apps" section of the README, linking to its npmjs.com page.
- Package names were taken from each package's `package.json` `name` field (a few differ from their folder/README-title, e.g. `about-system-info` → `about-system`, `react-native-app-buttons` → `react-app-store-buttons`).
- Left unchanged: apps (`docs`, `Cloud-Computer-Control-Panel`, `vscode-cloud`) and packages that aren't published to npm (`cloudflare-to-claude-fix`, `server-shell-setup`, `verify-phone-sms`, `web2mobile-wrapper` — the latter's `package.json` is marked `"private": true` and returns 404 on the npm registry).

## Test plan

- [x] Verified every badged package name resolves on `registry.npmjs.org` (200) and, where two similarly-named packages exist (`shadcn-theme-menu` vs `shadcn-themes`), confirmed via the registry's `repository` field which one is actually published from this repo.
- [x] Verified `web2mobile-wrapper` is not published (404 for both `web2mobile-wrapper` and `create-mobile-wrapper`, `package.json` has `"private": true`) and left it without a badge.
- [x] Diffed the rendered README to confirm only the intended badge lines were added and no other content changed.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011jGWFx4cjXVgr3qPY6ttGd)_