### PR TITLE
Add comprehensive test suite for about-system-info package

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,12 @@ jobs:
             install: bun install
             coverage: true
 
+          - name: about-system-info
+            dir: packages/about-system-info
+            runtime: node
+            install: npm install --ignore-scripts --legacy-peer-deps
+            coverage: true
+
           - name: web2mobile-wrapper
             dir: packages/web2mobile-wrapper
             runtime: node

--- a/codecov.yml
+++ b/codecov.yml
@@ -28,6 +28,9 @@ flag_management:
   default_rules:
     carryforward: true
   individual_flags:
+    - name: about-system-info
+      paths:
+        - packages/about-system-info/
     - name: git0-repo-downloader
       paths:
         - packages/git0-repo-downloader/

--- a/packages/about-system-info/package.json
+++ b/packages/about-system-info/package.json
@@ -39,6 +39,7 @@
     "app:dev": "cd native && npm run dev",
     "app:build": "cd native && npm run build:desktop",
     "test": "vitest run",
+    "test:ci": "vitest run --reporter=junit --outputFile=./junit.xml --coverage --coverage.reporter=lcov",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage"
   },

--- a/packages/about-system-info/src/cache/cache.test.ts
+++ b/packages/about-system-info/src/cache/cache.test.ts
@@ -1,0 +1,235 @@
+/**
+ * @fileoverview Covers the on-disk cache that keeps `about-system` fast: most
+ * of the facts it reports are expensive to collect (shelling out to `wmic`,
+ * `sw_vers`, `lspci`) and change rarely, so a stale-but-valid entry is the
+ * difference between an instant readout and a multi-second one.
+ *
+ * The behaviours worth pinning are the ones that decide whether a user sees
+ * anything at all: a corrupt cache file must not throw, an unwritable temp
+ * directory must not throw, and an expired entry must never be served.
+ */
+
+import fs from "fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type Cache,
+  getCachedValue,
+  isCacheValid,
+  loadCache,
+  saveCache,
+  setCachedValue,
+} from "./cache";
+import { CACHE_DURATION, CACHE_FILE } from "./cache-config";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("loadCache", () => {
+  it("returns an empty cache when no file exists yet", () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    expect(loadCache()).toEqual({});
+  });
+
+  it("reads a previously saved cache back", () => {
+    const stored: Cache = { cpu: { value: "M2 Pro", timestamp: 123 } };
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    vi.spyOn(fs, "readFileSync").mockReturnValue(JSON.stringify(stored));
+
+    expect(loadCache()).toEqual(stored);
+  });
+
+  it("reads from the temp-directory cache file", () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    const read = vi.spyOn(fs, "readFileSync").mockReturnValue("{}");
+
+    loadCache();
+
+    expect(read).toHaveBeenCalledWith(CACHE_FILE, "utf8");
+  });
+
+  it("recovers from a corrupt cache file rather than throwing", () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    vi.spyOn(fs, "readFileSync").mockReturnValue("{ not json");
+
+    expect(loadCache()).toEqual({});
+  });
+
+  it("recovers from an unreadable cache file", () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    vi.spyOn(fs, "readFileSync").mockImplementation(() => {
+      throw new Error("EACCES");
+    });
+
+    expect(loadCache()).toEqual({});
+  });
+});
+
+describe("saveCache", () => {
+  it("writes the cache as readable json", () => {
+    const write = vi.spyOn(fs, "writeFileSync").mockImplementation(() => {});
+    const cache: Cache = { cpu: { value: "M2 Pro", timestamp: 1 } };
+
+    saveCache(cache);
+
+    expect(write).toHaveBeenCalledWith(
+      CACHE_FILE,
+      JSON.stringify(cache, null, 2),
+    );
+  });
+
+  it("stays silent when the cache file cannot be written", () => {
+    vi.spyOn(fs, "writeFileSync").mockImplementation(() => {
+      throw new Error("EROFS");
+    });
+
+    expect(() => saveCache({})).not.toThrow();
+  });
+});
+
+describe("isCacheValid", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("accepts an entry written just now", () => {
+    expect(isCacheValid({ value: "x", timestamp: Date.now() }, "cpu")).toBe(true);
+  });
+
+  it("rejects an entry older than its key's duration", () => {
+    const timestamp = Date.now() - CACHE_DURATION.ram_used - 1;
+    expect(isCacheValid({ value: "x", timestamp }, "ram_used")).toBe(false);
+  });
+
+  it("uses each key's own duration, not one global one", () => {
+    // A minute-old entry is stale for RAM (10s) but fresh for the CPU (24h).
+    const timestamp = Date.now() - 60_000;
+    expect(isCacheValid({ value: "x", timestamp }, "ram_used")).toBe(false);
+    expect(isCacheValid({ value: "x", timestamp }, "cpu")).toBe(true);
+  });
+
+  it("falls back to a one-minute window for an unknown key", () => {
+    expect(
+      isCacheValid({ value: "x", timestamp: Date.now() - 59_000 }, "unknown"),
+    ).toBe(true);
+    expect(
+      isCacheValid({ value: "x", timestamp: Date.now() - 61_000 }, "unknown"),
+    ).toBe(false);
+  });
+
+  it.each([
+    [undefined, "missing"],
+    [null, "null"],
+    [{ value: "x" }, "timestamp-less"],
+    [{ value: "x", timestamp: 0 }, "zero-timestamped"],
+  ])("rejects a %s entry", (entry) => {
+    expect(isCacheValid(entry as never, "cpu")).toBe(false);
+  });
+});
+
+describe("getCachedValue", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns null for a key that was never cached", () => {
+    expect(getCachedValue({}, "cpu")).toBeNull();
+  });
+
+  it("returns a fresh value", () => {
+    const cache: Cache = { cpu: { value: "M2 Pro", timestamp: Date.now() } };
+    expect(getCachedValue(cache, "cpu")).toBe("M2 Pro");
+  });
+
+  it("returns a cached falsy value rather than mistaking it for a miss", () => {
+    const cache: Cache = { battery: { value: 0, timestamp: Date.now() } };
+    expect(getCachedValue(cache, "battery")).toBe(0);
+  });
+
+  it("returns null for an expired value", () => {
+    const cache: Cache = {
+      ram_used: { value: "8 GB", timestamp: Date.now() - 60_000 },
+    };
+    expect(getCachedValue(cache, "ram_used")).toBeNull();
+  });
+
+  it("evicts an expired entry so it is not re-checked", () => {
+    const cache: Cache = {
+      ram_used: { value: "8 GB", timestamp: Date.now() - 60_000 },
+    };
+
+    getCachedValue(cache, "ram_used");
+
+    expect(cache).not.toHaveProperty("ram_used");
+  });
+
+  it("keeps a fresh entry in place", () => {
+    const cache: Cache = { cpu: { value: "M2 Pro", timestamp: Date.now() } };
+    getCachedValue(cache, "cpu");
+    expect(cache).toHaveProperty("cpu");
+  });
+});
+
+describe("setCachedValue", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stamps the value with the time it was cached", () => {
+    const cache: Cache = {};
+    setCachedValue(cache, "cpu", "M2 Pro");
+
+    expect(cache.cpu).toEqual({ value: "M2 Pro", timestamp: 1_000_000 });
+  });
+
+  it("round-trips through getCachedValue", () => {
+    const cache: Cache = {};
+    setCachedValue(cache, "cpu", "M2 Pro");
+    expect(getCachedValue(cache, "cpu")).toBe("M2 Pro");
+  });
+
+  it("replaces an existing entry and refreshes its timestamp", () => {
+    const cache: Cache = { cpu: { value: "old", timestamp: 1 } };
+    setCachedValue(cache, "cpu", "new");
+
+    expect(cache.cpu).toEqual({ value: "new", timestamp: 1_000_000 });
+  });
+
+  it("stores structured values, not just strings", () => {
+    const cache: Cache = {};
+    setCachedValue(cache, "network_interfaces", [{ name: "en0" }]);
+
+    expect(getCachedValue(cache, "network_interfaces")).toEqual([
+      { name: "en0" },
+    ]);
+  });
+});
+
+describe("CACHE_DURATION", () => {
+  it("gives every cached key a positive window", () => {
+    for (const [key, duration] of Object.entries(CACHE_DURATION)) {
+      expect(duration, key).toBeGreaterThan(0);
+    }
+  });
+
+  it("caches volatile readings for less time than fixed hardware facts", () => {
+    expect(CACHE_DURATION.ram_used).toBeLessThan(CACHE_DURATION.cpu);
+    expect(CACHE_DURATION.top_process).toBeLessThan(CACHE_DURATION.os);
+  });
+});

