### PR TITLE
Configure moduleResolution to bundler in about-system-info

### DIFF
--- a/packages/about-system-info/tsconfig.json
+++ b/packages/about-system-info/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
+    "moduleResolution": "bundler",
     "lib": ["ES2022"],
     "outDir": "./dist",
     "rootDir": "./src",


### PR DESCRIPTION
## Summary
Updated the TypeScript compiler configuration for the `about-system-info` package to use the `bundler` module resolution strategy.

## Changes
- Added `"moduleResolution": "bundler"` to `tsconfig.json` compiler options

## Details
The `bundler` module resolution strategy is the recommended setting for projects that will be bundled. This aligns the TypeScript configuration with modern bundler expectations and ensures consistent module resolution behavior during the build process.

https://claude.ai/code/session_012hYpYUF2ps2W1TmRPnbW1p