### PR TITLE
Fix publish workflow to prevent version deadlock

### DIFF
--- a/.github/scripts/check-package-entrypoints.mjs
+++ b/.github/scripts/check-package-entrypoints.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Warns when a package is about to publish a tarball that does not contain the
+ * files its own package.json points at.
+ *
+ * api2ai is why this exists: its `main`, `module` and `types` all point into
+ * `dist/`, its `files` field ships only `dist/`, and its build script builds
+ * the Next.js app instead — so every one of its 29 releases is a tarball
+ * holding a README and a package.json, and `import 'api2ai'` has never
+ * resolved. Nothing in the pipeline noticed, because publishing succeeded.
+ *
+ * Usage:  node check-package-entrypoints.mjs <package-dir>
+ *
+ * Always exits 0: a missing entry point is a packaging bug to fix in the
+ * package, not a reason to hold back everything else in the release.
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** Paths a consumer resolves through, in the order a reader would look for them. */
+export function declaredEntryPoints(pkg) {
+  const entries = [];
+
+  // `main`, `module`, `types` and `bin` are always paths inside the package,
+  // with or without a `./`. Only `exports` targets have to declare the `./`,
+  // and only there can a value be something else entirely.
+  const add = (field, value) => {
+    if (typeof value === 'string') entries.push({ field, target: value, isPath: true });
+  };
+
+  add('main', pkg.main);
+  add('module', pkg.module);
+  add('types', pkg.types ?? pkg.typings);
+
+  if (typeof pkg.bin === 'string') {
+    add('bin', pkg.bin);
+  } else if (pkg.bin && typeof pkg.bin === 'object') {
+    for (const [name, target] of Object.entries(pkg.bin)) add(`bin[${name}]`, target);
+  }
+
+  const walkExports = (node, trail) => {
+    if (typeof node === 'string') {
+      entries.push({ field: `exports${trail}`, target: node, isPath: node.startsWith('./') });
+      return;
+    }
+    if (!node || typeof node !== 'object') return;
+    for (const [key, value] of Object.entries(node)) walkExports(value, `${trail}["${key}"]`);
+  };
+  walkExports(pkg.exports, '');
+
+  return entries;
+}
+
+/** npm stores tarball paths without a leading `./`; declarations usually have one. */
+export function normalizeTarballPath(target) {
+  return path.posix.normalize(String(target).replace(/^\.\//, ''));
+}
+
+export function findMissingEntryPoints(pkg, packedPaths) {
+  const packed = new Set(packedPaths.map(normalizeTarballPath));
+
+  // A wildcard target (`./dist/*.js`) stands for a set of files, not one, so
+  // there is nothing to look up.
+  return declaredEntryPoints(pkg).filter(
+    ({ target, isPath }) => isPath && !target.includes('*') && !packed.has(normalizeTarballPath(target)),
+  );
+}
+
+function packedPathsOf(dir) {
+  const output = execFileSync(
+    'npm',
+    ['pack', '--dry-run', '--json', '--ignore-scripts', '--no-workspaces'],
+    { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+  );
+
+  const [result] = JSON.parse(output);
+  return (result?.files ?? []).map((file) => file.path);
+}
+
+function main() {
+  const dir = process.argv[2];
+  if (!dir) {
+    process.stderr.write('usage: check-package-entrypoints.mjs <package-dir>\n');
+    process.exit(2);
+  }
+
+  const pkg = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'));
+
+  let missing;
+  try {
+    missing = findMissingEntryPoints(pkg, packedPathsOf(dir));
+  } catch (error) {
+    process.stderr.write(`::warning::could not inspect the ${pkg.name} tarball: ${error.message}\n`);
+    return;
+  }
+
+  if (missing.length === 0) return;
+
+  const detail = missing.map(({ field, target }) => `${field} → ${target}`).join(', ');
+  process.stderr.write(
+    `::warning::${pkg.name}@${pkg.version} is publishing a tarball that does not contain ` +
+      `${missing.length === 1 ? 'the file it points at' : 'the files it points at'}: ${detail}. ` +
+      `Consumers will fail to resolve ${missing.length === 1 ? 'it' : 'them'}. ` +
+      `Check the package's "files" field and its build script.\n`,
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/.github/scripts/check-package-entrypoints.test.mjs
+++ b/.github/scripts/check-package-entrypoints.test.mjs
@@ -1,0 +1,82 @@
+/** Run with: node --test .github/scripts/*.test.mjs */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  declaredEntryPoints,
+  findMissingEntryPoints,
+  normalizeTarballPath,
+} from './check-package-entrypoints.mjs';
+
+test('collects every path a consumer resolves through', () => {
+  const fields = declaredEntryPoints({
+    main: 'dist/index.js',
+    module: 'dist/index.mjs',
+    types: 'dist/index.d.ts',
+    bin: { cli: './bin/cli.js' },
+    exports: { '.': { types: './dist/index.d.ts', import: './dist/index.js' } },
+  }).map((entry) => entry.field);
+
+  assert.deepEqual(fields, [
+    'main',
+    'module',
+    'types',
+    'bin[cli]',
+    'exports["."]["types"]',
+    'exports["."]["import"]',
+  ]);
+});
+
+test('falls back to typings when types is absent', () => {
+  const [entry] = declaredEntryPoints({ typings: 'dist/index.d.ts' });
+  assert.deepEqual(entry, { field: 'types', target: 'dist/index.d.ts', isPath: true });
+});
+
+test('reads a string bin as one entry', () => {
+  const [entry] = declaredEntryPoints({ bin: './cli.js' });
+  assert.equal(entry.field, 'bin');
+});
+
+test('compares paths the way npm writes them into the tarball', () => {
+  assert.equal(normalizeTarballPath('./dist/index.js'), 'dist/index.js');
+  assert.equal(normalizeTarballPath('dist/./index.js'), 'dist/index.js');
+});
+
+test('passes a package whose declared files are all packed', () => {
+  const missing = findMissingEntryPoints(
+    { main: 'dist/index.js', exports: { '.': { import: './dist/index.js' } } },
+    ['package.json', 'README.md', 'dist/index.js'],
+  );
+  assert.deepEqual(missing, []);
+});
+
+// api2ai: `files: ["dist"]` with a build script that builds the Next.js app,
+// so the tarball is a README and a package.json.
+test('flags entry points missing from the tarball', () => {
+  const missing = findMissingEntryPoints(
+    { main: 'dist/index.js', module: 'dist/index.mjs' },
+    ['package.json', 'README.md'],
+  );
+  assert.deepEqual(
+    missing.map((entry) => entry.field),
+    ['main', 'module'],
+  );
+});
+
+test('ignores exports conditions that are not package-relative paths', () => {
+  const missing = findMissingEntryPoints(
+    { exports: { '.': { node: 'some-other-package/entry', default: './dist/index.js' } } },
+    ['dist/index.js'],
+  );
+  assert.deepEqual(missing, []);
+});
+
+test('ignores wildcard subpath exports, which stand for a set of files', () => {
+  const missing = findMissingEntryPoints({ exports: { './*': './dist/*.js' } }, ['dist/a.js']);
+  assert.deepEqual(missing, []);
+});
+
+test('reads a null exports condition without tripping over it', () => {
+  assert.deepEqual(findMissingEntryPoints({ exports: { './internal': null } }, []), []);
+});

--- a/.github/scripts/resolve-publish-version.mjs
+++ b/.github/scripts/resolve-publish-version.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+/**
+ * Picks the version a package should be published under, from the registry
+ * rather than from the working tree.
+ *
+ * The workflow used to run `npm version patch` and publish whatever came out.
+ * That only works while the repo's idea of each version stays in step with
+ * npm's, and it does not: the version bumps are committed back to master in a
+ * step that runs after publishing, so anything that stops that commit — a
+ * failed run, a push race, a branch protection — leaves every package one
+ * patch behind the registry forever. The next run then bumps into a version
+ * that is already published, npm rejects it with
+ *
+ *   You cannot publish over the previously published versions: 0.0.65.
+ *
+ * every package fails, nothing is committed, and the deadlock repeats. Asking
+ * the registry what exists closes that loop: the answer is correct on the
+ * first run after a failure, with no repair commit needed.
+ *
+ * Usage:  node resolve-publish-version.mjs <package-dir>
+ *
+ * Prints the resolved version on stdout and nothing else, so the caller can
+ * read it straight into a shell variable. Everything human-facing — including
+ * GitHub Actions annotations — goes to stderr.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { gt, incPatch, isPrerelease, isValid, maxVersion } from './semver-lite.mjs';
+
+const REGISTRY = process.env.NPM_CONFIG_REGISTRY ?? 'https://registry.npmjs.org';
+
+/**
+ * Resolves the version to publish, given what the registry currently holds.
+ *
+ * @param {object} input
+ * @param {string} input.current      version in the package's package.json
+ * @param {string[]} input.versions   every version already published
+ * @param {string | null} input.latestTag  version the `latest` dist-tag points at
+ * @returns {{version: string, reason: string}}
+ */
+export function resolvePublishVersion({ current, versions, latestTag }) {
+  if (!isValid(current)) {
+    throw new Error(`package.json version is not a valid semver version: ${current}`);
+  }
+
+  const published = new Set(versions);
+
+  // Nothing published yet: the version in the tree is the first release.
+  if (published.size === 0) {
+    return { version: current, reason: 'first publish' };
+  }
+
+  // A version the tree has moved to deliberately — a hand-written minor or
+  // major bump — is published as written. Patching over it would silently skip
+  // the release the author asked for.
+  if (!published.has(current) && (latestTag === null || gt(current, latestTag))) {
+    return { version: current, reason: 'unpublished version already in package.json' };
+  }
+
+  // Otherwise take the next free patch, counting from whichever of the tree and
+  // the `latest` tag is further ahead. Starting from `latest` rather than from
+  // the tree is what lets a repo that has fallen behind catch up in one run.
+  let candidate = latestTag !== null && gt(latestTag, current) ? latestTag : current;
+  do {
+    candidate = incPatch(candidate);
+  } while (published.has(candidate));
+
+  return { version: candidate, reason: 'next free patch' };
+}
+
+/** Reads name + version without requiring the file to be a module. */
+function readPackageJson(dir) {
+  const file = path.join(dir, 'package.json');
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+/**
+ * Abbreviated packument — a fraction of the size of the full document and all
+ * this needs. A package that has never been published answers 404.
+ */
+async function fetchRegistryVersions(name) {
+  const url = `${REGISTRY.replace(/\/+$/, '')}/${name.replace('/', '%2f')}`;
+  const response = await fetch(url, {
+    headers: { accept: 'application/vnd.npm.install-v1+json' },
+  });
+
+  if (response.status === 404) return { versions: [], latestTag: null };
+
+  if (!response.ok) {
+    throw new Error(`Registry answered ${response.status} ${response.statusText} for ${name}`);
+  }
+
+  const packument = await response.json();
+
+  return {
+    versions: Object.keys(packument.versions ?? {}),
+    latestTag: packument['dist-tags']?.latest ?? null,
+  };
+}
+
+function annotate(level, message) {
+  process.stderr.write(`::${level}::${message}\n`);
+}
+
+async function main() {
+  const dir = process.argv[2];
+  if (!dir) {
+    process.stderr.write('usage: resolve-publish-version.mjs <package-dir>\n');
+    process.exit(2);
+  }
+
+  const pkg = readPackageJson(dir);
+  const { versions, latestTag } = await fetchRegistryVersions(pkg.name);
+  const { version, reason } = resolvePublishVersion({
+    current: pkg.version,
+    versions,
+    latestTag,
+  });
+
+  process.stderr.write(
+    `${pkg.name}: ${pkg.version} (tree) → ${version} — ${reason}` +
+      ` [latest: ${latestTag ?? 'none'}, published: ${versions.length}]\n`,
+  );
+
+  // The workflow publishes with an explicit `--tag latest`, which switches off
+  // npm's guard against pointing `latest` at something older than it already
+  // is. Re-assert that guard here, where the guarantee actually comes from, so
+  // a future change to the rules above cannot quietly walk the tag backwards.
+  if (latestTag !== null && !gt(version, latestTag)) {
+    throw new Error(
+      `refusing to publish ${version}: it would move the "latest" tag back from ${latestTag}`,
+    );
+  }
+
+  if (isPrerelease(version)) {
+    throw new Error(`refusing to publish prerelease ${version} to the "latest" tag`);
+  }
+
+  // The reason the explicit tag is needed: some higher version exists that the
+  // `latest` tag does not point at. api2ai is the standing example — an
+  // abandoned 1.0.x line sits above the 0.2.x line still being released.
+  const highest = maxVersion(versions);
+  if (highest !== null && gt(highest, version)) {
+    annotate(
+      'notice',
+      `${pkg.name}@${version} publishes below ${highest}, which is already on the registry. ` +
+        `"latest" moves from ${latestTag} to ${version}; ${highest} keeps whatever tag it has.`,
+    );
+  }
+
+  process.stdout.write(`${version}\n`);
+}
+
+// Only run when invoked directly, so the tests can import the resolver.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    annotate('error', error.message);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/resolve-publish-version.test.mjs
+++ b/.github/scripts/resolve-publish-version.test.mjs
@@ -1,0 +1,123 @@
+/**
+ * Run with: node --test .github/scripts/
+ *
+ * The publish workflow runs these before it publishes anything, so a change to
+ * the version rules that would deadlock the pipeline again fails the run
+ * instead of burning a version number on every package.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { resolvePublishVersion } from './resolve-publish-version.mjs';
+
+test('publishes the tree version when the package is new to the registry', () => {
+  const { version } = resolvePublishVersion({ current: '0.1.0', versions: [], latestTag: null });
+  assert.equal(version, '0.1.0');
+});
+
+test('bumps a patch past the tree version in the ordinary case', () => {
+  const { version } = resolvePublishVersion({
+    current: '1.2.3',
+    versions: ['1.2.2', '1.2.3'],
+    latestTag: '1.2.3',
+  });
+  assert.equal(version, '1.2.4');
+});
+
+// The regression this whole script exists for: master fell a patch behind the
+// registry because the bump commit never landed, and every run afterwards
+// re-published the version npm already had.
+test('catches up when the registry is ahead of the working tree', () => {
+  const { version } = resolvePublishVersion({
+    current: '0.0.64',
+    versions: ['0.0.63', '0.0.64', '0.0.65'],
+    latestTag: '0.0.65',
+  });
+  assert.equal(version, '0.0.66');
+});
+
+test('catches up across a wide gap in one step', () => {
+  const { version } = resolvePublishVersion({
+    current: '0.0.60',
+    versions: ['0.0.60', '0.0.65', '0.0.70'],
+    latestTag: '0.0.70',
+  });
+  assert.equal(version, '0.0.71');
+});
+
+test('never returns a version that is already published', () => {
+  const { version } = resolvePublishVersion({
+    current: '2.0.0',
+    versions: ['2.0.0', '2.0.1', '2.0.2', '2.0.3'],
+    latestTag: '2.0.1',
+  });
+  assert.equal(version, '2.0.4');
+});
+
+// A maintainer who edits the version by hand means it: publish 0.3.0, not 0.3.1.
+test('honours a hand-written bump that has not been published', () => {
+  const { version, reason } = resolvePublishVersion({
+    current: '0.3.0',
+    versions: ['0.2.8', '0.2.9'],
+    latestTag: '0.2.9',
+  });
+  assert.equal(version, '0.3.0');
+  assert.match(reason, /already in package.json/);
+});
+
+test('does not honour a hand-written bump that is already published', () => {
+  const { version } = resolvePublishVersion({
+    current: '0.3.0',
+    versions: ['0.2.9', '0.3.0'],
+    latestTag: '0.3.0',
+  });
+  assert.equal(version, '0.3.1');
+});
+
+// api2ai: an abandoned 1.0.x line sits above the 0.2.x line still shipping, so
+// the highest version on the registry is not the one `latest` points at. The
+// resolver stays on the live line and leaves 1.0.6 where it is.
+test('stays on the line the latest tag follows, ignoring a higher stale line', () => {
+  const { version } = resolvePublishVersion({
+    current: '0.2.42',
+    versions: ['0.2.28', '0.2.29', '1.0.5', '1.0.6'],
+    latestTag: '0.2.29',
+  });
+  assert.equal(version, '0.2.42');
+});
+
+test('keeps bumping the live line on later runs', () => {
+  const { version } = resolvePublishVersion({
+    current: '0.2.42',
+    versions: ['0.2.29', '0.2.42', '1.0.6'],
+    latestTag: '0.2.42',
+  });
+  assert.equal(version, '0.2.43');
+});
+
+// The invariant the workflow's explicit `--tag latest` leans on.
+test('always resolves above the current latest tag', () => {
+  const cases = [
+    { current: '0.0.64', versions: ['0.0.64', '0.0.65'], latestTag: '0.0.65' },
+    { current: '1.2.3', versions: ['1.2.3'], latestTag: '1.2.3' },
+    { current: '0.2.42', versions: ['0.2.29', '1.0.6'], latestTag: '0.2.29' },
+    { current: '0.3.0', versions: ['0.2.9'], latestTag: '0.2.9' },
+  ];
+
+  for (const input of cases) {
+    const { version } = resolvePublishVersion(input);
+    assert.ok(
+      version.localeCompare(input.latestTag) !== 0,
+      `${version} must differ from ${input.latestTag}`,
+    );
+    assert.ok(!input.versions.includes(version), `${version} must not already be published`);
+  }
+});
+
+test('rejects a version package.json cannot mean', () => {
+  assert.throws(
+    () => resolvePublishVersion({ current: 'v1.2', versions: ['1.0.0'], latestTag: '1.0.0' }),
+    /valid semver/,
+  );
+});

--- a/.github/scripts/semver-lite.mjs
+++ b/.github/scripts/semver-lite.mjs
@@ -1,0 +1,98 @@
+/**
+ * The small slice of semver the publish workflow needs, with no dependencies —
+ * the workflow resolves versions before it has installed anything, so pulling
+ * in `semver` would mean an install per package just to read a number.
+ *
+ * Handles `major.minor.patch` with an optional dot-separated prerelease and an
+ * ignored build suffix, which is everything the packages here use. Anything it
+ * cannot parse is reported as invalid rather than guessed at.
+ */
+
+const VERSION_RE = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/;
+
+/** @returns {{major: number, minor: number, patch: number, prerelease: string[]} | null} */
+export function parse(version) {
+  const match = VERSION_RE.exec(String(version ?? '').trim());
+  if (!match) return null;
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ? match[4].split('.') : [],
+  };
+}
+
+export function isValid(version) {
+  return parse(version) !== null;
+}
+
+/** Numeric identifiers compare numerically and rank below alphanumeric ones. */
+function comparePrereleaseIds(a, b) {
+  const aNumeric = /^\d+$/.test(a);
+  const bNumeric = /^\d+$/.test(b);
+
+  if (aNumeric && bNumeric) return Math.sign(Number(a) - Number(b));
+  if (aNumeric) return -1;
+  if (bNumeric) return 1;
+
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/** @returns {-1 | 0 | 1} */
+export function compare(a, b) {
+  const left = parse(a);
+  const right = parse(b);
+
+  if (!left) throw new TypeError(`Not a version: ${a}`);
+  if (!right) throw new TypeError(`Not a version: ${b}`);
+
+  for (const part of ['major', 'minor', 'patch']) {
+    if (left[part] !== right[part]) return left[part] < right[part] ? -1 : 1;
+  }
+
+  // A prerelease sorts below the release it leads up to: 1.0.0-rc.1 < 1.0.0.
+  if (left.prerelease.length === 0 && right.prerelease.length > 0) return 1;
+  if (left.prerelease.length > 0 && right.prerelease.length === 0) return -1;
+
+  const shared = Math.min(left.prerelease.length, right.prerelease.length);
+  for (let i = 0; i < shared; i += 1) {
+    const order = comparePrereleaseIds(left.prerelease[i], right.prerelease[i]);
+    if (order !== 0) return order;
+  }
+
+  return Math.sign(left.prerelease.length - right.prerelease.length);
+}
+
+export function gt(a, b) {
+  return compare(a, b) > 0;
+}
+
+export function isPrerelease(version) {
+  const parsed = parse(version);
+  return parsed !== null && parsed.prerelease.length > 0;
+}
+
+/**
+ * Next patch release. A prerelease drops its tag rather than incrementing —
+ * 1.2.3-rc.1 becomes 1.2.3 — matching `semver.inc(v, 'patch')`.
+ */
+export function incPatch(version) {
+  const parsed = parse(version);
+  if (!parsed) throw new TypeError(`Not a version: ${version}`);
+
+  const patch = parsed.prerelease.length > 0 ? parsed.patch : parsed.patch + 1;
+  return `${parsed.major}.${parsed.minor}.${patch}`;
+}
+
+/** Highest of the given versions, ignoring any that do not parse. @returns {string | null} */
+export function maxVersion(versions) {
+  let highest = null;
+
+  for (const version of versions) {
+    if (!isValid(version)) continue;
+    if (highest === null || gt(version, highest)) highest = version;
+  }
+
+  return highest;
+}

--- a/.github/scripts/semver-lite.test.mjs
+++ b/.github/scripts/semver-lite.test.mjs
@@ -1,0 +1,46 @@
+/** Run with: node --test .github/scripts/ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { compare, incPatch, isPrerelease, isValid, maxVersion, parse } from './semver-lite.mjs';
+
+test('parses the shapes package.json versions take', () => {
+  assert.deepEqual(parse('1.2.3'), { major: 1, minor: 2, patch: 3, prerelease: [] });
+  assert.deepEqual(parse('0.0.0-rc.1'), { major: 0, minor: 0, patch: 0, prerelease: ['rc', '1'] });
+  assert.equal(parse('1.2.3+build.5').prerelease.length, 0);
+});
+
+test('refuses what it cannot compare rather than guessing', () => {
+  for (const bad of ['v1.2.3', '1.2', '1.2.3.4', 'latest', '', null, undefined]) {
+    assert.equal(isValid(bad), false, `${bad} should be invalid`);
+  }
+});
+
+test('orders by precedence, not by string', () => {
+  assert.equal(compare('0.0.10', '0.0.9'), 1, 'numeric, not lexicographic');
+  assert.equal(compare('1.0.6', '0.2.43'), 1);
+  assert.equal(compare('1.2.3', '1.2.3'), 0);
+  assert.equal(compare('0.2.9', '0.10.0'), -1);
+});
+
+test('ranks a prerelease below its release', () => {
+  assert.equal(compare('1.0.0-rc.1', '1.0.0'), -1);
+  assert.equal(compare('1.0.0-rc.1', '1.0.0-rc.2'), -1);
+  assert.equal(compare('1.0.0-alpha', '1.0.0-alpha.1'), -1);
+  assert.equal(compare('1.0.0-2', '1.0.0-beta'), -1, 'numeric ids rank below alphanumeric');
+  assert.equal(isPrerelease('1.0.0-rc.1'), true);
+  assert.equal(isPrerelease('1.0.0'), false);
+});
+
+test('increments the patch, and resolves a prerelease to its release', () => {
+  assert.equal(incPatch('0.0.65'), '0.0.66');
+  assert.equal(incPatch('1.2.9'), '1.2.10');
+  assert.equal(incPatch('1.0.0-rc.1'), '1.0.0');
+});
+
+test('finds the highest version and skips ones it cannot read', () => {
+  assert.equal(maxVersion(['0.2.29', '1.0.6', '0.2.43']), '1.0.6');
+  assert.equal(maxVersion(['0.0.9', 'not-a-version', '0.0.10']), '0.0.10');
+  assert.equal(maxVersion([]), null);
+});

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,21 +12,33 @@ jobs:
   publish-packages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v4
+      # 22, not 20: several TanStack packages already declare engines
+      # ">=22.12.0", and actions running on Node 20 are deprecated.
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           registry-url: "https://registry.npmjs.org"
 
-      # Node 20 ships npm 10, which cannot use npm's OIDC trusted publishing.
+      # Node 22 ships npm 10, which cannot use npm's OIDC trusted publishing.
       # npm >= 11.5.1 picks up the id-token permission above automatically for
       # any package configured with a trusted publisher on npmjs.com, and falls
       # back to NODE_AUTH_TOKEN for the rest.
       - name: Upgrade npm
         run: npm install -g npm@^11
+
+      # setup-node writes `always-auth` into the npmrc it generates. npm 11 does
+      # not know the key and warns about it on every single invocation, which is
+      # a few hundred lines of noise across a run. Authentication comes from the
+      # _authToken line, which stays.
+      - name: Drop the deprecated always-auth key from the generated npmrc
+        run: |
+          if [ -f "$NPM_CONFIG_USERCONFIG" ]; then
+            sed -i '/^always-auth[[:space:]]*=/d' "$NPM_CONFIG_USERCONFIG"
+          fi
 
       - uses: oven-sh/setup-bun@v2
 
@@ -34,6 +46,11 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      # Publishing is not reversible, so the code that decides version numbers
+      # is checked before it decides any. These run in well under a second.
+      - name: Test the publish scripts
+        run: node --test .github/scripts/*.test.mjs
 
       # Publishing takes ~3 minutes of installs and builds before the first
       # `npm publish` runs, so bad credentials used to surface as a wall of
@@ -78,14 +95,29 @@ jobs:
             fi
 
             name=$(node -e "const p=require('./$pkg'); console.log(p.name)")
-            echo "📦 Publishing $name ($dir)"
+
+            # Ask the registry what to publish rather than bumping blindly. The
+            # bump commit at the end of this job is best-effort — a failed run,
+            # a push race or a protected branch all skip it — and once the repo
+            # falls behind npm, `npm version patch` produces a version that is
+            # already published and every package fails for good. Resolving
+            # against the registry makes the next run correct on its own.
+            if ! version=$(node .github/scripts/resolve-publish-version.mjs "$dir"); then
+              echo "❌ Could not resolve a version for $name"
+              failed_packages="$failed_packages $name"
+              continue
+            fi
+
+            echo "📦 Publishing $name@$version ($dir)"
 
             (
               cd "$dir"
 
               # --no-workspaces keeps npm operating on this package alone now that
               # the repo root declares a Turborepo/bun workspace.
-              npm version patch --no-git-tag-version --no-workspaces
+              # --allow-same-version because the resolved version is sometimes the
+              # one already in package.json, when a bump was written by hand.
+              npm version "$version" --no-git-tag-version --no-workspaces --allow-same-version
 
               # Skip postinstall hooks (e.g. drizzle-kit push, fumadocs-mdx) that require
               # runtime env vars not available in CI — build script is run explicitly below
@@ -96,7 +128,17 @@ jobs:
                 npm run build
               fi
 
-              npm publish --provenance --access public --no-workspaces
+              # Warns, never fails: a tarball missing its own entry points is a
+              # bug in that package, not a reason to hold up the release.
+              node "$GITHUB_WORKSPACE/.github/scripts/check-package-entrypoints.mjs" .
+
+              # --tag latest is explicit, not implied. npm refuses to apply the
+              # tag implicitly when any higher version exists on the registry,
+              # even one the tag does not point at — api2ai has an abandoned
+              # 1.0.x line sitting above the 0.2.x line it still ships from.
+              # resolve-publish-version.mjs guarantees this version is above the
+              # current `latest`, so the tag can only move forward.
+              npm publish --provenance --access public --no-workspaces --tag latest
             ) || {
               echo "❌ Failed to publish $name"
               failed_packages="$failed_packages $name"
@@ -117,10 +159,30 @@ jobs:
             exit 1
           fi
 
+      # Best-effort bookkeeping. What was published is already published; this
+      # only keeps the tree readable, and the next run resolves versions from
+      # the registry either way.
       - name: Commit version bumps
         if: always()
         run: |
-          git add packages/*/package.json packages/*/package-lock.json
-          git diff --staged --quiet && echo "No version changes to commit" && exit 0
+          git add -- packages/*/package.json packages/*/package-lock.json
+
+          if git diff --staged --quiet; then
+            echo "No version changes to commit"
+            exit 0
+          fi
+
           git commit -m "chore: bump package versions [skip ci]"
-          git push
+
+          # Another push to master during the ~3 minutes of installs and builds
+          # would otherwise reject this one and leave the tree behind again.
+          for attempt in 1 2 3; do
+            if git push; then
+              exit 0
+            fi
+
+            echo "Push rejected (attempt $attempt); rebasing onto the current master"
+            git pull --rebase origin master || break
+          done
+
+          echo "::warning::Could not push the version bumps. The packages are published; the tree is behind by one patch each, which the next run resolves from the registry."

--- a/packages/about-system-info/package.json
+++ b/packages/about-system-info/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "about-system": "./dist/about-system-cli.js"
+    "about-system": "dist/about-system-cli.js"
   },
   "type": "module",
   "exports": {
@@ -64,7 +64,8 @@
   "license": "rights.institute/prosper",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/about-system-info"
+    "url": "git+https://github.com/OpenSourceAGI/dev-tools-starter-agent.git",
+    "directory": "packages/about-system-info"
   },
   "homepage": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/about-system-info",
   "files": [

--- a/packages/api2ai-mcp-generator/app/layout.tsx
+++ b/packages/api2ai-mcp-generator/app/layout.tsx
@@ -8,7 +8,11 @@ import "./globals.css"
 import "../styles/themes-shadcn.css"
 import { APP_NAME, APP_DESCRIPTION } from "@/lib/constants";
 
+// Without this, Next resolves every relative social-image URL against
+// http://localhost:3000 at build time and warns about it, so the OG and
+// Twitter cards a deployed build serves point at the builder's machine.
 export const metadata: Metadata = {
+  metadataBase: new URL(process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000"),
   title: `${APP_NAME}`,
   description: APP_DESCRIPTION,
   icons: {

--- a/packages/api2ai-mcp-generator/lib/auth.ts
+++ b/packages/api2ai-mcp-generator/lib/auth.ts
@@ -28,7 +28,15 @@ const APP_DOMAIN = process.env.NEXT_PUBLIC_APP_URL?.split("//")[1] || "localhost
 export const auth = betterAuth({
   baseURL: process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000",
   // basePath: "/api/auth", // better-auth defaults to this, but keeping it explicit if user wants
-  secret: process.env.BETTER_AUTH_SECRET || process.env.AUTH_SECRET || "your-secret-key",
+  // better-auth rejects a secret shorter than 32 characters, and the previous
+  // 15-character placeholder tripped that on every build with no secret set —
+  // including CI, where it turned static generation into a page of errors.
+  // Set BETTER_AUTH_SECRET (`openssl rand -base64 32`) anywhere real; this
+  // value only exists so a local run without one still boots.
+  secret:
+    process.env.BETTER_AUTH_SECRET ||
+    process.env.AUTH_SECRET ||
+    "development-only-insecure-secret-do-not-use-in-production",
   database: drizzleAdapter(db, {
     provider: "sqlite",
     schema: {

--- a/packages/api2ai-mcp-generator/next.config.mjs
+++ b/packages/api2ai-mcp-generator/next.config.mjs
@@ -26,11 +26,12 @@ const nextConfig = {
     'shiki',
   ],
   reactStrictMode: true,
-  experimental: {
-    turbo: {
-      resolveAlias: {
-        'fumadocs-mdx:collections/server': path.resolve(__dirname, '.source/server.ts'),
-      },
+  // Next 16 builds with Turbopack by default and reads this at the top level;
+  // `experimental.turbo` is no longer a recognised key and is ignored with a
+  // warning, which would have dropped the alias below on every build.
+  turbopack: {
+    resolveAlias: {
+      'fumadocs-mdx:collections/server': path.resolve(__dirname, '.source/server.ts'),
     },
   },
   webpack: (config, { isServer }) => {

--- a/packages/api2ai-mcp-generator/package.json
+++ b/packages/api2ai-mcp-generator/package.json
@@ -6,7 +6,8 @@
   "author": "vtempest",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/api2ai-mcp-generator"
+    "url": "git+https://github.com/OpenSourceAGI/dev-tools-starter-agent.git",
+    "directory": "packages/api2ai-mcp-generator"
   },
   "homepage": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/api2ai-mcp-generator",
   "keywords": [
@@ -21,9 +22,9 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     }
   },
   "main": "dist/index.js",

--- a/packages/cloudflare-to-claude-fix/package.json
+++ b/packages/cloudflare-to-claude-fix/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/cloudflare-to-claude-fix"
+    "url": "git+https://github.com/OpenSourceAGI/dev-tools-starter-agent.git",
+    "directory": "packages/cloudflare-to-claude-fix"
   },
   "homepage": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/cloudflare-to-claude-fix",
   "keywords": [

--- a/packages/code-tree-graph/package.json
+++ b/packages/code-tree-graph/package.json
@@ -4,7 +4,8 @@
   "description": "Code dependency graph and file tree visualization components",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/code-tree-graph"
+    "url": "git+https://github.com/OpenSourceAGI/dev-tools-starter-agent.git",
+    "directory": "packages/code-tree-graph"
   },
   "homepage": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/code-tree-graph",
   "keywords": [

--- a/packages/create-cloud-db/package.json
+++ b/packages/create-cloud-db/package.json
@@ -6,7 +6,7 @@
   "version": "1.0.47",
   "main": "create-cloud-db.js",
   "bin": {
-    "create-cloud-db": "./create-cloud-db.js"
+    "create-cloud-db": "create-cloud-db.js"
   },
   "scripts": {
     "ship": "npx standard-version --release-as patch; rm CHANGELOG.md; npm publish",
@@ -17,7 +17,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/create-cloud-db"
+    "url": "git+https://github.com/OpenSourceAGI/dev-tools-starter-agent.git",
+    "directory": "packages/create-cloud-db"
   },
   "homepage": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/create-cloud-db",
   "keywords": [

--- a/packages/create-starter-app/package.json
+++ b/packages/create-starter-app/package.json
@@ -4,7 +4,7 @@
   "description": "Interactive CLI to scaffold a starter app from curated templates",
   "type": "module",
   "bin": {
-    "create-starter-app": "./bin/create-starter-app.js"
+    "create-starter-app": "bin/create-starter-app.js"
   },
   "scripts": {
     "ship": "npm run build && npx standard-version --release-as patch; rm CHANGELOG.md; npm publish",
@@ -35,7 +35,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/create-starter-app"
+    "url": "git+https://github.com/OpenSourceAGI/dev-tools-starter-agent.git",
+    "directory": "packages/create-starter-app"
   },
   "homepage": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/create-starter-app",
   "devDependencies": {

--- a/packages/export-svg-icons-typescript/package.json
+++ b/packages/export-svg-icons-typescript/package.json
@@ -14,7 +14,7 @@
     "coverage": "vitest run --coverage"
   },
   "bin": {
-    "export-svg-typescript": "./export-svg-typescript.js"
+    "export-svg-typescript": "export-svg-typescript.js"
   },
   "keywords": [
     "svg",
@@ -26,7 +26,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/export-svg-icons-typescript"
+    "url": "git+https://github.com/OpenSourceAGI/dev-tools-starter-agent.git",
+    "directory": "packages/export-svg-icons-typescript"
   },
   "homepage": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/export-svg-icons-typescript",
   "devDependencies": {

--- a/packages/git0-repo-downloader/package.json
+++ b/packages/git0-repo-downloader/package.json
@@ -25,10 +25,10 @@
         ".": "./dist/cli.js"
     },
     "bin": {
-        "g": "./dist/cli.js",
-        "gg": "./dist/cli.js",
-        "fm": "./src/fm.js",
-        "git0": "./dist/cli.js"
+        "g": "dist/cli.js",
+        "gg": "dist/cli.js",
+        "fm": "src/fm.js",
+        "git0": "dist/cli.js"
     },
     "type": "module",
     "keywords": [
@@ -42,7 +42,8 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/git0-repo-downloader"
+        "url": "git+https://github.com/OpenSourceAGI/dev-tools-starter-agent.git",
+        "directory": "packages/git0-repo-downloader"
     },
     "homepage": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/git0-repo-downloader",
     "devDependencies": {

--- a/packages/manage-storage/package.json
+++ b/packages/manage-storage/package.json
@@ -24,7 +24,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/manage-storage"
+    "url": "git+https://github.com/OpenSourceAGI/dev-tools-starter-agent.git",
+    "directory": "packages/manage-storage"
   },
   "homepage": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/manage-storage",
   "dependencies": {

--- a/packages/native-app-wrapper/package.json
+++ b/packages/native-app-wrapper/package.json
@@ -7,7 +7,7 @@
   "author": "vtempest",
   "license": "rights.institute/prosper",
   "bin": {
-    "native-app-wrapper": "./bin/cli.js"
+    "native-app-wrapper": "bin/cli.js"
   },
   "scripts": {
     "init": "node bin/cli.js init",
@@ -47,7 +47,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/native-app-wrapper"
+    "url": "git+https://github.com/OpenSourceAGI/dev-tools-starter-agent.git",
+    "directory": "packages/native-app-wrapper"
   },
   "homepage": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/native-app-wrapper",
   "devDependencies": {

--- a/packages/open-when-ready/package.json
+++ b/packages/open-when-ready/package.json
@@ -4,7 +4,7 @@
   "description": "Smart dev server launcher: error→AI search, success→auto-open browser. Any CLI tool.",
   "type": "module",
   "bin": {
-    "open-ready": "./open-when-ready.mjs"
+    "open-ready": "open-when-ready.mjs"
   },
   "scripts": {
     "ship": "bun x standard-version --release-as patch;rm CHANGELOG.md; npm publish",
@@ -31,7 +31,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/open-when-ready"
+    "url": "git+https://github.com/OpenSourceAGI/dev-tools-starter-agent.git",
+    "directory": "packages/open-when-ready"
   },
   "homepage": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/open-when-ready",
   "devDependencies": {

--- a/packages/react-app-store-buttons/package.json
+++ b/packages/react-app-store-buttons/package.json
@@ -8,9 +8,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     },
     "./styles": "./dist/style.css"
   },
@@ -61,7 +61,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/react-download-app-buttons"
+    "url": "git+https://github.com/OpenSourceAGI/dev-tools-starter-agent.git",
+    "directory": "packages/react-app-store-buttons"
   },
-  "homepage": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/react-download-app-buttons"
+  "homepage": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/react-app-store-buttons"
 }

--- a/packages/shadcn-theme-menu/package.json
+++ b/packages/shadcn-theme-menu/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/shadcn-theme-menu"
+    "url": "git+https://github.com/OpenSourceAGI/dev-tools-starter-agent.git",
+    "directory": "packages/shadcn-theme-menu"
   },
   "homepage": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/shadcn-theme-menu",
   "main": "./dist/index.js",

--- a/packages/verify-phone-sms/package.json
+++ b/packages/verify-phone-sms/package.json
@@ -70,7 +70,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/verify-phone-sms"
+    "url": "git+https://github.com/OpenSourceAGI/dev-tools-starter-agent.git",
+    "directory": "packages/verify-phone-sms"
   },
   "homepage": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/verify-phone-sms"
 }

--- a/packages/web2mobile-wrapper/package.json
+++ b/packages/web2mobile-wrapper/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "src/generate.js",
   "bin": {
-    "create-mobile-wrapper": "./bin/cli.js"
+    "create-mobile-wrapper": "bin/cli.js"
   },
   "keywords": [
     "react-native",
@@ -48,7 +48,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/web2mobile-wrapper"
+    "url": "git+https://github.com/OpenSourceAGI/dev-tools-starter-agent.git",
+    "directory": "packages/web2mobile-wrapper"
   },
   "homepage": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/web2mobile-wrapper",
   "private": true


### PR DESCRIPTION
## Summary

This PR overhauls the npm publish workflow to prevent version deadlock when publish commits fail to land. Instead of blindly bumping versions with `npm version patch`, the workflow now queries the registry to determine the correct next version, ensuring recovery from failed runs without manual intervention.

## Key Changes

- **New version resolution script** (`resolve-publish-version.mjs`): Queries npm registry to determine the correct version to publish, handling cases where:
  - The repo has fallen behind the registry (catches up in one step)
  - A maintainer has manually bumped the version in package.json
  - Multiple release lines exist (e.g., abandoned 1.0.x above active 0.2.x)
  - The package is new to the registry

- **New entrypoint validation script** (`check-package-entrypoints.mjs`): Warns when a package tarball is missing files declared in `main`, `module`, `types`, `bin`, or `exports` fields (non-fatal, catches packaging bugs like api2ai)

- **Lightweight semver implementation** (`semver-lite.mjs`): Provides version comparison and manipulation without external dependencies, since the workflow runs before npm install

- **Comprehensive test suites**: Added tests for all three scripts to prevent regressions in version resolution logic

- **Updated npm-publish workflow**:
  - Runs publish scripts tests before any publishing
  - Uses resolved version instead of `npm version patch`
  - Adds `--allow-same-version` flag to handle hand-written version bumps
  - Explicitly uses `--tag latest` with registry safeguards
  - Calls entrypoint validation before publishing
  - Upgraded to Node 22 and npm 11

- **Package.json fixes**:
  - Normalized `bin` field paths (removed leading `./` for consistency with npm tarball format)
  - Fixed repository URLs to use `git+https://` format with `directory` field where applicable
  - Reordered `exports` fields for consistency

- **Configuration updates**:
  - Updated Next.js config to use top-level `turbopack` instead of deprecated `experimental.turbo`
  - Fixed auth secret length validation in better-auth setup
  - Added metadata to Next.js layout for social image resolution

## Implementation Details

The version resolution algorithm prioritizes:
1. First publish: use version from package.json
2. Hand-written bumps: honor unpublished versions in package.json that exceed the latest tag
3. Catch-up: start from whichever is higher (tree version or latest tag) and increment patches until finding an unpublished version

This closes the deadlock loop where failed commit steps would leave the repo permanently behind the registry.

https://claude.ai/code/session_017vuvL2AWULpa4uzjfLbcyr