--- a/packages/about-system-info/src/info/platform.test.ts
+++ b/packages/about-system-info/src/info/platform.test.ts
@@ -1,0 +1,190 @@
+/**
+ * @fileoverview Covers the platform facts `about-system` opens its readout
+ * with: user, hostname, OS name, kernel and device model.
+ *
+ * Each of these shells out to a different tool per platform and parses its
+ * output, so the tests drive the Linux path (the one CI runs on) end to end and
+ * pin the two behaviours that hold everywhere: the cache is consulted before
+ * any command runs, and a missing tool degrades to a fallback rather than
+ * throwing.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// These modules bind their imports by name, so the dependencies have to be
+// mocked outright rather than spied on through a namespace object.
+const execCommand = vi.hoisted(() => vi.fn());
+const commandExists = vi.hoisted(() => vi.fn());
+vi.mock("../utils/command", () => ({ execCommand, commandExists }));
+
+const osMock = vi.hoisted(() => ({
+  platform: vi.fn(() => "linux"),
+  release: vi.fn(() => "6.1.0-generic"),
+  hostname: vi.fn(() => "workstation"),
+  userInfo: vi.fn(() => ({ username: "ada" })),
+  // cache-config resolves the cache file under the temp directory at import time.
+  tmpdir: vi.fn(() => "/tmp"),
+}));
+vi.mock("os", () => ({ ...osMock, default: osMock }));
+
+const fsMock = vi.hoisted(() => ({
+  existsSync: vi.fn(() => false),
+  readFileSync: vi.fn(() => ""),
+}));
+vi.mock("fs", () => ({ ...fsMock, default: fsMock }));
+
+const { device, hostname, kernel, os_info, user } = await import("./platform");
+const { IS_LINUX } = await import("../utils/platform");
+import type { InfoContext } from "../types/internal-types";
+
+const context = (): InfoContext => ({ cache: {} });
+
+beforeEach(() => {
+  execCommand.mockReturnValue("");
+  commandExists.mockReturnValue(false);
+  fsMock.existsSync.mockReturnValue(false);
+  fsMock.readFileSync.mockReturnValue("");
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("user and hostname", () => {
+  it("reads the current username", () => {
+    expect(user()).toBe("ada");
+  });
+
+  it("reads the machine's network name", () => {
+    expect(hostname()).toBe("workstation");
+  });
+});
+
+describe("kernel", () => {
+  it("reports the kernel release", () => {
+    expect(kernel(context())).toBe("6.1.0-generic");
+  });
+
+  it("caches the result", () => {
+    const ctx = context();
+    kernel(ctx);
+    expect(ctx.cache.kernel?.value).toBe("6.1.0-generic");
+  });
+
+  it("serves a cached kernel without asking the OS again", () => {
+    const ctx = context();
+    ctx.cache.kernel = { value: "cached-kernel", timestamp: Date.now() };
+
+    expect(kernel(ctx)).toBe("cached-kernel");
+    expect(osMock.release).not.toHaveBeenCalled();
+  });
+});
+
+describe("os_info", () => {
+  it("serves a cached value without running any command", () => {
+    const ctx = context();
+    ctx.cache.os = { value: "Cached OS 1.0", timestamp: Date.now() };
+
+    expect(os_info(ctx)).toBe("Cached OS 1.0");
+    expect(execCommand).not.toHaveBeenCalled();
+  });
+
+  it("caches whatever it resolves", () => {
+    const ctx = context();
+    const resolved = os_info(ctx);
+    expect(ctx.cache.os?.value).toBe(resolved);
+  });
+
+  it("never returns an empty string, whatever the platform", () => {
+    expect(os_info(context())).toBeTruthy();
+  });
+
+  it.runIf(IS_LINUX)("reads the distribution from /etc/os-release", () => {
+    fsMock.existsSync.mockReturnValue(true);
+    fsMock.readFileSync.mockReturnValue(
+      'NAME="Ubuntu"\nVERSION_ID="22.04"\nID=ubuntu\n',
+    );
+
+    expect(os_info(context())).toBe("Ubuntu 22.04");
+  });
+
+  it.runIf(IS_LINUX)("uses the name alone when there is no version id", () => {
+    fsMock.readFileSync.mockReturnValue('NAME="Arch Linux"\n');
+    expect(os_info(context())).toBe("Arch Linux");
+  });
+
+  it.runIf(IS_LINUX)("falls back to the kernel release with no os-release file", () => {
+    fsMock.readFileSync.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+
+    expect(os_info(context())).toBe("Linux 6.1.0-generic");
+  });
+
+  it.runIf(IS_LINUX)("falls back to a bare Linux when the file has no NAME", () => {
+    fsMock.readFileSync.mockReturnValue("ID=unknown\n");
+    expect(os_info(context())).toBe("Linux");
+  });
+});
+
+describe("device", () => {
+  it("serves a cached model without probing", () => {
+    const ctx = context();
+    ctx.cache.device = { value: "Cached Box", timestamp: Date.now() };
+
+    expect(device(ctx)).toBe("Cached Box");
+    expect(execCommand).not.toHaveBeenCalled();
+  });
+
+  it("caches an empty result too, so the probe is not repeated", () => {
+    const ctx = context();
+    device(ctx);
+    expect(ctx.cache.device).toBeDefined();
+  });
+
+  it("returns an empty string when nothing identifies the machine", () => {
+    expect(device(context())).toBe("");
+  });
+
+  it.runIf(IS_LINUX)("reads the model from the DMI product name", () => {
+    fsMock.existsSync.mockImplementation(
+      (path: string) => path === "/sys/devices/virtual/dmi/id/product_name",
+    );
+    fsMock.readFileSync.mockReturnValue("OptiPlex 7090\n");
+
+    expect(device(context())).toBe("OptiPlex 7090");
+  });
+
+  it.runIf(IS_LINUX)("prefers Android's getprop when it is available", () => {
+    commandExists.mockImplementation((cmd: string) => cmd === "getprop");
+    execCommand.mockReturnValue("Pixel 8");
+
+    expect(device(context())).toBe("Pixel 8");
+    expect(execCommand).toHaveBeenCalledWith("getprop ro.product.model");
+  });
+
+  it.runIf(IS_LINUX)("falls through to DMI when getprop answers nothing", () => {
+    commandExists.mockImplementation((cmd: string) => cmd === "getprop");
+    execCommand.mockReturnValue("");
+    fsMock.existsSync.mockReturnValue(true);
+    fsMock.readFileSync.mockReturnValue("Steam Deck\n");
+
+    expect(device(context())).toBe("Steam Deck");
+  });
+
+  it.runIf(IS_LINUX)("ignores a blank DMI product name", () => {
+    fsMock.existsSync.mockReturnValue(true);
+    fsMock.readFileSync.mockReturnValue("   \n");
+
+    expect(device(context())).toBe("");
+  });
+
+  it.runIf(IS_LINUX)("survives an unreadable DMI file", () => {
+    fsMock.existsSync.mockReturnValue(true);
+    fsMock.readFileSync.mockImplementation(() => {
+      throw new Error("EACCES");
+    });
+
+    expect(device(context())).toBe("");
+  });
+});

--- a/packages/about-system-info/src/utils/utils.test.ts
+++ b/packages/about-system-info/src/utils/utils.test.ts
@@ -1,0 +1,218 @@
+/**
+ * @fileoverview Covers the shell and network helpers every info module is
+ * built on. Both are written to never throw — `about-system` prints a partial
+ * readout rather than crashing when a tool is missing or the network is down —
+ * so the failure paths are the point of these tests.
+ */
+
+import { EventEmitter } from "events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// `command.ts` binds `execSync` as a named ESM import, so spying on the
+// child_process namespace object would not reach it — the module has to be
+// mocked outright.
+const execSync = vi.hoisted(() => vi.fn());
+vi.mock("child_process", () => ({
+  execSync,
+  default: { execSync },
+}));
+
+const httpsGet = vi.hoisted(() => vi.fn());
+vi.mock("https", () => ({
+  get: httpsGet,
+  default: { get: httpsGet },
+}));
+
+import { commandExists, execCommand } from "./command";
+import { IS_LINUX, IS_MAC, IS_WINDOWS } from "./platform";
+import { fetchIPInfo } from "./network";
+import { DEFAULT_IPINFO_TOKEN } from "../cache/cache-config";
+
+afterEach(() => {
+  execSync.mockReset();
+  httpsGet.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe("platform flags", () => {
+  it("identifies exactly one platform", () => {
+    expect([IS_WINDOWS, IS_MAC, IS_LINUX].filter(Boolean).length).toBeLessThanOrEqual(1);
+  });
+
+  it("agrees with the running platform", () => {
+    expect(IS_LINUX).toBe(process.platform === "linux");
+    expect(IS_MAC).toBe(process.platform === "darwin");
+    expect(IS_WINDOWS).toBe(process.platform === "win32");
+  });
+});
+
+describe("execCommand", () => {
+  it("returns the command's trimmed output", () => {
+    execSync.mockReturnValue("  hello \n");
+    expect(execCommand("echo hello")).toBe("hello");
+  });
+
+  it("returns an empty string instead of throwing when the command fails", () => {
+    execSync.mockImplementation(() => {
+      throw new Error("command not found");
+    });
+    expect(execCommand("nope")).toBe("");
+  });
+
+  it("never waits forever on a hung command", () => {
+    execSync.mockReturnValue("");
+    execCommand("sleep 999");
+
+    expect(execSync.mock.calls[0][1]).toMatchObject({ timeout: 10_000 });
+  });
+
+  it("discards the command's stderr so it cannot corrupt the readout", () => {
+    execSync.mockReturnValue("");
+    execCommand("noisy");
+
+    expect((execSync.mock.calls[0][1] as { stdio: string[] }).stdio).toEqual([
+      "pipe",
+      "pipe",
+      "ignore",
+    ]);
+  });
+
+  it("lets the caller override the default options", () => {
+    execSync.mockReturnValue("");
+    execCommand("slow", { timeout: 100 });
+
+    expect(execSync.mock.calls[0][1]).toMatchObject({ timeout: 100 });
+  });
+
+  it("handles a Buffer result from execSync", () => {
+    execSync.mockReturnValue(Buffer.from(" buffered \n"));
+    expect(execCommand("x")).toBe("buffered");
+  });
+});
+
+describe("commandExists", () => {
+  it("reports a command that resolves", () => {
+    execSync.mockReturnValue("");
+    expect(commandExists("node")).toBe(true);
+  });
+
+  it("reports a command that does not resolve", () => {
+    execSync.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    expect(commandExists("definitely-not-a-real-command")).toBe(false);
+  });
+
+  it("looks the command up with the platform's own resolver", () => {
+    execSync.mockReturnValue("");
+    commandExists("git");
+
+    expect(execSync.mock.calls[0][0]).toBe(IS_WINDOWS ? "where git" : "which git");
+  });
+
+  it("silences the resolver's own output", () => {
+    execSync.mockReturnValue("");
+    commandExists("git");
+
+    expect(execSync.mock.calls[0][1]).toMatchObject({ stdio: "ignore" });
+  });
+});
+
+/** A fake `https.get` whose response body and failure mode a test controls. */
+function stubHttpsGet(behavior: (req: EventEmitter & { setTimeout: (ms: number, fn: () => void) => void; destroy: () => void }, onResponse: (res: EventEmitter) => void) => void) {
+  httpsGet.mockImplementation(
+    (_url: string, callback: (res: EventEmitter) => void) => {
+      const req = Object.assign(new EventEmitter(), {
+        setTimeout: vi.fn(),
+        destroy: vi.fn(),
+      });
+      queueMicrotask(() => behavior(req, callback));
+      return req;
+    },
+  );
+  return httpsGet;
+}
+
+/** Emits a complete response body on the next tick. */
+const respondWith = (body: string) =>
+  stubHttpsGet((_req, onResponse) => {
+    const res = new EventEmitter();
+    onResponse(res);
+    res.emit("data", body);
+    res.emit("end");
+  });
+
+describe("fetchIPInfo", () => {
+  it("parses the ipinfo.io payload", async () => {
+    respondWith(JSON.stringify({ ip: "1.2.3.4", city: "San Francisco" }));
+
+    await expect(fetchIPInfo()).resolves.toEqual({
+      ip: "1.2.3.4",
+      city: "San Francisco",
+    });
+  });
+
+  it("sends the default token when none is given", async () => {
+    const get = respondWith("{}");
+    await fetchIPInfo();
+
+    expect(get.mock.calls[0][0]).toBe(
+      `https://ipinfo.io/json?token=${DEFAULT_IPINFO_TOKEN}`,
+    );
+  });
+
+  it("sends a caller-supplied token", async () => {
+    const get = respondWith("{}");
+    await fetchIPInfo("my-token");
+
+    expect(get.mock.calls[0][0]).toContain("token=my-token");
+  });
+
+  it("omits the query string entirely for an empty token", async () => {
+    const get = respondWith("{}");
+    await fetchIPInfo("");
+
+    expect(get.mock.calls[0][0]).toBe("https://ipinfo.io/json");
+  });
+
+  it("reassembles a body that arrives in chunks", async () => {
+    stubHttpsGet((_req, onResponse) => {
+      const res = new EventEmitter();
+      onResponse(res);
+      res.emit("data", '{"ip":"1.2');
+      res.emit("data", '.3.4"}');
+      res.emit("end");
+    });
+
+    await expect(fetchIPInfo()).resolves.toEqual({ ip: "1.2.3.4" });
+  });
+
+  it("resolves empty rather than rejecting on a malformed body", async () => {
+    respondWith("<html>gateway error</html>");
+    await expect(fetchIPInfo()).resolves.toEqual({});
+  });
+
+  it("resolves empty rather than rejecting when the request errors", async () => {
+    stubHttpsGet((req) => req.emit("error", new Error("ENOTFOUND")));
+    await expect(fetchIPInfo()).resolves.toEqual({});
+  });
+
+  it("arms a timeout that abandons the request", async () => {
+    let armed: { ms: number; fire: () => void } | undefined;
+    httpsGet.mockImplementation(() => {
+      const req = Object.assign(new EventEmitter(), {
+        setTimeout: (ms: number, fire: () => void) => {
+          armed = { ms, fire };
+        },
+        destroy: vi.fn(),
+      });
+      return req;
+    });
+
+    const pending = fetchIPInfo("t", 1234);
+    expect(armed?.ms).toBe(1234);
+
+    armed?.fire();
+    await expect(pending).resolves.toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds a complete test suite for the `about-system-info` package, covering the core caching, utility, and platform information modules. The tests ensure reliability of system information collection by validating error handling, cache behavior, and platform-specific logic.

## Key Changes
- **Cache tests** (`cache.test.ts`): 235 lines covering cache loading, saving, validation, and expiration logic
  - Validates graceful handling of corrupt/unreadable cache files
  - Ensures expired entries are never served and are evicted from cache
  - Tests per-key cache duration configuration
  
- **Utility tests** (`utils.test.ts`): 218 lines covering shell command execution and network utilities
  - Validates `execCommand` never throws and respects timeouts
  - Tests `commandExists` platform-specific command resolution
  - Covers `fetchIPInfo` network request handling with chunked responses, timeouts, and error recovery
  
- **Platform tests** (`platform.test.ts`): 190 lines covering system information collection
  - Tests user, hostname, kernel, OS, and device information gathering
  - Validates cache consultation before command execution
  - Tests platform-specific fallbacks (Linux DMI, Android getprop, etc.)
  - Ensures missing tools degrade gracefully rather than throwing

- **CI/Coverage Integration**:
  - Added `about-system-info` to GitHub Actions test matrix with npm/Node.js runtime
  - Configured codecov flags for package-specific coverage tracking
  - Added `test:ci` script for JUnit XML reporting in CI environments

## Notable Implementation Details
- Tests use Vitest with mocked dependencies (`child_process`, `https`, `os`, `fs`) to avoid system calls
- Fake timers used to test cache expiration logic deterministically
- Error paths are thoroughly tested since the package is designed to never throw and provide partial readouts
- Platform-specific tests use `.runIf()` to run only on relevant platforms

https://claude.ai/code/session_01HMC4C8otymb2facQ4d52KF