### PR TITLE
Expand desktop app docs with installer table and build instructions

### DIFF
--- a/.github/workflows/about-system-desktop.yml
+++ b/.github/workflows/about-system-desktop.yml
@@ -1,10 +1,11 @@
 # Builds the About System desktop app for Windows, macOS, and Linux and attaches
 # every installer to one draft GitHub Release.
 #
-# Three runners rather than one because neither half of this build cross-compiles:
-# Tauri needs each OS's own native webview and toolchain, and the sidecar is a
-# `bun build --compile` binary that is likewise per-platform. The macOS job
-# builds both architectures' sidecars so it can produce a universal app.
+# One runner per desktop OS/architecture rather than one for all of them, because
+# neither half of this build cross-compiles: Tauri needs each OS's own native
+# webview and toolchain, and the sidecar is a `bun build --compile` binary that is
+# likewise per-platform. The macOS job builds both architectures' sidecars so it
+# can produce a universal app; Linux gets an x86_64 and an aarch64 runner.
 
 name: About System desktop
 
@@ -35,6 +36,9 @@ jobs:
         include:
           - platform: ubuntu-22.04
             args: ""
+          # GitHub's arm64 Linux runner: same build, aarch64 .deb/.rpm/.AppImage.
+          - platform: ubuntu-22.04-arm
+            args: ""
           - platform: macos-latest
             args: "--target universal-apple-darwin"
           - platform: windows-latest
@@ -62,7 +66,7 @@ jobs:
           workspaces: ${{ env.APP_DIR }}/src-tauri -> target
 
       - name: Install Linux webview dependencies
-        if: matrix.platform == 'ubuntu-22.04'
+        if: startsWith(matrix.platform, 'ubuntu')
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev \

--- a/apps/docs/content/docs/(index)/packages/about-system-info.mdx
+++ b/apps/docs/content/docs/(index)/packages/about-system-info.mdx
@@ -36,17 +36,49 @@ bun x about-system
 
 ### Desktop app
 
