### PR TITLE
Fix about-system colors for light backgrounds, add background badges

### DIFF
--- a/apps/docs/content/docs/(index)/guides/about-system.mdx
+++ b/apps/docs/content/docs/(index)/guides/about-system.mdx
@@ -110,6 +110,7 @@ about-system --settings-reset
 
 # Set individual values
 about-system --set display.show_emojis false
+about-system --set display.show_backgrounds false
 about-system --set colors.user blue
 about-system --set cache.enabled true
 
@@ -145,6 +146,7 @@ about-system --cache-clear
   },
   "display": {
     "show_emojis": true,
+    "show_backgrounds": true,
     "separator": " ",
     "max_width": 120
   },

--- a/packages/about-system-info/README.md
+++ b/packages/about-system-info/README.md
@@ -210,6 +210,7 @@ about-system --cache-clear
   },
   "display": {
     "show_emojis": true,
+    "show_backgrounds": true,
     "single_line": true,
     "line_wrap_length": 100
   },
@@ -231,9 +232,19 @@ Available color options for each info block:
 - `red`, `orange`, `yellow`, `green`, `blue`, `cyan`, `purple`, `magenta`, `gray`, `lightblue`
 - Use `multicolor` for ports to get a rainbow effect
 
+All colors use darker, more saturated shades so they stay readable on both light and dark terminal backgrounds.
+
 ```bash
 about-system --set colors.user blue
 about-system --set colors.hostname green
+```
+
+#### Backgrounds
+
+By default, every info block is rendered as a colored background badge with a contrasting text color, so it stays legible no matter what background color your terminal uses. Disable it to fall back to plain colored text:
+
+```bash
+about-system --set display.show_backgrounds false
 ```
 
 #### Emojis

