### PR TITLE
Enlarge globe and reshape region section in Create Manager form

### DIFF
--- a/apps/Cloud-Computer-Control-Panel/components/instance/create-manager.tsx
+++ b/apps/Cloud-Computer-Control-Panel/components/instance/create-manager.tsx
@@ -305,10 +305,16 @@ export function CreateManager({ credentials, onSuccess }: { credentials: any; on
               />
             </div>
 
-            <div className="space-y-2">
-              <div className="flex items-center gap-3">
-                <div className="flex-1 space-y-2">
-                  <Label htmlFor="region">Region</Label>
+            <div className="space-y-3">
+              <Label htmlFor="region">Region</Label>
+              <div className="flex flex-col items-center gap-4 sm:flex-row sm:items-center">
+                <GlobeCdn
+                  markers={AWS_REGION_MARKERS}
+                  arcs={[]}
+                  className="w-32 shrink-0 sm:w-36"
+                  speed={0.004}
+                />
+                <div className="w-full flex-1 space-y-2">
                   <Select
                     value={formData.region}
                     onValueChange={(value) => setFormData({ ...formData, region: value })}
@@ -324,19 +330,13 @@ export function CreateManager({ credentials, onSuccess }: { credentials: any; on
                       ))}
                     </SelectContent>
                   </Select>
+                  <div className="flex items-center gap-1 pt-1">
+                    <Badge variant="outline" className="text-xs">
+                      <MapPin className="h-3 w-3 mr-1" />
+                      {formData.region}
+                    </Badge>
+                  </div>
                 </div>
-                <GlobeCdn
-                  markers={AWS_REGION_MARKERS}
-                  arcs={[]}
-                  className="w-16 shrink-0"
-                  speed={0.004}
-                />
-              </div>
-              <div className="flex items-center gap-1 pt-1">
-                <Badge variant="outline" className="text-xs">
-                  <MapPin className="h-3 w-3 mr-1" />
-                  {formData.region}
-                </Badge>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- The region globe (`GlobeCdn`, powered by `cobe`) in the instance creation form was rendered at a cramped `w-16` (64px), squeezed next to the region dropdown.
- Resized it to `w-32`/`w-36` (128–144px) and reshaped the region section: the globe now sits above the dropdown on narrow viewports and side-by-side on wider ones, instead of being squashed into the flex row.

## Files changed
- `apps/Cloud-Computer-Control-Panel/components/instance/create-manager.tsx`

## Test plan
- [x] Reviewed the JSX changes for correctness (no `tsc` errors introduced by this change; pre-existing repo-wide "module not found" errors are due to `node_modules` not being installed in this environment)
- [ ] Visually verify in a running dev server that the globe renders at the larger size and the layout looks correct at both mobile and desktop widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQXRJQP25fByvDv2cRcenV

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQXRJQP25fByvDv2cRcenV)_