### PR TITLE
feat(shadcn-theme-menu): make the theme's font follow the theme

### DIFF
--- a/packages/shadcn-theme-menu/README.md
+++ b/packages/shadcn-theme-menu/README.md
@@ -39,6 +39,7 @@ Beautiful theme components for shadcn/ui with 24+ color themes, dark/light mode,
 - **Fully type-safe** – complete TypeScript support with exported types
 - **Customizable** – pass your own Button/DropdownMenu components or set themes programmatically
 - **Persistent** – automatic `localStorage` support for color theme preferences
+- **Themed typography** – each theme brings its own font, previewed live on hover
 
 ---
 
@@ -123,6 +124,57 @@ Animated toggle with particle effects.
 ### Available Themes
 
 24 themes: `modern-minimal`, `elegant-luxury`, `cyberpunk`, `twitter`, `mocha-mousse`, `bubblegum`, `amethyst-haze`, `pink-lemonade`, `notebook`, `doom-64`, `catppuccin`, `graphite`, `perpetuity`, `kodama-grove`, `cosmic-night`, `tangerine`, `quantum-rose`, `nature`, `bold-tech`, `amber-minimal`, `supabase`, `neo-brutalism`, `solar-dusk`, `claymorphism`, `pastel-dreams`
+
+## Theme Fonts
+
+A theme is a typeface as much as a palette. Each `theme-*` class defines
+`--font-sans`, `--font-serif` and `--font-mono` alongside its colors, and
+`themes.css` both loads those families from Google Fonts and applies the sans
+face to the document:
+
+```css
+html[class*="theme-"],
+html[class*="theme-"] body {
+  font-family: var(--font-sans, ui-sans-serif, system-ui, sans-serif);
+}
+```
+
+Because the color theme is a class on `<html>`, the font follows every theme
+change — including the hover preview in `ThemeDropdown` and `SidebarUserMenu`,
+where the page re-typesets under the cursor and reverts on mouse-out. Nothing
+to wire up: importing `themes.css` is enough.
+
+The serif and mono faces are not applied globally; reach them with the
+`.font-theme-serif` / `.font-theme-mono` utilities (and `.font-theme-sans` for
+a subtree that opted out).
+
+```tsx
+<blockquote className="font-theme-serif">Set in the theme's serif face.</blockquote>
+<pre className="font-theme-mono">$ npm install</pre>
+```
+
+**Overriding.** To keep a self-hosted face (`next/font`, Fontsource) while the
+theme colors still switch, restate the same selector pair after the import —
+equal specificity, later source order, so yours wins:
+
+```css
+@import "shadcn-theme-menu/themes.css";
+
+html[class*="theme-"],
+html[class*="theme-"] body {
+  font-family: var(--font-geist-sans), sans-serif;
+}
+```
+
+Redefining `--font-sans` on `:root` will *not* do it: each theme block declares
+that variable at two-class specificity and outranks `:root`. A bare
+`body { font-family }` loses too. For a user-facing font preference, set
+`style.fontFamily` inline on **both** `<html>` and `<body>` — inline beats the
+rule, but setting it on `<html>` alone is overridden again at `<body>`, since
+the rule targets both. Clearing it back to `""` restores the theme's font.
+
+A handful of themes (`claude`, `caffeine`, `lemonade`) deliberately declare no
+font of their own and inherit whatever your app already uses.
 
 ## Custom Components
 

