### PR TITLE
fix(cccp): declare drizzle-orm, which the app imports but never depended on

### DIFF
--- a/apps/Cloud-Computer-Control-Panel/package.json
+++ b/apps/Cloud-Computer-Control-Panel/package.json
@@ -38,6 +38,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cobe": "^0.6.3",
+    "drizzle-orm": "^0.45.2",
     "lucide-react": "^0.454.0",
     "next": "16.0.10",
     "next-themes": "^0.4.6",


### PR DESCRIPTION
## Summary

The Cloud Computer Control Panel has failed to build since #54, so **production is currently down**. This adds the one missing dependency.

Its Vercel project's last green deployment was `c600bc2`. It went `ERROR` at `3c3c86b` ("Add sign-in and an encrypted credentials database to CCCP", #54) and has failed on every commit since — `master` (production target) as well as every open branch: #56, #57, #58, #59, #60.

```
Module not found: Can't resolve 'drizzle-orm'          × 4
Module not found: Can't resolve 'drizzle-orm/libsql'
Module not found: Can't resolve 'drizzle-orm/sqlite-core'
Error: Command "npm run build" exited with 1
```

## Cause

#54 added four files that import `drizzle-orm`:

| File | Import |
| --- | --- |
| `lib/db/schema.ts` | `drizzle-orm/sqlite-core` |
| `lib/db/index.ts` | `drizzle-orm/libsql` |
| `lib/db/relations.ts` | `drizzle-orm` |
| `lib/aws-credentials.ts` | `drizzle-orm` |

but only added `drizzle-kit` — the migration CLI, and a devDependency. `drizzle-orm` itself was never declared. A dev checkout can paper over this when a transitive copy happens to be hoisted into `node_modules`; a clean CI install has nothing to resolve.

**The version range matters.** `better-auth@1.7.3` declares `peerOptional drizzle-orm@"^0.45.2 || >=1.0.0-rc.1 <2.0.0"`, so `^0.44.x` aborts `npm install` with `ERESOLVE` before the build is even reached.

## Verification

1. Clean `npm install` on `master` → reproduced all six `Module not found` errors, identical to the Vercel log.
2. Applied only this one line.
3. `rm -rf node_modules .next`, clean `npm install` (333 packages, `drizzle-orm@0.45.2` resolved), `npm run build` → **compiles successfully, all 17 routes**.

## Why `package-lock.json` is untouched

Deliberate, and worth a follow-up. The committed lockfile has not been regenerated since `cobe` was added in #53 — it carries no `better-auth`, `drizzle-kit`, `@libsql/client` or `resend` either. Vercel installs with `npm install`, not `npm ci` (its log reads `added 118 packages, and changed 1 package`), so `package.json` alone is enough to restore the build.

Regenerating the lockfile moves a large number of transitive versions (~5,900 lines here) and deserves its own PR and its own review, rather than riding along on a production hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vAzsE1hg8tYBsugkP3vUW

---
_Generated by [Claude Code](https://claude.ai/code/session_019vAzsE1hg8tYBsugkP3vUW)_