-The same information as a window you can leave open, for Windows, macOS, and Linux. The CLI is
-compiled into the app, so it installs and runs on a machine with no Node on it:
+The same 30+ metrics as a window you can leave open, built natively for every desktop OS. The CLI
+is compiled into the app as a [Tauri sidecar](https://v2.tauri.app/develop/sidecar/), so an
+installer runs on a machine with no Node, no Bun, and no package manager on it.
+
+#### Download an installer
+
+Every tagged release attaches a native build for each desktop system
+([Releases](https://github.com/OpenSourceAGI/dev-tools-starter-agent/releases?q=about-system-desktop)):
+
+| System | Architecture | Installer |
+| --- | --- | --- |
+| Windows 10 1803+ / 11 | x86_64 | `About System_<version>_x64_en-US.msi`, `About System_<version>_x64-setup.exe` |
+| macOS 10.15+ | Apple Silicon + Intel (universal) | `About System_<version>_universal.dmg` |
+| Linux (Debian/Ubuntu) | x86_64, aarch64 | `About System_<version>_amd64.deb`, `About System_<version>_arm64.deb` |
+| Linux (Fedora/RHEL) | x86_64, aarch64 | `About System-<version>-1.x86_64.rpm`, `About System-<version>-1.aarch64.rpm` |
+| Linux (any distro) | x86_64, aarch64 | `About System_<version>_amd64.AppImage`, `About System_<version>_aarch64.AppImage` |
+
+Installers are unsigned by default, so macOS shows an "unidentified developer" warning and Windows
+shows a SmartScreen prompt on first launch.
+
+#### Build it yourself
+
+Needs [Rust](https://rustup.rs) 1.77.2+, Node 18+, [Bun](https://bun.sh), and your platform's
+[Tauri prerequisites](https://v2.tauri.app/start/prerequisites/):
 
 ```bash
-cd native && npm install && npm run build:desktop   # or grab an installer from Releases
+bun install                # the CLI's dependencies — the sidecar is compiled from its source
+cd native
+npm install
+npm run build:desktop      # regenerates config, compiles the sidecar, builds the installers
 ```
 
-See [`native/README.md`](https://github.com/OpenSourceAGI/dev-tools-starter-agent/blob/master/packages/about-system-info/native/README.md) for prerequisites, per-platform artifacts, and how the
-release workflow builds all three. The app is scaffolded from
-[`packages/native-app-wrapper`](https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/native-app-wrapper/) and owns its own identity in
-`native/profiles/about-system.json`.
+Artifacts land in `native/src-tauri/target/release/bundle/`. **Each installer must be built on its
+own OS and architecture** — neither Tauri nor the `bun build --compile` sidecar cross-compiles,
+which is why `.github/workflows/about-system-desktop.yml` runs the same two commands on a Windows,
+a macOS, an x86_64 Linux, and an aarch64 Linux runner and attaches every artifact to one release.
+
+The app is scaffolded from [`packages/native-app-wrapper`](https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/native-app-wrapper/) — a Tauri shell
+that turns one JSON profile into a native app — and owns its whole identity (name, bundle id,
+version, window, sidecar command) in `native/profiles/about-system.json`. See
+[`native/README.md`](https://github.com/OpenSourceAGI/dev-tools-starter-agent/blob/master/packages/about-system-info/native/README.md) for the development loop, the universal-macOS build, and the
+known limitations (no Windows-on-ARM build, since Bun has no `windows-arm64` compile target; and no
+mobile build, since Android and iOS don't let an app spawn a bundled executable).
 
 ## Examples
 

--- a/apps/docs/content/docs/(index)/packages/code-tree-graph.mdx
+++ b/apps/docs/content/docs/(index)/packages/code-tree-graph.mdx
@@ -12,22 +12,22 @@ icon: Workflow
     <a href="https://discord.gg/SJdBqBz3tV">
         <img src="https://img.shields.io/discord/1110227955554209923.svg?label=Chat&logo=Discord&colorB=7289da&style=flat" alt="Join Discord" />
     </a>
-     <a href="https://github.com/OpenSourceAGI/starter-app-dev-tools/discussions">
-     <img alt="GitHub Stars" src="https://img.shields.io/github/stars/OpenSourceAGI/starter-app-dev-tools" /></a>
-    <a href="https://github.com/OpenSourceAGI/starter-app-dev-tools/discussions">
-    <img alt="GitHub Discussions" src="https://img.shields.io/github/discussions/OpenSourceAGI/starter-app-dev-tools" />
+     <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions">
+     <img alt="GitHub Stars" src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions">
+    <img alt="GitHub Discussions" src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" />
     </a>
 <br />
-    <a href="https://github.com/OpenSourceAGI/starter-app-dev-tools/pulse" alt="Activity">
-        <img src="https://img.shields.io/github/commit-activity/m/OpenSourceAGI/starter-app-dev-tools" />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulse" alt="Activity">
+        <img src="https://img.shields.io/github/commit-activity/m/OpenSourceAGI/dev-tools-starter-agent" />
     </a>
-    <img src="https://img.shields.io/github/last-commit/OpenSourceAGI/starter-app-dev-tools.svg" alt="GitHub last commit" />
+    <img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" />
 <br />
     <img src="https://img.shields.io/badge/Next.js-16-black" alt="Next.js" />
     <a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request">
         <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" />
     </a>
-    <a href="https://codespaces.new/OpenSourceAGI/starter-app-dev-tools">
+    <a href="https://codespaces.new/OpenSourceAGI/dev-tools-starter-agent">
     <img src="https://github.com/codespaces/badge.svg" width="150" height="20" />
     </a>
 </div>

--- a/apps/docs/content/docs/(index)/packages/shadcn-theme-menu.mdx
+++ b/apps/docs/content/docs/(index)/packages/shadcn-theme-menu.mdx
@@ -12,22 +12,22 @@ icon: Palette
     <a href="https://discord.gg/SJdBqBz3tV">
         <img src="https://img.shields.io/discord/1110227955554209923.svg?label=Chat&logo=Discord&colorB=7289da&style=flat" alt="Join Discord" />
     </a>
-     <a href="https://github.com/OpenSourceAGI/starter-app-dev-tools/discussions">
-     <img alt="GitHub Stars" src="https://img.shields.io/github/stars/OpenSourceAGI/starter-app-dev-tools" /></a>
-    <a href="https://github.com/OpenSourceAGI/starter-app-dev-tools/discussions">
-    <img alt="GitHub Discussions" src="https://img.shields.io/github/discussions/OpenSourceAGI/starter-app-dev-tools" />
+     <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions">
+     <img alt="GitHub Stars" src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions">
+    <img alt="GitHub Discussions" src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" />
     </a>
 <br />
-    <a href="https://github.com/OpenSourceAGI/starter-app-dev-tools/pulse" alt="Activity">
-        <img src="https://img.shields.io/github/commit-activity/m/OpenSourceAGI/starter-app-dev-tools" />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulse" alt="Activity">
+        <img src="https://img.shields.io/github/commit-activity/m/OpenSourceAGI/dev-tools-starter-agent" />
     </a>
-    <img src="https://img.shields.io/github/last-commit/OpenSourceAGI/starter-app-dev-tools.svg" alt="GitHub last commit" />
+    <img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" />
 <br />
     <img src="https://img.shields.io/badge/Next.js-16-black" alt="Next.js" />
     <a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request">
         <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" />
     </a>
-    <a href="https://codespaces.new/OpenSourceAGI/starter-app-dev-tools">
+    <a href="https://codespaces.new/OpenSourceAGI/dev-tools-starter-agent">
     <img src="https://github.com/codespaces/badge.svg" width="150" height="20" />
     </a>
 </div>
@@ -231,7 +231,10 @@ import type { ThemeProviderProps } from "shadcn-theme-menu";
 
 ## Demo
 
-Run the interactive demo:
+An interactive page in [`demo/`](https://github.com/OpenSourceAGI/dev-tools-starter-agent/blob/master/packages/shadcn-theme-menu/demo) exercises every export against this
+package's source — the theme gallery, the per-theme fonts, all four switchers
+wired to their callbacks, injected `Button`/`DropdownMenu` primitives, and the
+shadcn dashboard block re-themed end to end.
 
 ```bash
 pnpm demo
@@ -242,8 +245,11 @@ Or manually:
 ```bash
 cd demo
 pnpm install
-pnpm dev
+pnpm dev      # http://localhost:3001
 ```
+
+See [`demo/README.md`](https://github.com/OpenSourceAGI/dev-tools-starter-agent/blob/master/packages/shadcn-theme-menu/demo/README.md) for what each section covers and for
+the Vite/Tailwind wiring that lets a demo consume the package from source.
 
 ---
 

--- a/packages/about-system-info/README.md
+++ b/packages/about-system-info/README.md
@@ -30,17 +30,49 @@ bun x about-system
 
 ### Desktop app
 
-The same information as a window you can leave open, for Windows, macOS, and Linux. The CLI is
-compiled into the app, so it installs and runs on a machine with no Node on it:
+The same 30+ metrics as a window you can leave open, built natively for every desktop OS. The CLI
+is compiled into the app as a [Tauri sidecar](https://v2.tauri.app/develop/sidecar/), so an
+installer runs on a machine with no Node, no Bun, and no package manager on it.
+
+#### Download an installer
+
+Every tagged release attaches a native build for each desktop system
+([Releases](https://github.com/OpenSourceAGI/dev-tools-starter-agent/releases?q=about-system-desktop)):
+
+| System | Architecture | Installer |
+| --- | --- | --- |
+| Windows 10 1803+ / 11 | x86_64 | `About System_<version>_x64_en-US.msi`, `About System_<version>_x64-setup.exe` |
+| macOS 10.15+ | Apple Silicon + Intel (universal) | `About System_<version>_universal.dmg` |
+| Linux (Debian/Ubuntu) | x86_64, aarch64 | `About System_<version>_amd64.deb`, `About System_<version>_arm64.deb` |
+| Linux (Fedora/RHEL) | x86_64, aarch64 | `About System-<version>-1.x86_64.rpm`, `About System-<version>-1.aarch64.rpm` |
+| Linux (any distro) | x86_64, aarch64 | `About System_<version>_amd64.AppImage`, `About System_<version>_aarch64.AppImage` |
+
+Installers are unsigned by default, so macOS shows an "unidentified developer" warning and Windows
+shows a SmartScreen prompt on first launch.
+
+#### Build it yourself
+
+Needs [Rust](https://rustup.rs) 1.77.2+, Node 18+, [Bun](https://bun.sh), and your platform's
+[Tauri prerequisites](https://v2.tauri.app/start/prerequisites/):
 
 ```bash
-cd native && npm install && npm run build:desktop   # or grab an installer from Releases
+bun install                # the CLI's dependencies — the sidecar is compiled from its source
+cd native
+npm install
+npm run build:desktop      # regenerates config, compiles the sidecar, builds the installers
 ```
 
-See [`native/README.md`](native/README.md) for prerequisites, per-platform artifacts, and how the
-release workflow builds all three. The app is scaffolded from
-[`packages/native-app-wrapper`](../native-app-wrapper/) and owns its own identity in
-`native/profiles/about-system.json`.
+Artifacts land in `native/src-tauri/target/release/bundle/`. **Each installer must be built on its
+own OS and architecture** — neither Tauri nor the `bun build --compile` sidecar cross-compiles,
+which is why `.github/workflows/about-system-desktop.yml` runs the same two commands on a Windows,
+a macOS, an x86_64 Linux, and an aarch64 Linux runner and attaches every artifact to one release.
+
+The app is scaffolded from [`packages/native-app-wrapper`](../native-app-wrapper/) — a Tauri shell
+that turns one JSON profile into a native app — and owns its whole identity (name, bundle id,
+version, window, sidecar command) in `native/profiles/about-system.json`. See
+[`native/README.md`](native/README.md) for the development loop, the universal-macOS build, and the
+known limitations (no Windows-on-ARM build, since Bun has no `windows-arm64` compile target; and no
+mobile build, since Android and iOS don't let an app spawn a bundled executable).
 
 ## Examples
 

--- a/packages/about-system-info/native/README.md
+++ b/packages/about-system-info/native/README.md
@@ -54,15 +54,18 @@ npm run build:desktop  # regenerates config, compiles the sidecar, builds the in
 
 Installers land in `src-tauri/target/release/bundle/`:
 
-| Platform | Artifacts |
-|---|---|
-| Windows | `msi/About System_<version>_x64_en-US.msi`, `nsis/About System_<version>_x64-setup.exe` |
-| macOS | `dmg/About System_<version>_<arch>.dmg`, `macos/About System.app` |
-| Linux | `deb/*.deb`, `rpm/*.rpm`, `appimage/*.AppImage` |
+| Platform | Architecture | Artifacts |
+|---|---|---|
+| Windows | x86_64 | `msi/About System_<version>_x64_en-US.msi`, `nsis/About System_<version>_x64-setup.exe` |
+| macOS | universal (Apple Silicon + Intel) | `dmg/About System_<version>_universal.dmg`, `macos/About System.app` |
+| Linux | x86_64 | `deb/About System_<version>_amd64.deb`, `rpm/About System-<version>-1.x86_64.rpm`, `appimage/About System_<version>_amd64.AppImage` |
+| Linux | aarch64 | `deb/About System_<version>_arm64.deb`, `rpm/About System-<version>-1.aarch64.rpm`, `appimage/About System_<version>_aarch64.AppImage` |
 
-**Each installer must be built on its own OS** — Tauri does not cross-compile, and neither does the
-sidecar. That's what `.github/workflows/about-system-desktop.yml` is for: it runs the same two
-commands on a Windows, macOS, and Linux runner and attaches every artifact to one GitHub Release.
+**Each installer must be built on its own OS and architecture** — Tauri does not cross-compile, and
+neither does the sidecar. That's what `.github/workflows/about-system-desktop.yml` is for: it runs
+the same two commands on a Windows, a macOS, an x86_64 Linux (`ubuntu-22.04`), and an aarch64 Linux
+(`ubuntu-22.04-arm`) runner, and attaches every artifact to one GitHub Release. The sidecar build
+reads the host Rust target triple, so the arm64 runner needs no extra configuration.
 
 For a universal macOS build, compile both sidecar architectures first (Tauri does not `lipo` the
 sidecar for you) and then build for the universal target:
@@ -95,7 +98,8 @@ that the IPC bridge is missing and says so instead of failing silently.
    installer's metadata — the CLI's own npm version in `../package.json` is separate and moves on
    its own schedule).
 2. Commit, then tag: `git tag about-system-desktop-v0.2.0 && git push origin about-system-desktop-v0.2.0`.
-3. The workflow builds all three platforms and attaches them to a draft release. Review and publish.
+3. The workflow builds every desktop target — Windows x64, macOS universal, Linux x86_64, Linux
+   aarch64 — and attaches them to a draft release. Review and publish.
 
 Installers are unsigned by default, so first launch shows an "unidentified developer" warning on
 macOS and a SmartScreen prompt on Windows. `docs/BUILDING.md` lists the secrets that turn signing
@@ -109,6 +113,9 @@ Releases.
   binary has no such disk path, so the lookup fails and the fields come back empty — the app hides
   empty fields, so they simply don't appear. Every other field works. Fixing it means having the
   CLI import those JSON files as modules instead of reading them by path.
+- **No Windows on ARM build.** Bun has no `windows-arm64` `--compile` target, so the sidecar can't
+  be produced for it. Windows on ARM runs the x64 installer under emulation instead. Every other
+  desktop OS/architecture is built natively.
 - **Desktop only.** Android and iOS don't let an app spawn a bundled executable, so there is no
   mobile build of this app. See the wrapper's `docs/MOBILE.md`.
 - **The app is large** (~100 MB installed) because the compiled CLI carries a JavaScript runtime.


### PR DESCRIPTION
## Summary
Significantly expanded documentation for the About System desktop app across multiple files, adding comprehensive installer information, detailed build instructions, and clarifying the Tauri sidecar architecture. Also updated repository references and added an aarch64 Linux build target to the CI workflow.

## Key Changes

- **Enhanced desktop app documentation** in `about-system-info.mdx` and `README.md`:
  - Added new "Download an installer" section with a detailed table showing available installers for each OS/architecture combination (Windows x64, macOS universal, Linux Debian/Ubuntu/Fedora/RHEL/AppImage)
  - Added "Build it yourself" section with step-by-step build instructions and prerequisite requirements
  - Clarified that the CLI is compiled as a Tauri sidecar and runs without Node/Bun/package manager dependencies
  - Expanded explanation of the build process, artifact locations, and per-platform compilation requirements
  - Added notes about unsigned installers and security warnings on first launch

- **Updated `native/README.md`**:
  - Restructured installer artifacts table to include architecture column for clarity
  - Added specific artifact filenames for each platform/architecture combination
  - Expanded explanation of per-OS/architecture build requirements
  - Added details about the aarch64 Linux runner and Rust target triple detection
  - Added new "Known limitations" section documenting Windows-on-ARM and mobile build constraints

- **Updated CI workflow** (`about-system-desktop.yml`):
  - Added `ubuntu-22.04-arm` runner to build aarch64 Linux installers
  - Updated workflow comments to reflect four build targets instead of three
  - Updated Linux dependency installation condition to cover both x86_64 and aarch64 Ubuntu runners

- **Repository reference updates**:
  - Updated all GitHub URLs from `starter-app-dev-tools` to `dev-tools-starter-agent` in `shadcn-theme-menu.mdx` and `code-tree-graph.mdx`
  - Enhanced demo documentation in `shadcn-theme-menu.mdx` with more detailed description of demo coverage

## Notable Details

- Documentation now explicitly mentions the 30+ metrics provided by the app
- Build instructions clarify the two-step process: `bun install` for CLI dependencies, then `npm run build:desktop` in the native directory
- Explains why cross-compilation isn't possible and why multiple runners are needed in CI
- Added information about the universal macOS build process and sidecar compilation for both architectures

https://claude.ai/code/session_013cR5xDMyQMZnGPRdTWPVK7