--- a/packages/about-system-info/src/about-system-cli.ts
+++ b/packages/about-system-info/src/about-system-cli.ts
@@ -12,6 +12,7 @@ import {
   Settings,
   DEFAULT_SETTINGS,
   colors,
+  backgrounds,
   SETTINGS_FILE,
   CACHE_FILE,
   loadSettings,
@@ -21,11 +22,25 @@ import {
 // Platform detection
 const IS_WINDOWS = os.platform() === "win32";
 
+// Foreground code -> [background code, contrasting text code] for the
+// legacy 8-color multicolor rotation (ports/pacman rainbow mode).
+const MULTICOLOR_BG: Record<number, [number, number]> = {
+  31: [41, 97], // red
+  32: [42, 30], // green
+  33: [43, 30], // yellow
+  34: [44, 97], // blue
+  35: [45, 97], // magenta
+  36: [46, 30], // cyan
+};
+
 function formatValue(key: string, value: string, settings: Settings): string {
   if (!value || value.trim() === "") return "";
 
-  const color =
-    colors[settings.colors[key] as keyof typeof colors] || colors.reset;
+  const showBackgrounds = settings.display.show_backgrounds !== false;
+  const colorName = settings.colors[key] as keyof typeof colors;
+  const bg = backgrounds[colorName as keyof typeof backgrounds];
+  const style = (showBackgrounds && bg) || colors[colorName] || colors.reset;
+  const suffix = showBackgrounds ? colors.reset : "";
   const emoji = settings.display.show_emojis ? settings.emojis[key] || "" : "";
 
   // Special handling for battery emoji
@@ -33,7 +48,7 @@ function formatValue(key: string, value: string, settings: Settings): string {
     const batteryEmoji = value.includes("+")
       ? settings.emojis.battery_charging
       : settings.emojis.battery;
-    return `${color}${batteryEmoji}${value}`;
+    return `${style}${batteryEmoji}${value}${suffix}`;
   }
 
   // Multicolor handling for ports
@@ -44,7 +59,12 @@ function formatValue(key: string, value: string, settings: Settings): string {
     const colorCodes = [31, 32, 33, 34, 35, 36];
     ports.forEach((port, index) => {
       const colorCode = colorCodes[index % colorCodes.length];
-      output += `\x1b[${colorCode}m${port}\x1b[0m `;
+      if (showBackgrounds) {
+        const [bgCode, textCode] = MULTICOLOR_BG[colorCode];
+        output += `\x1b[${bgCode}m\x1b[${textCode}m${port}\x1b[0m `;
+      } else {
+        output += `\x1b[${colorCode}m${port}\x1b[0m `;
+      }
     });
     return output.trim();
   }
@@ -52,10 +72,10 @@ function formatValue(key: string, value: string, settings: Settings): string {
   // Multicolor handling for pacman
   if (key === "pacman" && settings.colors[key] === "multicolor" && value) {
     const emoji = settings.display.show_emojis ? settings.emojis.pacman : "";
-    return `${color}${emoji}${value}`;
+    return `${style}${emoji}${value}${suffix}`;
   }
 
-  return `${color}${emoji}${value}`;
+  return `${style}${emoji}${value}${suffix}`;
 }
 
 /**
@@ -230,6 +250,10 @@ function handleSettingsCommand(args: string[]): boolean {
       const parsedValue =
         value.startsWith("{") || value.startsWith("[")
           ? JSON.parse(value)
+          : value === "true"
+          ? true
+          : value === "false"
+          ? false
           : value;
 
       const keys = key.split(".");
@@ -400,6 +424,7 @@ Examples:
   about-system disk_used            # Show only disk usage
   about-system --install
   about-system --set display.show_emojis false
+  about-system --set display.show_backgrounds false
   about-system --set colors.user blue
   about-system --set emojis.cpu "🚀 "
   about-system --set labels.cpu "Processor"

--- a/packages/about-system-info/src/info/settings.ts
+++ b/packages/about-system-info/src/info/settings.ts
@@ -17,18 +17,43 @@ export const SETTINGS_FILE = path.join(
 export const CACHE_FILE = path.join(os.tmpdir(), "systeminfo-cache.json");
 
 // Color codes
+//
+// These are deliberately darker/more saturated than a typical terminal
+// palette. The original bright variants (e.g. yellow 226, cyan 51, gray 250)
+// have very high luminance and are nearly unreadable on a light/white
+// terminal background. `lightblue` was also mislabeled: it pointed at gold
+// (220), not a blue at all. Every value below reads clearly on both light
+// and dark backgrounds.
 export const colors = {
   reset: "\x1b[0m",
-  red: "\x1b[38;5;196m",
-  orange: "\x1b[38;5;208m",
-  yellow: "\x1b[38;5;226m",
-  green: "\x1b[38;5;46m",
-  blue: "\x1b[38;5;39m",
-  cyan: "\x1b[38;5;51m",
-  purple: "\x1b[38;5;171m",
-  magenta: "\x1b[38;5;213m",
-  gray: "\x1b[38;5;250m",
-  lightblue: "\x1b[38;5;220m",
+  red: "\x1b[38;5;160m",
+  orange: "\x1b[38;5;130m",
+  yellow: "\x1b[38;5;58m",
+  green: "\x1b[38;5;22m",
+  blue: "\x1b[38;5;25m",
+  cyan: "\x1b[38;5;23m",
+  purple: "\x1b[38;5;91m",
+  magenta: "\x1b[38;5;125m",
+  gray: "\x1b[38;5;238m",
+  lightblue: "\x1b[38;5;24m",
+};
+
+// Background variants, keyed the same as `colors`, used when
+// `display.show_backgrounds` is enabled. Each entry sets its own background
+// block plus a foreground text color chosen for contrast against it, so
+// every item is legible on its own regardless of what the terminal's
+// background actually is.
+export const backgrounds = {
+  red: "\x1b[48;5;88m\x1b[38;5;255m",
+  orange: "\x1b[48;5;166m\x1b[38;5;232m",
+  yellow: "\x1b[48;5;178m\x1b[38;5;232m",
+  green: "\x1b[48;5;22m\x1b[38;5;255m",
+  blue: "\x1b[48;5;18m\x1b[38;5;255m",
+  cyan: "\x1b[48;5;23m\x1b[38;5;255m",
+  purple: "\x1b[48;5;54m\x1b[38;5;255m",
+  magenta: "\x1b[48;5;53m\x1b[38;5;255m",
+  gray: "\x1b[48;5;236m\x1b[38;5;255m",
+  lightblue: "\x1b[48;5;26m\x1b[38;5;255m",
 };
 
 // Default settings
@@ -154,6 +179,7 @@ export const DEFAULT_SETTINGS = {
   },
   display: {
     show_emojis: true,
+    show_backgrounds: true,
     single_line: true,
     line_wrap_length: process?.stdout?.columns || 100,
   },
@@ -172,6 +198,8 @@ export interface Settings {
   labels: Record<string, string>;
   display: {
     show_emojis: boolean;
+    /** true (default): give every item its own background color block, so it stays legible regardless of the terminal's background */
+    show_backgrounds: boolean;
     /** true: print one continuous line and let the terminal soft-wrap it; false: hard-wrap at line_wrap_length */
     single_line: boolean;
     line_wrap_length: number;

--- a/skills/ask-about-system/API.md
+++ b/skills/ask-about-system/API.md
@@ -53,7 +53,7 @@ Note the two internal renames: `os` maps to `os_info`, `pacman` maps to `package
 | `colors` | `{ [block]: color }` | `red`, `orange`, `yellow`, `green`, `blue`, `cyan`, `purple`, `magenta`, `gray`, `lightblue`; `multicolor` for `ports`. |
 | `emojis` | `{ [block]: string }` | Include the trailing space, e.g. `"🚀 "`. |
 | `labels` | `{ [block]: string }` | Text label used when emojis are off. |
-| `display` | `{ show_emojis, single_line, line_wrap_length }` | |
+| `display` | `{ show_emojis, show_backgrounds, single_line, line_wrap_length }` | `show_backgrounds` (default `true`) renders each block as a colored background badge with contrasting text, legible on any terminal background. |
 | `network` | `{ show_offline_message }` | |
 | `advanced` | `{ debug }` | |
 


### PR DESCRIPTION
## Summary

- The `about-system` CLI's default color palette used very bright/light ANSI colors (`yellow`, `cyan`, `gray`, `green`, `magenta`) that have poor contrast on a light terminal background. `lightblue` was also mislabeled — it actually pointed at a gold/yellow ANSI code, not blue. All colors in `packages/about-system-info/src/info/settings.ts` are now darker, more saturated shades that read clearly on both light and dark backgrounds.
- Added a new `display.show_backgrounds` setting, **on by default**, that renders every info item (user, hostname, CPU, etc.) as its own colored background badge with a contrasting text color, so each item stays legible regardless of the terminal's actual background color. Disable with `about-system --set display.show_backgrounds false`.
- Fixed a latent bug in `--set`: boolean values like `false`/`true` were stored as the literal strings `"false"`/`"true"` instead of real booleans, which silently broke existing toggles such as `display.show_emojis` (and would have broken the new `show_backgrounds` toggle too).
- Updated README, docs guide, and the `ask-about-system` skill's API reference to document the new setting.

## Test plan

- [x] `pnpm install` + `vite build` in `packages/about-system-info` succeeds
- [x] Ran the built CLI and confirmed default output now shows colored background badges per item
- [x] Ran with `--set display.show_backgrounds false` and confirmed it falls back to plain (now darker) foreground colors
- [x] Confirmed `--set display.show_emojis false` (and the new backgrounds toggle) now correctly persist as real booleans

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAiR2Ctsn1biX7eC9biT2R

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAiR2Ctsn1biX7eC9biT2R)_