--- a/packages/shadcn-theme-menu/src/themes-shadcn.css
+++ b/packages/shadcn-theme-menu/src/themes-shadcn.css
@@ -1,3 +1,51 @@
+/* ---------------------------------------------------------------------------
+ * Theme typography
+ *
+ * Every `theme-*` block in this file carries `--font-sans` / `--font-serif` /
+ * `--font-mono` next to its colors, so a theme is a typeface as much as a
+ * palette. Two things have to be true for that to reach the screen:
+ *
+ *   1. the families have to be loaded — the Google Fonts import below covers
+ *      every non-system family the themes reference; and
+ *   2. something has to actually read `--font-sans` — the rule under it.
+ *
+ * The rule is scoped to `theme-*` so it only takes over once a color theme is
+ * active. Because the color theme is a class on `<html>`, the font then follows
+ * every theme change — including the hover preview in `ThemeDropdown`, where
+ * the page re-typesets under the cursor and reverts on mouse-out.
+ *
+ * Overriding it: the selector is (0,1,1), so a bare `body { font-family }` in
+ * an app stylesheet loses to it — restate this same selector pair after the
+ * import (equal specificity, later source order), or set `style.fontFamily`
+ * inline on `<html>` *and* `<body>`: the rule targets both, so an inline style
+ * on `<html>` alone is overridden again at `<body>`. Redefining `--font-sans`
+ * on `:root` is *not* enough: each theme block declares it at (0,2,0) and
+ * outranks `:root`.
+ *
+ * Themes with no `--font-*` of their own — `claude`, `caffeine`, `lemonade` —
+ * deliberately inherit whatever the app already uses.
+ * ------------------------------------------------------------------------- */
+@import url("https://fonts.googleapis.com/css2?family=Architects+Daughter&family=DM+Sans:wght@400;500;700&family=Fira+Code:wght@400;500;700&family=Geist+Mono:wght@400;500;700&family=Geist:wght@400;500;700&family=IBM+Plex+Mono:wght@400;500;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&family=Libre+Baskerville:wght@400;700&family=Lora:wght@400;500;600;700&family=Merriweather:wght@400;700&family=Montserrat:wght@400;500;600;700&family=Open+Sans:wght@400;500;600;700&family=Outfit:wght@400;500;600;700&family=Oxanium:wght@400;500;600;700&family=Playfair+Display:wght@400;500;600;700&family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Poppins:wght@400;500;600;700&family=Quicksand:wght@400;500;600;700&family=Roboto+Mono:wght@400;500;700&family=Roboto:wght@400;500;700&family=Source+Code+Pro:wght@400;500;700&family=Source+Serif+4:wght@400;500;600;700&family=Space+Mono:wght@400;700&family=Ubuntu+Mono:wght@400;700&display=swap");
+
+html[class*="theme-"],
+html[class*="theme-"] body {
+  font-family: var(--font-sans, ui-sans-serif, system-ui, sans-serif);
+}
+
+/* Opt-in escape hatches for the other two faces a theme defines — there is no
+   other way to reach them, since only the sans face is applied globally. */
+.font-theme-sans {
+  font-family: var(--font-sans, ui-sans-serif, system-ui, sans-serif);
+}
+
+.font-theme-serif {
+  font-family: var(--font-serif, ui-serif, Georgia, serif);
+}
+
+.font-theme-mono {
+  font-family: var(--font-mono, ui-monospace, monospace);
+}
+
 .theme-minimal.light {
   --background: #ffffff;
   --foreground: #333333;
@@ -71,6 +119,9 @@
   --sidebar-accent-foreground: #bfdbfe;
   --sidebar-border: #404040;
   --sidebar-ring: #3b82f6;
+  --font-sans: Inter, sans-serif;
+  --font-serif: Source Serif 4, serif;
+  --font-mono: JetBrains Mono, monospace;
 }
 
 .theme-lemonade.light {
@@ -223,6 +274,9 @@
   --sidebar-border: #38444d;
   --sidebar-ring: #1da1f2;
   --shadow-color: rgba(29, 161, 242, 0.25);
+  --font-sans: Open Sans, sans-serif;
+  --font-serif: Georgia, serif;
+  --font-mono: Menlo, monospace;
 }
 
 .theme-mocha.light {
@@ -304,6 +358,9 @@
   --sidebar-border: #56453f;
   --sidebar-ring: #c39e88;
   --shadow-color: hsl(20 18% 30% / 0.5);
+  --font-sans: DM Sans, sans-serif;
+  --font-serif: Georgia, serif;
+  --font-mono: Menlo, monospace;
 }
 
 .theme-bubblegum.light {
@@ -470,6 +527,9 @@
   --sidebar-accent-foreground: #f2b8c6;
   --sidebar-border: #2a273a;
   --sidebar-ring: #a995c9;
+  --font-sans: Geist, sans-serif;
+  --font-serif: "Lora", Georgia, serif;
+  --font-mono: "Fira Code", "Courier New", monospace;
 }
 
 .theme-notebook.light {
@@ -738,6 +798,9 @@
   --sidebar-accent-foreground: #1e1e2e;
   --sidebar-border: #45475a;
   --sidebar-ring: #cba6f7;
+  --font-sans: Montserrat, sans-serif;
+  --font-serif: Georgia, serif;
+  --font-mono: Fira Code, monospace;
 }
 
 .theme-graphite.light {
@@ -991,6 +1054,9 @@
   --sidebar-accent-foreground: #2a2521;
   --sidebar-border: #5a5345;
   --sidebar-ring: #8a9f7b;
+  --font-sans: Merriweather, serif;
+  --font-serif: Source Serif 4, serif;
+  --font-mono: JetBrains Mono, monospace;
 }
 
 .theme-cosmic.light {
@@ -1072,6 +1138,9 @@
   --sidebar-accent-foreground: #e2e2f5;
   --sidebar-border: #303052;
   --sidebar-ring: #a48fff;
+  --font-sans: Inter, sans-serif;
+  --font-serif: Georgia, serif;
+  --font-mono: JetBrains Mono, monospace;
 }
 
 .theme-tangerine.light {
@@ -1152,6 +1221,9 @@
   --sidebar-accent-foreground: #bfdbfe;
   --sidebar-border: #3d4354;
   --sidebar-ring: #e05d38;
+  --font-sans: Inter, sans-serif;
+  --font-serif: Source Serif 4, serif;
+  --font-mono: JetBrains Mono, monospace;
 }
 
 .theme-quantum.light {
@@ -1311,6 +1383,9 @@
   --sidebar-accent-foreground: #f0ebe5;
   --sidebar-border: #3e4a3d;
   --sidebar-ring: #4caf50;
+  --font-sans: Montserrat, sans-serif;
+  --font-serif: Merriweather, serif;
+  --font-mono: Source Code Pro, monospace;
 }
 
 .theme-boldtech.light {
@@ -1392,6 +1467,9 @@
   --sidebar-accent-foreground: #e0e7ff;
   --sidebar-border: #2e1065;
   --sidebar-ring: #8b5cf6;
+  --font-sans: Roboto, sans-serif;
+  --font-serif: Playfair Display, serif;
+  --font-mono: Fira Code, monospace;
 }
 
 .theme-luxury.light {
@@ -1473,6 +1551,9 @@
   --sidebar-accent-foreground: #fef3c7;
   --sidebar-border: #44403c;
   --sidebar-ring: #b91c1c;
+  --font-sans: Poppins, sans-serif;
+  --font-serif: Libre Baskerville, serif;
+  --font-mono: IBM Plex Mono, monospace;
 }
 
 .theme-ambermin.light {
@@ -1555,6 +1636,9 @@
   --sidebar-accent-foreground: #fde68a;
   --sidebar-border: #404040;
   --sidebar-ring: #f59e0b;
+  --font-sans: Inter, sans-serif;
+  --font-serif: Source Serif 4, serif;
+  --font-mono: JetBrains Mono, monospace;
 }
 
 .theme-supabase.light {
@@ -1636,6 +1720,9 @@
   --sidebar-accent-foreground: #fafafa;
   --sidebar-border: #292929;
   --sidebar-ring: #4ade80;
+  --font-sans: Outfit, sans-serif;
+  --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+  --font-mono: monospace;
 }
 
 .theme-brutalism.light {
@@ -1716,6 +1803,8 @@
   --sidebar-accent-foreground: #000000;
   --sidebar-border: #ffffff;
   --sidebar-ring: #ff6666;
+  --font-sans: DM Sans, sans-serif;
+  --font-mono: Space Mono, monospace;
 }
 
 .theme-solardusk.light {
@@ -1798,6 +1887,9 @@
   --sidebar-border: #44403c;
   --sidebar-ring: #f97316;
   --shadow-color: hsl(0 0% 5%);
+  --font-sans: Oxanium, sans-serif;
+  --font-serif: Merriweather, serif;
+  --font-mono: Fira Code, monospace;
 }
 
 .theme-claymorphism.light {
@@ -1880,6 +1972,9 @@
   --sidebar-border: #3a3633;
   --sidebar-ring: #818cf8;
   --shadow-color: hsl(0 0% 0%);
+  --font-sans: Plus Jakarta Sans, sans-serif;
+  --font-serif: Lora, serif;
+  --font-mono: Roboto Mono, monospace;
 }
 
 .theme-cyberpunk.light {
@@ -1960,6 +2055,8 @@
   --sidebar-accent-foreground: #0c0c1d;
   --sidebar-border: #2e2e5e;
   --sidebar-ring: #ff00c8;
+  --font-sans: Outfit, sans-serif;
+  --font-mono: Fira Code, monospace;
 }
 
 .theme-pastel.light {
@@ -2041,6 +2138,9 @@
   --sidebar-accent-foreground: #d1d5db;
   --sidebar-border: #3f324a;
   --sidebar-ring: #c0aafd;
+  --font-sans: Open Sans, sans-serif;
+  --font-serif: Source Serif 4, serif;
+  --font-mono: IBM Plex Mono, monospace;
 }
 
 .theme-cleanslate.light {
@@ -2122,6 +2222,9 @@
   --sidebar-accent-foreground: #d1d5db;
   --sidebar-border: #4b5563;
   --sidebar-ring: #818cf8;
+  --font-sans: Inter, sans-serif;
+  --font-serif: Merriweather, serif;
+  --font-mono: JetBrains Mono, monospace;
 }
 
 .theme-caffeine.light {
@@ -2275,6 +2378,9 @@
   --sidebar-accent-foreground: #a1a1aa;
   --sidebar-border: #4b5563;
   --sidebar-ring: #34d399;
+  --font-sans: DM Sans, sans-serif;
+  --font-serif: Lora, serif;
+  --font-mono: IBM Plex Mono, monospace;
 }
 
 .theme-retro.light {
@@ -2355,6 +2461,8 @@
   --sidebar-accent-foreground: #ffffff;
   --sidebar-border: #586e75;
   --sidebar-ring: #d33682;
+  --font-sans: Outfit, sans-serif;
+  --font-mono: Space Mono, monospace;
 }
 
 .theme-bloom.light {
@@ -2436,6 +2544,9 @@
   --sidebar-accent-foreground: #e5e5e5;
   --sidebar-border: #444444;
   --sidebar-ring: #6c5ce7;
+  --font-sans: Montserrat, sans-serif;
+  --font-serif: Playfair Display, serif;
+  --font-mono: Source Code Pro, monospace;
 }
 
 .theme-candyland.light {
@@ -2510,6 +2621,8 @@
   --sidebar-accent-foreground: #000000;
   --sidebar-border: #444444;
   --sidebar-ring: #ff99cc;
+  --font-sans: Poppins, sans-serif;
+  --font-mono: Roboto Mono, monospace;
 }
 
 .theme-aurora.light {
@@ -2585,6 +2698,9 @@
   --sidebar-accent-foreground: #e5e5e5;
   --sidebar-border: #444444;
   --sidebar-ring: #34a85a;
+  --font-sans: Plus Jakarta Sans, sans-serif;
+  --font-serif: Source Serif 4, serif;
+  --font-mono: JetBrains Mono, monospace;
 }
 
 .theme-vintage.light {
@@ -2666,6 +2782,9 @@
   --sidebar-accent-foreground: #ece5d8;
   --sidebar-border: #4a4039;
   --sidebar-ring: #c0a080;
+  --font-sans: Libre Baskerville, serif;
+  --font-serif: Lora, serif;
+  --font-mono: IBM Plex Mono, monospace;
 }
 
 .theme-horizon.light {
@@ -2747,6 +2866,9 @@
   --sidebar-accent-foreground: #2a2024;
   --sidebar-border: #463a41;
   --sidebar-ring: #ff7e5f;
+  --font-sans: Montserrat, sans-serif;
+  --font-serif: Merriweather, serif;
+  --font-mono: Ubuntu Mono, monospace;
 }
 
 .theme-starry.light {
@@ -2820,6 +2942,7 @@
   --sidebar-border: #2d2e3e;
   --sidebar-ring: #ffe066;
   --radius: 0.5rem;
+  --font-sans: Libre Baskerville, serif;
 }
 
 .theme-claude.light {
@@ -3054,4 +3177,7 @@
   --sidebar-accent-foreground: #fafafa;
   --sidebar-border: #ffffff;
   --sidebar-ring: #525252;
+  --font-sans: Geist Mono, monospace;
+  --font-serif: Geist Mono, monospace;
+  --font-mono: Geist Mono, monospace;
 }

--- a/skills/ask-shadcn-theme-menu/SKILL.md
+++ b/skills/ask-shadcn-theme-menu/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ask-shadcn-theme-menu
-description: Guide to shadcn-theme-menu (packages/shadcn-theme-menu), the shadcn/ui theme switcher — wiring ThemeProvider, ThemeToggle, ThemeDropdown, CinematicThemeSwitcher and SidebarUserMenu, importing themes.css, the 25 OKLCH color themes, setting themes programmatically, and injecting your own Button/DropdownMenu. Use when working with shadcn-theme-menu or troubleshooting it — a flash of the wrong theme on load, colors that don't change when the theme does, dark mode not applying, hydration mismatch warnings, or the dropdown rendering unstyled.
+description: Guide to shadcn-theme-menu (packages/shadcn-theme-menu), the shadcn/ui theme switcher — wiring ThemeProvider, ThemeToggle, ThemeDropdown, CinematicThemeSwitcher and SidebarUserMenu, importing themes.css, the 25 OKLCH color themes, per-theme fonts, setting themes programmatically, and injecting your own Button/DropdownMenu. Use when working with shadcn-theme-menu or troubleshooting it — a flash of the wrong theme on load, colors that don't change when the theme does, fonts that don't change with the theme (or change when they shouldn't), dark mode not applying, hydration mismatch warnings, or the dropdown rendering unstyled.
 ---
 
 # Working With shadcn-theme-menu
@@ -11,7 +11,7 @@ The component set in `packages/shadcn-theme-menu`, published as **`shadcn-theme-
 
 Three pieces, in this order:
 
-1. **The CSS**, once, at the app root: `import "shadcn-theme-menu/themes.css";` — it defines every `theme-*` class as OKLCH custom properties.
+1. **The CSS**, once, at the app root: `import "shadcn-theme-menu/themes.css";` — it defines every `theme-*` class as OKLCH custom properties plus `--font-sans`/`--font-serif`/`--font-mono`, loads those families from Google Fonts, and applies the sans face to the document.
 2. **The provider**, wrapping the app: `<ThemeProvider attribute="class" defaultTheme="system">`. It re-exports `next-themes`, so `useTheme()` works as usual.
 3. **A switcher component** anywhere below it.
 
@@ -45,6 +45,8 @@ document.documentElement.classList.add(`theme-${name}`);
 
 **Available themes** — 25 of them: `modern-minimal`, `elegant-luxury`, `cyberpunk`, `twitter`, `mocha-mousse`, `bubblegum`, `amethyst-haze`, `pink-lemonade`, `notebook`, `doom-64`, `catppuccin`, `graphite`, `perpetuity`, `kodama-grove`, `cosmic-night`, `tangerine`, `quantum-rose`, `nature`, `bold-tech`, `amber-minimal`, `supabase`, `neo-brutalism`, `solar-dusk`, `claymorphism`, `pastel-dreams`. `themeColors[name]` gives `{ primary, secondary }` for swatches; `formatThemeName("modern-minimal")` → `"Modern Minimal"`.
 
+**Fonts follow the theme** — each `theme-*` class carries `--font-sans`/`--font-serif`/`--font-mono`, and `themes.css` applies the sans face at `html[class*="theme-"], html[class*="theme-"] body`. Since the theme is a class on `<html>`, the page re-typesets on every theme change, hover preview included. Nothing to wire up. Serif and mono aren't global — use the `.font-theme-serif` / `.font-theme-mono` utilities. To keep a self-hosted face (`next/font`, Fontsource), restate that same selector pair after the import — equal specificity, later source order. Redefining `--font-sans` on `:root` won't do it (theme blocks declare it at (0,2,0)) and neither will a bare `body { font-family }` (0,0,1); an inline `style.fontFamily` wins but must go on **both** `<html>` and `<body>` (the rule targets both, so `<html>` alone is overridden at `<body>`) — that's the handle for a user font preference, and clearing it to `""` restores the theme's font. `claude`, `caffeine` and `lemonade` declare no font and inherit the app's.
+
 **Using your own primitives** — pass `Button` and a `DropdownMenu` object (`Root`, `Trigger`, `Content`, `Item`, `Label`, `Separator`) so the switcher inherits your design system instead of the bundled shadcn copies.
 
 **Reacting to changes** — `onThemeChange` on `ThemeToggle`; `onColorThemeChange` / `onModeChange` on `ThemeDropdown`.
@@ -57,6 +59,10 @@ document.documentElement.classList.add(`theme-${name}`);
 | Hydration mismatch warning on the toggle | The server can't know the stored theme. Render the switcher only after mount (`useEffect` + `mounted` flag), or pass `suppressHydrationWarning` on `<html>` as `next-themes` recommends. |
 | Mode toggles but colors never change | `themes.css` wasn't imported, so the `theme-*` classes have no definitions. Import it at the root; the package marks CSS as side-effectful so bundlers keep it. |
 | Colors change but dark mode doesn't | The two axes are separate: dark mode is `next-themes`' `class` attribute, color theme is `theme-*`. Make sure `ThemeProvider` has `attribute="class"` and your Tailwind config uses `darkMode: "class"`. |
+| Colors change but the font doesn't | The `theme-*` class is on `<body>` (or a wrapper) instead of `<html>` — the font rule is scoped to `html[class*="theme-"]`. Move the class to `document.documentElement`. |
+| Font never changes on any theme | Something outranks the package rule (0,1,1): a Tailwind `font-*` utility or `body.some-class` rule on an element *below* `<html>`, or an inline `style.fontFamily` left set on `<html>`/`<body>`. Check computed styles on `<body>` and drop the competing declaration. |
+| Font changes when it shouldn't | That's the rule doing its job. Pin your own by restating `html[class*="theme-"], html[class*="theme-"] body { font-family: … }` after the import — the theme colors keep switching, the face doesn't. `:root { --font-sans: … }` is too weak; the theme blocks outrank it. |
+| Theme font renders as the fallback | The family isn't loaded — either the Google Fonts `@import` at the top of `themes.css` was stripped (a bundler that hoists `@import` after other rules drops it) or the network blocks fonts.googleapis.com. Self-host the face and redefine `--font-sans`. |
 | Chosen theme resets on reload | Persistence uses the `color-theme` `localStorage` key; something else is clearing it, or the app runs in an incognito/storage-blocked context. |
 | Dropdown renders unstyled | Your project has no Tailwind/shadcn base layer, or you passed custom `DropdownMenu` primitives without their styles. Import `themes.css` and keep your shadcn `globals.css`. |
 | `Cannot find module 'next-themes'` | It's a peer dependency, not bundled — install it. |


### PR DESCRIPTION
Every theme block already carried --font-sans/--font-serif/--font-mono next to its colors, but nothing loaded those families or read the variables, so switching themes only ever changed the palette. qwksearch got the typography half by hand — a Google Fonts import in its own globals.css plus `font-sans` on <body> — which meant the behavior lived in the app rather than the package every other consumer installs.

Move it into themes.css:

- Import the 25 non-system families the themes reference from Google Fonts (audited: every family used is loaded, nothing unused is).
- Apply the sans face at `html[class*="theme-"], html[class*="theme-"] body`, scoped so it only takes over once a color theme is active. Since the theme is a class on <html>, the page now re-typesets on every theme change — including the hover preview in ThemeDropdown and SidebarUserMenu, which already swap the class on mouseenter and revert on mouseleave.
- Add .font-theme-serif/.font-theme-mono/.font-theme-sans as the only way to reach the other two faces, which stay opt-in.

Backfill the 28 `.theme-*.dark` blocks that were missing the font variables their `.light` sibling declared — without this, half the themes silently lost their typeface in dark mode once the rule started reading them. `claude`, `caffeine` and `lemonade` declare no font in either variant and keep inheriting the app's.

Verified in Chromium: the computed font tracks the theme class on html, body and descendants; themes with no font fall back to the declared stack; with no theme class the package leaves typography untouched. Override precedence checked too — a bare `body { font-family }` and `:root { --font-sans }` both lose to the theme, restating the selector pair wins, and an inline style.fontFamily wins only when set on <body> as well as <html> (which is what qwksearch's own font-preference script already does, so its user font setting still overrides and still reverts cleanly when cleared).


Claude-Session: https://claude.ai/code/session_015BG9TFkPhji3gjuwDmHdwR