### PR TITLE
feat: template-git-repo + setup-git-repo CLI + skills for the Actions and badges

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
           - package: native-app-wrapper
           - package: open-when-ready
           - package: react-app-store-buttons
+          - package: setup-git-repo
           - package: shadcn-theme-menu
           # TODO: this suite predates the current /api/send + /api/verify routes
           # and fails against them. Non-blocking until the tests are rewritten.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,12 @@ jobs:
             install: bun install
             coverage: true
 
+          - name: setup-git-repo
+            dir: packages/setup-git-repo
+            runtime: bun
+            install: bun install --ignore-scripts
+            coverage: true
+
           - name: about-system-info
             dir: packages/about-system-info
             runtime: node

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ packages/template-fumadocs/.next/*
 # Test result / coverage artifacts uploaded to Codecov by .github/workflows/tests.yml
 junit.xml
 coverage/
+
+# Turborepo local cache and task logs
+.turbo

--- a/README.md
+++ b/README.md
@@ -92,10 +92,16 @@
 **[verify-phone-sms](packages/verify-phone-sms/)** - SMS phone verification API server built with Hono on Cloudflare Workers, backed by AWS SNS. Sends one-time codes, blocks VoIP numbers, enforces API-key authentication, applies rate limiting, and exposes auto-generated OpenAPI documentation. Includes health-check endpoints and CORS/security-header middleware.
 `bun deploy` · `wrangler deploy`
 
+[![npm downloads](https://img.shields.io/npm/dm/setup-git-repo.svg)](https://www.npmjs.com/package/setup-git-repo) **[setup-git-repo](packages/setup-git-repo/)** - One command to give a repo its whole GitHub setup: Turborepo, five CI workflows (auto-discovering test matrix to Codecov, content-hash npm publishing, agent PR auto-merge, Cloudflare-deployed test reports), the centered README badge block filled in from your git remote, and docs explaining how to set up every badge, workflow and secret.
+`bunx setup-git-repo` · `npx setup-git-repo`
+
 **[web2mobile-wrapper](packages/web2mobile-wrapper/)** - Transform any website URL into a native mobile app wrapper for iOS and Android. No coding required — generates a React Native project pre-configured with your URL, push notifications, and app store metadata. Boosts discoverability via App Store and Google Play presence.
 `npm run generate` · `node bin/cli.js`
 
 ### Starter Templates
+
+**[template-git-repo](starter-templates/template-git-repo/)** - The GitHub repo scaffold itself: Turborepo task graph, the five CI workflows, `codecov.yml`, the badge block, and `docs/` covering every badge, workflow and secret. Applied to an existing repo rather than copied into a new one.
+`bunx setup-git-repo`
 
 **[template-svelte-betterauth-shadcn-drizzle](starter-templates/template-svelte-betterauth-shadcn-drizzle/)** - Full-stack SvelteKit app with Better Auth, Drizzle ORM on Cloudflare D1, Stripe payments, and shadcn-svelte components.
 `bun create starter-app` · `npx create-starter-app`
@@ -125,7 +131,7 @@ See [skills/README.md](skills/README.md) for the full index.
 
 ### ✅ Tests
 
-Three packages are wired into CI reporting today. Each exposes a `test:ci` script that writes a
+Four packages are wired into CI reporting today. Each exposes a `test:ci` script that writes a
 `junit.xml` (and lcov coverage where its runner can produce one) for
 [`.github/workflows/tests.yml`](.github/workflows/tests.yml) to upload to Codecov
 Test Analytics, which tracks run times, failure rates and flaky tests, and comments
@@ -133,6 +139,7 @@ the failing ones on the pull request.
 
 | Package | Runner | Run locally |
 | --- | --- | --- |
+| [setup-git-repo](packages/setup-git-repo/) | Vitest | `bun run test` |
 | [git0-repo-downloader](packages/git0-repo-downloader/) | `bun test` | `bun test` |
 | [web2mobile-wrapper](packages/web2mobile-wrapper/) | Jest | `npm test` |
 | [verify-phone-sms](packages/verify-phone-sms/) | Vitest | `npm test` |

--- a/codecov.yml
+++ b/codecov.yml
@@ -34,6 +34,9 @@ flag_management:
     - name: git0-repo-downloader
       paths:
         - packages/git0-repo-downloader/
+    - name: setup-git-repo
+      paths:
+        - packages/setup-git-repo/
     - name: web2mobile-wrapper
       paths:
         - packages/web2mobile-wrapper/

--- a/packages/setup-git-repo/.gitignore
+++ b/packages/setup-git-repo/.gitignore
@@ -1,0 +1,4 @@
+# Built by `prepack` from starter-templates/template-git-repo — never edit here.
+template/
+coverage/
+junit.xml

--- a/packages/setup-git-repo/README.md
+++ b/packages/setup-git-repo/README.md
@@ -1,0 +1,105 @@
+# setup-git-repo
+
+One command to give a repository the whole GitHub setup: Turborepo, the CI
+workflows, the README badge block, and the docs explaining every part of it.
+
+```bash
+bunx setup-git-repo          # or: npx setup-git-repo
+```
+
+Run it inside the repo you want to set up. Owner, repo name and default branch
+are read from `git remote get-url origin`; the optional badges are prompted for
+and left out if you skip them.
+
+## What it writes
+
+```
+.github/workflows/tests.yml                   auto-discovering test matrix → Codecov
+.github/workflows/npm-publish.yml             publishes packages whose content changed
+.github/workflows/deploy-test-reports.yml     HTML test report → Cloudflare Workers
+.github/workflows/auto-merge-claude.yml       auto-merge for agent and maintainer PRs
+.github/workflows/auto-merge-and-create-prs.yml  twice-daily branch/PR sweep
+.github/scripts/next-free-version.mjs         picks a version npm has not spent
+turbo.json  package.json  vitest.config.ts    the Turborepo task graph
+codecov.yml                                   flags, carryforward, comment layout
+README.md                                     the badge block, filled in
+docs/BADGES.md  docs/WORKFLOWS.md  docs/SECRETS.md
+```
+
+Existing files are never overwritten unless you pass `--force`, so it is safe to
+run against a repo that already has some of this.
+
+## Flags
+
+Identity — detected from git when omitted:
+
+| Flag | |
+| --- | --- |
+| `--owner <name>` | GitHub owner |
+| `--repo <name>` | Repository name |
+| `--branch <name>` | Default branch, used in every workflow's `branches:` filter |
+| `--description <text>` | One-line description for the README |
+
+Optional badges — a badge whose value you omit is dropped from the README
+rather than shipped pointing at a placeholder:
+
+| Flag | Badge |
+| --- | --- |
+| `--package <name>` | npm version + monthly downloads |
+| `--doi <10.5281/zenodo.N>` | Zenodo DOI |
+| `--docs <url>` / `--api <url>` / `--youtube <url>` | link badges |
+| `--uptime <page-id>` | UptimeRobot status page |
+| `--discord-id <id>` + `--discord-invite <url>` | Discord (both required) |
+
+Behavior:
+
+| Flag | |
+| --- | --- |
+| `--dir <path>` | Target directory (default: the current one) |
+| `-n, --dry-run` | Print the plan, write nothing |
+| `-f, --force` | Overwrite files that already exist |
+| `-y, --yes` | Never prompt; use flags and git detection only |
+| `--workflows-only` / `--badges-only` / `--docs-only` / `--turbo-only` | Write one part |
+| `--template <path>` | Use a template directory other than the bundled one |
+
+## Examples
+
+```bash
+# See what would land, without writing anything
+bunx setup-git-repo --dry-run
+
+# Non-interactive, for a script or an agent
+bunx setup-git-repo -y --owner acme --repo widget --branch main --package widget-cli
+
+# Add just the workflows to a repo that already has its own README
+bunx setup-git-repo --workflows-only
+
+# Refresh the badge block after the repo moved to a new owner
+bunx setup-git-repo --badges-only --force --owner new-org
+```
+
+## After it runs
+
+It prints the repository secrets and settings the workflows need —
+`CODECOV_TOKEN`, `NPM_TOKEN` (or trusted publishing), the two Cloudflare values,
+and `GIT_TOKEN` — plus the "Allow auto-merge" and branch-protection settings
+that make `gh pr merge --auto` wait for CI instead of merging immediately.
+`docs/SECRETS.md`, written into your repo, has the same list with where each
+value comes from.
+
+## Where the template lives
+
+The single source of truth is
+[`starter-templates/template-git-repo/`](../../starter-templates/template-git-repo)
+in this monorepo. `prepack` copies it into `template/` inside the package so the
+published tarball carries it, and the CLI checks that bundled copy first — a CLI
+that only climbs out of its own package works in the repo and breaks the moment
+it is installed from npm.
+
+Its `.gitignore` is stored as `gitignore`, without the dot, because npm strips
+`.gitignore` files out of published tarballs; the CLI restores the dot on write.
+
+## Related skills
+
+- [`ask-github-actions-setup`](../../skills/ask-github-actions-setup/SKILL.md) — the workflows: what each needs, how each fails
+- [`ask-git-badges`](../../skills/ask-git-badges/SKILL.md) — the badge block: every badge's setup and failure modes

--- a/packages/setup-git-repo/bin/setup-git-repo.js
+++ b/packages/setup-git-repo/bin/setup-git-repo.js
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { createInterface } from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+
+import { detectRepo } from "../src/git.mjs";
+import { resolveTemplateDir } from "../src/resolve-template.mjs";
+import {
+  OPTIONAL_BADGES,
+  SUBSETS,
+  collectFiles,
+  configuredBadges,
+  destinationFor,
+  planFiles,
+  render,
+} from "../src/template.mjs";
+
+const c = {
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  cyan: "\x1b[36m",
+  red: "\x1b[31m",
+};
+const bold = (s) => `${c.bold}${s}${c.reset}`;
+const dim = (s) => `${c.dim}${s}${c.reset}`;
+const green = (s) => `${c.green}${s}${c.reset}`;
+const yellow = (s) => `${c.yellow}${s}${c.reset}`;
+const cyan = (s) => `${c.cyan}${s}${c.reset}`;
+const red = (s) => `${c.red}${s}${c.reset}`;
+
+// ─── Flags ───────────────────────────────────────────────────────────────────
+// Each flag maps to a placeholder in the template, except the behavioral ones.
+const FLAGS = {
+  owner: "OWNER",
+  repo: "REPO",
+  branch: "DEFAULT_BRANCH",
+  description: "DESCRIPTION",
+  package: "PACKAGE",
+  doi: "DOI",
+  docs: "DOCS_URL",
+  api: "API_URL",
+  youtube: "YOUTUBE_URL",
+  uptime: "UPTIME_ID",
+  "discord-id": "DISCORD_ID",
+  "discord-invite": "DISCORD_INVITE",
+};
+
+function parseArgs(argv) {
+  const opts = { values: {}, dir: ".", force: false, dryRun: false, yes: false, only: null, template: null };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const take = () => {
+      const next = argv[++i];
+      if (next === undefined) {
+        console.error(red(`Missing value for ${arg}`));
+        process.exit(2);
+      }
+      return next;
+    };
+
+    if (arg === "--help" || arg === "-h") return { help: true };
+    else if (arg === "--version" || arg === "-v") return { version: true };
+    else if (arg === "--force" || arg === "-f") opts.force = true;
+    else if (arg === "--dry-run" || arg === "-n") opts.dryRun = true;
+    else if (arg === "--yes" || arg === "-y") opts.yes = true;
+    else if (arg === "--dir") opts.dir = take();
+    else if (arg === "--template") opts.template = take();
+    else if (arg.endsWith("-only") && arg.startsWith("--")) {
+      const name = arg.slice(2, -5);
+      if (!SUBSETS[name]) {
+        console.error(red(`Unknown subset ${arg}. Try: ${Object.keys(SUBSETS).map((s) => `--${s}-only`).join(", ")}`));
+        process.exit(2);
+      }
+      opts.only = [...(opts.only ?? []), ...SUBSETS[name]];
+    } else if (arg.startsWith("--")) {
+      const [flag, inline] = arg.slice(2).split(/=(.*)/s);
+      const key = FLAGS[flag];
+      if (!key) {
+        console.error(red(`Unknown flag --${flag}. Run with --help.`));
+        process.exit(2);
+      }
+      opts.values[key] = inline ?? take();
+    } else {
+      // A bare argument is the target directory: `setup-git-repo ./my-repo`.
+      opts.dir = arg;
+    }
+  }
+
+  return opts;
+}
+
+function help() {
+  const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+  console.log(`
+${bold("setup-git-repo")} ${dim(`v${pkg.version}`)}
+
+  One command to give a repo the whole GitHub setup: Turborepo, the CI
+  workflows, the README badge block, and the docs explaining each of them.
+
+${bold("Usage")}
+
+  ${cyan("bunx setup-git-repo")}                 ${dim("# set up the repo you are standing in")}
+  ${cyan("bunx setup-git-repo ./my-repo")}       ${dim("# or one somewhere else")}
+  ${cyan("bunx setup-git-repo --dry-run")}       ${dim("# show what would be written")}
+
+${bold("Identity")} ${dim("(detected from git remote when omitted)")}
+
+  --owner <name>            GitHub owner
+  --repo <name>             Repository name
+  --branch <name>           Default branch, used in workflow filters
+  --description <text>      One-line description for the README
+
+${bold("Optional badges")} ${dim("(a badge whose value is omitted is left out of the README)")}
+
+  --package <name>          npm package, for the version + downloads badges
+  --doi <10.5281/zenodo.N>  Zenodo DOI
+  --docs <url>              Documentation link
+  --api <url>               API reference link
+  --youtube <url>           Demo video link
+  --uptime <page-id>        UptimeRobot status page id
+  --discord-id <id>         Discord server id ${dim("(both are needed for")}
+  --discord-invite <url>    Discord invite link   ${dim("the Discord badge)")}
+
+${bold("Behavior")}
+
+  --dir <path>              Target directory (default: the current one)
+  -f, --force               Overwrite files that already exist
+  -n, --dry-run             Print the plan, write nothing
+  -y, --yes                 Never prompt; use flags and git detection only
+  --workflows-only          Only .github/
+  --badges-only             Only README.md
+  --docs-only               Only docs/
+  --turbo-only              Only turbo.json, package.json, vitest.config.ts
+  --template <path>         Use a template directory other than the bundled one
+
+${bold("After it runs")} it prints the secrets and repo settings the workflows
+need. ${dim("docs/SECRETS.md")} has the same list with where each value comes from.
+`);
+}
+
+async function prompt(rl, label, fallback) {
+  const suffix = fallback ? dim(` (${fallback})`) : dim(" (skip)");
+  const answer = (await rl.question(`  ${label}${suffix}: `)).trim();
+  return answer || fallback || "";
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+
+  if (opts.help) return help();
+  if (opts.version) {
+    const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+    return console.log(pkg.version);
+  }
+
+  const target = resolve(opts.dir);
+  const templateDir = resolveTemplateDir(opts.template);
+
+  console.log(`\n${bold("setup-git-repo")} → ${cyan(target)}\n`);
+
+  if (!existsSync(target)) {
+    mkdirSync(target, { recursive: true });
+    console.log(dim(`  created ${target}`));
+  }
+
+  // ── Identity: flags win, then git, then the directory name ────────────────
+  const detected = detectRepo(target);
+  const values = {
+    OWNER: opts.values.OWNER ?? detected.owner ?? "",
+    REPO: opts.values.REPO ?? detected.repo ?? target.split("/").pop(),
+    DEFAULT_BRANCH: opts.values.DEFAULT_BRANCH ?? detected.defaultBranch ?? "main",
+    DESCRIPTION: opts.values.DESCRIPTION ?? "",
+    ...opts.values,
+  };
+
+  if (!detected.isRepo) {
+    console.log(yellow("  Not a git repository — owner and branch cannot be detected."));
+  }
+
+  const interactive = !opts.yes && stdin.isTTY && stdout.isTTY;
+
+  if (interactive) {
+    const rl = createInterface({ input: stdin, output: stdout });
+    try {
+      console.log(bold("  Repository"));
+      values.OWNER = await prompt(rl, "GitHub owner", values.OWNER);
+      values.REPO = await prompt(rl, "Repository name", values.REPO);
+      values.DEFAULT_BRANCH = await prompt(rl, "Default branch", values.DEFAULT_BRANCH);
+      values.DESCRIPTION = await prompt(rl, "One-line description", values.DESCRIPTION);
+
+      console.log(`\n${bold("  Optional badges")} ${dim("— press Enter to leave one out")}`);
+      values.PACKAGE = await prompt(rl, "npm package name", values.PACKAGE);
+      values.DOI = await prompt(rl, "Zenodo DOI", values.DOI);
+      values.DOCS_URL = await prompt(rl, "Docs URL", values.DOCS_URL);
+      values.API_URL = await prompt(rl, "API URL", values.API_URL);
+      values.YOUTUBE_URL = await prompt(rl, "YouTube URL", values.YOUTUBE_URL);
+      values.UPTIME_ID = await prompt(rl, "UptimeRobot status page id", values.UPTIME_ID);
+      values.DISCORD_ID = await prompt(rl, "Discord server id", values.DISCORD_ID);
+      values.DISCORD_INVITE = await prompt(rl, "Discord invite URL", values.DISCORD_INVITE);
+      console.log("");
+    } finally {
+      rl.close();
+    }
+  }
+
+  if (!values.OWNER || !values.REPO) {
+    console.error(red("\n  Owner and repo are required. Pass --owner and --repo, or run inside a git repo with an origin remote.\n"));
+    process.exit(1);
+  }
+  if (!values.DESCRIPTION) values.DESCRIPTION = `${values.REPO} — a Turborepo monorepo.`;
+
+  // ── Plan ──────────────────────────────────────────────────────────────────
+  const files = collectFiles(templateDir);
+  const plan = planFiles(files, {
+    exists: (file) => existsSync(join(target, destinationFor(file))),
+    force: opts.force,
+    only: opts.only,
+  });
+
+  const report = (label, list, color) => {
+    if (!list.length) return;
+    console.log(`  ${color(label)} ${dim(`(${list.length})`)}`);
+    for (const file of list) console.log(`    ${destinationFor(file)}`);
+  };
+
+  report(opts.dryRun ? "would write" : "write", plan.write, green);
+  report(opts.dryRun ? "would overwrite" : "overwrite", plan.overwrite, yellow);
+  report("skip, already present", plan.skip, dim);
+
+  if (plan.skip.length && !opts.force) {
+    console.log(dim("\n  Re-run with --force to overwrite the skipped files."));
+  }
+
+  if (opts.dryRun) {
+    console.log(dim("\n  --dry-run: nothing was written.\n"));
+    return;
+  }
+
+  for (const file of [...plan.write, ...plan.overwrite]) {
+    const destination = join(target, destinationFor(file));
+    mkdirSync(dirname(destination), { recursive: true });
+    writeFileSync(destination, render(readFileSync(join(templateDir, file), "utf8"), values));
+  }
+
+  // ── What is still on the human ────────────────────────────────────────────
+  const badges = configuredBadges(values);
+  const omitted = Object.keys(OPTIONAL_BADGES).filter((b) => !badges.has(b));
+
+  console.log(`\n${green("✓")} ${bold(`${plan.write.length + plan.overwrite.length} files written`)}\n`);
+
+  if (omitted.length) {
+    console.log(`${bold("Badges left out")} ${dim("(no value given)")}: ${omitted.join(", ")}`);
+    console.log(dim("  docs/BADGES.md has the snippet and setup steps for each.\n"));
+  }
+
+  console.log(bold("Next: the secrets these workflows need"));
+  console.log(dim("  Settings → Secrets and variables → Actions → New repository secret"));
+  console.log(`
+  ${cyan("CODECOV_TOKEN")}          coverage + test analytics ${dim("(tests.yml)")}
+  ${cyan("NPM_TOKEN")}              npm publishing ${dim("(npm-publish.yml — or set up trusted publishing instead)")}
+  ${cyan("CLOUDFLARE_API_TOKEN")}   test report deploys ${dim("(deploy-test-reports.yml)")}
+  ${cyan("CLOUDFLARE_ACCOUNT_ID")}  test report deploys ${dim("(deploy-test-reports.yml)")}
+  ${cyan("GIT_TOKEN")}              auto-merge ${dim("(a PAT: GITHUB_TOKEN's merges do not trigger other workflows)")}
+`);
+
+  console.log(bold("Next: the repository settings they need"));
+  console.log(`
+  Settings → General → Pull Requests → ${cyan("Allow auto-merge")}
+  Settings → Branches → branch protection with ${cyan("at least one required check")}
+  ${dim("without both, --auto is rejected and the fallback merges without waiting for CI")}
+  Settings → Actions → General → ${cyan("Read and write permissions")} ${dim("(for the version-bump commit)")}
+  Settings → Actions → General → ${cyan("Allow Actions to create pull requests")}
+`);
+
+  console.log(`${bold("Then")}\n`);
+  console.log(`  ${cyan("bun install")}`);
+  console.log(`  ${cyan("bun run build")}   ${dim("# turbo fans out across packages/ and apps/")}`);
+  console.log(`\n  Read ${cyan("docs/BADGES.md")}, ${cyan("docs/WORKFLOWS.md")} and ${cyan("docs/SECRETS.md")} for the details.\n`);
+}
+
+main().catch((error) => {
+  console.error(red(`\n${error.message}\n`));
+  process.exit(1);
+});

--- a/packages/setup-git-repo/package.json
+++ b/packages/setup-git-repo/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "setup-git-repo",
+  "version": "1.0.0",
+  "description": "One command to set up a GitHub repo: Turborepo, CI workflows, README badges, and the docs for each",
+  "type": "module",
+  "bin": {
+    "setup-git-repo": "bin/setup-git-repo.js"
+  },
+  "scripts": {
+    "sync-template": "node scripts/sync-template.mjs",
+    "prepack": "node scripts/sync-template.mjs",
+    "test": "vitest run",
+    "test:ci": "vitest run --reporter=junit --outputFile=junit.xml --coverage",
+    "test:watch": "vitest",
+    "coverage": "vitest run --coverage"
+  },
+  "files": [
+    "bin",
+    "src",
+    "template"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "github-actions",
+    "turborepo",
+    "monorepo",
+    "badges",
+    "shields",
+    "codecov",
+    "ci",
+    "scaffold",
+    "template"
+  ],
+  "author": "vtempest <grokthiscontact@gmail.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OpenSourceAGI/dev-tools-starter-agent.git",
+    "directory": "packages/setup-git-repo"
+  },
+  "homepage": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/setup-git-repo",
+  "devDependencies": {
+    "@vitest/coverage-v8": "^4.1.0",
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/setup-git-repo/scripts/sync-template.mjs
+++ b/packages/setup-git-repo/scripts/sync-template.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+/**
+ * Copy starter-templates/template-git-repo into this package as `template/`,
+ * so the published tarball carries it.
+ *
+ * Runs from `prepack`. The monorepo copy stays the single source of truth; the
+ * bundled one is build output and is gitignored.
+ */
+import { cpSync, existsSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const source = join(packageRoot, "..", "..", "starter-templates", "template-git-repo");
+const destination = join(packageRoot, "template");
+
+if (!existsSync(source)) {
+  console.error(`sync-template: source not found at ${source}`);
+  process.exit(1);
+}
+
+rmSync(destination, { recursive: true, force: true });
+cpSync(source, destination, {
+  recursive: true,
+  filter: (path) => !/(^|[\\/])(node_modules|\.turbo|dist)([\\/]|$)/.test(path),
+});
+
+console.log(`sync-template: copied ${source} -> ${destination}`);

--- a/packages/setup-git-repo/src/git.mjs
+++ b/packages/setup-git-repo/src/git.mjs
@@ -1,0 +1,74 @@
+import { execFileSync } from "node:child_process";
+
+/**
+ * Parse an `owner/repo` pair out of a git remote URL.
+ *
+ * Handles the four shapes a remote realistically takes:
+ *   https://github.com/owner/repo.git
+ *   git@github.com:owner/repo.git
+ *   ssh://git@github.com/owner/repo
+ *   https://user:token@github.com/owner/repo.git   (credentials in the URL)
+ *
+ * Returns null rather than throwing, so a repo with an unusual remote falls
+ * back to prompting instead of failing the run.
+ */
+export function parseRemote(url) {
+  if (typeof url !== "string" || !url.trim()) return null;
+
+  let rest = url.trim().replace(/\.git$/, "");
+
+  // scp-style: git@host:owner/repo
+  const scp = rest.match(/^[^/]+@[^:/]+:(.+)$/);
+  if (scp) {
+    rest = scp[1];
+  } else {
+    // Any URL scheme, with or without embedded credentials.
+    const withScheme = rest.match(/^[a-z][a-z0-9+.-]*:\/\/(?:[^@/]+@)?[^/]+\/(.+)$/i);
+    if (withScheme) rest = withScheme[1];
+  }
+
+  const parts = rest.split("/").filter(Boolean);
+  if (parts.length < 2) return null;
+
+  // Take the last two segments: enterprise hosts prefix paths with more.
+  const [owner, repo] = parts.slice(-2);
+  if (!owner || !repo) return null;
+  return { owner, repo };
+}
+
+/** Run a git command, returning trimmed stdout or null if git fails. */
+function git(args, cwd) {
+  try {
+    return execFileSync("git", args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Best-effort detection of owner, repo and default branch for a checkout.
+ *
+ * The default branch is read from origin's HEAD ref, which is only present once
+ * something has fetched it. When it is missing, fall back to the current branch
+ * — in a fresh `git init` that is the branch the first push will create.
+ */
+export function detectRepo(cwd = process.cwd()) {
+  const remote = git(["remote", "get-url", "origin"], cwd);
+  const parsed = parseRemote(remote);
+
+  let defaultBranch = null;
+  const originHead = git(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], cwd);
+  if (originHead) defaultBranch = originHead.replace(/^origin\//, "");
+  if (!defaultBranch) defaultBranch = git(["branch", "--show-current"], cwd);
+
+  return {
+    owner: parsed?.owner ?? null,
+    repo: parsed?.repo ?? null,
+    defaultBranch: defaultBranch || null,
+    isRepo: git(["rev-parse", "--is-inside-work-tree"], cwd) === "true",
+  };
+}

--- a/packages/setup-git-repo/src/resolve-template.mjs
+++ b/packages/setup-git-repo/src/resolve-template.mjs
@@ -1,0 +1,44 @@
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Find the template directory.
+ *
+ * Two locations, in order, because the package has to work both ways:
+ *
+ *   1. `template/` inside the package — what the published tarball ships.
+ *      `scripts/sync-template.mjs` copies it in at pack time.
+ *   2. `starter-templates/template-git-repo/` up in the monorepo — what a
+ *      checkout has, and the single source of truth the copy is made from.
+ *
+ * Checking the bundled copy first matters: a CLI that only climbs out of its
+ * own package works in the repo and breaks the moment it is installed from npm,
+ * which is exactly the trap `create-starter-app` fell into.
+ */
+export function resolveTemplateDir(override = null) {
+  if (override) {
+    const abs = resolve(override);
+    if (!existsSync(abs)) {
+      throw new Error(`--template path does not exist: ${abs}`);
+    }
+    return abs;
+  }
+
+  const candidates = [
+    join(here, "..", "template"),
+    join(here, "..", "..", "..", "starter-templates", "template-git-repo"),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(join(candidate, "package.json"))) return resolve(candidate);
+  }
+
+  throw new Error(
+    "Could not find the template. Looked in:\n" +
+      candidates.map((c) => `  ${resolve(c)}`).join("\n") +
+      "\nPass --template <path> to point at it explicitly.",
+  );
+}

--- a/packages/setup-git-repo/src/template.mjs
+++ b/packages/setup-git-repo/src/template.mjs
@@ -1,0 +1,142 @@
+import { readdirSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
+/**
+ * Every optional badge in the template README carries a `<!-- badge:NAME -->`
+ * marker at the start of its line. A badge whose value the user did not supply
+ * would render as a broken image pointing at a literal `{{DOI}}`, so its whole
+ * line is dropped; a badge that is kept has only its marker removed.
+ *
+ * Maps marker name -> the placeholders that badge needs to be renderable.
+ */
+export const OPTIONAL_BADGES = {
+  doi: ["DOI"],
+  docs: ["DOCS_URL"],
+  api: ["API_URL"],
+  youtube: ["YOUTUBE_URL"],
+  npm: ["PACKAGE"],
+  uptime: ["UPTIME_ID"],
+  discord: ["DISCORD_ID", "DISCORD_INVITE"],
+};
+
+const BADGE_MARKER = /<!--\s*badge:([a-z0-9-]+)\s*-->/i;
+
+/** Badge names whose placeholders all have a non-empty value. */
+export function configuredBadges(values) {
+  return new Set(
+    Object.entries(OPTIONAL_BADGES)
+      .filter(([, keys]) => keys.every((k) => typeof values[k] === "string" && values[k].trim() !== ""))
+      .map(([name]) => name),
+  );
+}
+
+/**
+ * Drop the lines of unconfigured badges and strip markers from the rest.
+ *
+ * Operates line by line, which is why the template keeps one `<a>` per line.
+ */
+export function applyBadges(content, values) {
+  const keep = configuredBadges(values);
+  const out = [];
+
+  for (const line of content.split("\n")) {
+    const match = line.match(BADGE_MARKER);
+    if (!match) {
+      out.push(line);
+      continue;
+    }
+    if (!keep.has(match[1].toLowerCase())) continue;
+    // Normalize indentation: the marker sits at column 0, but the badge
+    // lines around it are indented, and the block is read by humans.
+    out.push(`    ${line.replace(BADGE_MARKER, "").trimStart()}`);
+  }
+
+  return out.join("\n");
+}
+
+/**
+ * Replace every `{{KEY}}` with its value.
+ *
+ * An unknown or empty key is left as-is rather than replaced with an empty
+ * string: a visible `{{THING}}` in the output is a bug you notice, whereas a
+ * silent blank in a URL is one you ship.
+ */
+export function substitute(content, values) {
+  return content.replace(/\{\{([A-Z0-9_]+)\}\}/g, (whole, key) => {
+    const value = values[key];
+    return typeof value === "string" && value.trim() !== "" ? value : whole;
+  });
+}
+
+/** Render one template file: badge pruning first, then placeholders. */
+export function render(content, values) {
+  return substitute(applyBadges(content, values), values);
+}
+
+/** Recursively list files under `dir`, as paths relative to it, sorted. */
+export function collectFiles(dir) {
+  const out = [];
+
+  const walk = (current) => {
+    for (const entry of readdirSync(current).sort()) {
+      const full = join(current, entry);
+      if (statSync(full).isDirectory()) {
+        // Nothing in the template needs these, and copying a stale build into a
+        // fresh repo is worse than useless.
+        if (entry === "node_modules" || entry === ".turbo" || entry === "dist") continue;
+        walk(full);
+        continue;
+      }
+      out.push(relative(dir, full).split(sep).join("/"));
+    }
+  };
+
+  walk(dir);
+  return out.sort();
+}
+
+/**
+ * Decide what to do with each template file given what already exists.
+ *
+ * `only` narrows the run to a subset — the `--workflows-only` / `--badges-only`
+ * flags — matched as path prefixes.
+ */
+export function planFiles(files, { exists, force = false, only = null }) {
+  const plan = { write: [], overwrite: [], skip: [] };
+
+  for (const file of files) {
+    if (only && !only.some((prefix) => file === prefix || file.startsWith(`${prefix}/`))) {
+      continue;
+    }
+    if (!exists(file)) {
+      plan.write.push(file);
+    } else if (force) {
+      plan.overwrite.push(file);
+    } else {
+      plan.skip.push(file);
+    }
+  }
+
+  return plan;
+}
+
+/**
+ * Where a template file lands in the target repo.
+ *
+ * `gitignore` becomes `.gitignore`. It is stored without the dot because npm
+ * strips `.gitignore` out of published tarballs — a template that carried one
+ * would work from a checkout and silently lose the file when installed from the
+ * registry.
+ */
+export function destinationFor(file) {
+  if (file === "gitignore") return ".gitignore";
+  return file;
+}
+
+/** Path prefixes selected by the `--*-only` flags. */
+export const SUBSETS = {
+  workflows: [".github"],
+  badges: ["README.md"],
+  docs: ["docs"],
+  turbo: ["turbo.json", "package.json", "vitest.config.ts"],
+};

--- a/packages/setup-git-repo/test/git.test.mjs
+++ b/packages/setup-git-repo/test/git.test.mjs
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { parseRemote } from "../src/git.mjs";
+
+describe("parseRemote", () => {
+  it("parses https remotes", () => {
+    expect(parseRemote("https://github.com/OpenSourceAGI/dev-tools-starter-agent.git")).toEqual({
+      owner: "OpenSourceAGI",
+      repo: "dev-tools-starter-agent",
+    });
+  });
+
+  it("parses https remotes without the .git suffix", () => {
+    expect(parseRemote("https://github.com/acme/widget")).toEqual({ owner: "acme", repo: "widget" });
+  });
+
+  it("parses scp-style ssh remotes", () => {
+    expect(parseRemote("git@github.com:acme/widget.git")).toEqual({ owner: "acme", repo: "widget" });
+  });
+
+  it("parses ssh:// remotes", () => {
+    expect(parseRemote("ssh://git@github.com/acme/widget.git")).toEqual({ owner: "acme", repo: "widget" });
+  });
+
+  it("ignores credentials embedded in the URL", () => {
+    expect(parseRemote("https://x-access-token:ghp_secret@github.com/acme/widget.git")).toEqual({
+      owner: "acme",
+      repo: "widget",
+    });
+  });
+
+  it("takes the last two segments on enterprise hosts with a path prefix", () => {
+    expect(parseRemote("https://git.example.com/scm/team/acme/widget.git")).toEqual({
+      owner: "acme",
+      repo: "widget",
+    });
+  });
+
+  it("returns null rather than throwing on unusable input", () => {
+    for (const input of ["", "   ", null, undefined, 42, "not-a-remote"]) {
+      expect(parseRemote(input)).toBeNull();
+    }
+  });
+});

--- a/packages/setup-git-repo/test/resolve-template.test.mjs
+++ b/packages/setup-git-repo/test/resolve-template.test.mjs
@@ -1,0 +1,57 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveTemplateDir } from "../src/resolve-template.mjs";
+import { detectRepo } from "../src/git.mjs";
+
+describe("resolveTemplateDir", () => {
+  it("finds the monorepo template when nothing is bundled", () => {
+    // The published package carries `template/`; a checkout does not, and must
+    // still resolve starter-templates/template-git-repo.
+    const dir = resolveTemplateDir();
+    expect(dir).toMatch(/template-git-repo$|[/\\]template$/);
+  });
+
+  it("honors an explicit override", () => {
+    const dir = mkdtempSync(join(tmpdir(), "sgr-tpl-"));
+    expect(resolveTemplateDir(dir)).toBe(dir);
+  });
+
+  it("throws a path-listing error for an override that does not exist", () => {
+    expect(() => resolveTemplateDir("/no/such/template")).toThrow(/does not exist/);
+  });
+});
+
+describe("detectRepo", () => {
+  const git = (args, cwd) =>
+    execFileSync("git", args, { cwd, stdio: ["ignore", "ignore", "ignore"] });
+
+  it("reads owner, repo and branch out of a real checkout", () => {
+    const dir = mkdtempSync(join(tmpdir(), "sgr-git-"));
+    git(["init", "-q", "-b", "trunk", "."], dir);
+    git(["remote", "add", "origin", "git@github.com:acme/widget.git"], dir);
+    writeFileSync(join(dir, "f"), "");
+    git(["add", "-A"], dir);
+    git(["-c", "user.email=a@b", "-c", "user.name=t", "commit", "-qm", "init"], dir);
+
+    // No origin/HEAD in a fresh repo, so it falls back to the current branch —
+    // which is the branch the first push will create.
+    expect(detectRepo(dir)).toEqual({
+      owner: "acme",
+      repo: "widget",
+      defaultBranch: "trunk",
+      isRepo: true,
+    });
+  });
+
+  it("reports a plain directory as not a repo, without throwing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "sgr-nogit-"));
+    mkdirSync(join(dir, "sub"));
+    const detected = detectRepo(join(dir, "sub"));
+    expect(detected.isRepo).toBe(false);
+    expect(detected.owner).toBeNull();
+    expect(detected.repo).toBeNull();
+  });
+});

--- a/packages/setup-git-repo/test/template.test.mjs
+++ b/packages/setup-git-repo/test/template.test.mjs
@@ -1,0 +1,154 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  OPTIONAL_BADGES,
+  applyBadges,
+  collectFiles,
+  configuredBadges,
+  destinationFor,
+  planFiles,
+  render,
+  substitute,
+} from "../src/template.mjs";
+
+describe("substitute", () => {
+  it("replaces known placeholders", () => {
+    expect(substitute("https://github.com/{{OWNER}}/{{REPO}}", { OWNER: "acme", REPO: "widget" })).toBe(
+      "https://github.com/acme/widget",
+    );
+  });
+
+  it("leaves a placeholder visible when its value is missing or blank", () => {
+    // A visible {{DOI}} is a bug you notice; a silent blank in a URL is one you ship.
+    expect(substitute("doi/{{DOI}}", {})).toBe("doi/{{DOI}}");
+    expect(substitute("doi/{{DOI}}", { DOI: "   " })).toBe("doi/{{DOI}}");
+  });
+
+  it("replaces every occurrence", () => {
+    expect(substitute("{{REPO}}-{{REPO}}", { REPO: "x" })).toBe("x-x");
+  });
+});
+
+describe("configuredBadges", () => {
+  it("requires every placeholder a badge needs", () => {
+    // Discord needs both the server id and the invite; one alone is not enough.
+    expect(configuredBadges({ DISCORD_ID: "123" }).has("discord")).toBe(false);
+    expect(configuredBadges({ DISCORD_ID: "123", DISCORD_INVITE: "https://discord.gg/x" }).has("discord")).toBe(true);
+  });
+
+  it("treats whitespace as unset", () => {
+    expect(configuredBadges({ DOI: "  " }).has("doi")).toBe(false);
+  });
+
+  it("covers every optional badge the template declares", () => {
+    const all = Object.fromEntries(
+      Object.values(OPTIONAL_BADGES).flat().map((key) => [key, "value"]),
+    );
+    expect(configuredBadges(all).size).toBe(Object.keys(OPTIONAL_BADGES).length);
+  });
+});
+
+describe("applyBadges", () => {
+  const readme = [
+    "<p align=\"center\">",
+    "<!-- badge:doi --><a href=\"https://doi.org/{{DOI}}\">doi</a>",
+    "    <a href=\"stars\">stars</a>",
+    "<!-- badge:npm --><a href=\"npm/{{PACKAGE}}\">npm</a>",
+    "</p>",
+  ].join("\n");
+
+  it("drops the whole line of an unconfigured badge", () => {
+    const out = applyBadges(readme, { PACKAGE: "widget" });
+    expect(out).not.toContain("doi.org");
+    expect(out).toContain("npm/{{PACKAGE}}");
+  });
+
+  it("strips the marker from badges it keeps", () => {
+    const out = applyBadges(readme, { PACKAGE: "widget", DOI: "10.5281/zenodo.1" });
+    expect(out).not.toContain("<!-- badge:");
+    expect(out).toContain("doi.org");
+  });
+
+  it("indents a kept badge to match its unmarked neighbors", () => {
+    const out = applyBadges(readme, { PACKAGE: "widget", DOI: "10.5281/zenodo.1" });
+    for (const line of out.split("\n").filter((l) => l.includes("<a "))) {
+      expect(line).toMatch(/^ {4}</);
+    }
+  });
+
+  it("leaves unmarked lines untouched", () => {
+    expect(applyBadges(readme, {})).toContain('    <a href="stars">stars</a>');
+  });
+
+  it("renders a README with no optional badges configured", () => {
+    const out = applyBadges(readme, {});
+    expect(out.split("\n")).toEqual(['<p align="center">', '    <a href="stars">stars</a>', "</p>"]);
+  });
+});
+
+describe("render", () => {
+  it("prunes badges before substituting, so a dropped badge never leaks a value", () => {
+    const out = render('<!-- badge:doi --><a href="{{DOI}}">d</a>\n<span>{{REPO}}</span>', { REPO: "widget" });
+    expect(out).toBe("<span>widget</span>");
+  });
+});
+
+describe("destinationFor", () => {
+  it("restores the dot on gitignore", () => {
+    // Stored undotted because npm strips .gitignore from published tarballs.
+    expect(destinationFor("gitignore")).toBe(".gitignore");
+  });
+
+  it("passes everything else through unchanged", () => {
+    expect(destinationFor(".github/workflows/tests.yml")).toBe(".github/workflows/tests.yml");
+  });
+});
+
+describe("planFiles", () => {
+  const files = ["README.md", "turbo.json", ".github/workflows/tests.yml", "docs/BADGES.md"];
+
+  it("writes files that do not exist and skips those that do", () => {
+    const plan = planFiles(files, { exists: (f) => f === "README.md" });
+    expect(plan.write).toEqual(["turbo.json", ".github/workflows/tests.yml", "docs/BADGES.md"]);
+    expect(plan.skip).toEqual(["README.md"]);
+    expect(plan.overwrite).toEqual([]);
+  });
+
+  it("moves existing files to overwrite under --force", () => {
+    const plan = planFiles(files, { exists: () => true, force: true });
+    expect(plan.overwrite).toEqual(files);
+    expect(plan.skip).toEqual([]);
+  });
+
+  it("narrows to a subset by path prefix", () => {
+    const plan = planFiles(files, { exists: () => false, only: [".github"] });
+    expect(plan.write).toEqual([".github/workflows/tests.yml"]);
+  });
+
+  it("matches an exact file as a subset, not just a directory", () => {
+    const plan = planFiles(files, { exists: () => false, only: ["README.md"] });
+    expect(plan.write).toEqual(["README.md"]);
+  });
+
+  it("does not treat a prefix as matching a longer sibling name", () => {
+    const plan = planFiles(["docs/BADGES.md", "docs-old/x.md"], { exists: () => false, only: ["docs"] });
+    expect(plan.write).toEqual(["docs/BADGES.md"]);
+  });
+});
+
+describe("collectFiles", () => {
+  it("lists files recursively, relative and sorted, skipping build output", () => {
+    const dir = mkdtempSync(join(tmpdir(), "sgr-"));
+    mkdirSync(join(dir, ".github", "workflows"), { recursive: true });
+    mkdirSync(join(dir, "node_modules", "x"), { recursive: true });
+    mkdirSync(join(dir, "dist"), { recursive: true });
+    writeFileSync(join(dir, "README.md"), "");
+    writeFileSync(join(dir, ".github", "workflows", "tests.yml"), "");
+    writeFileSync(join(dir, "node_modules", "x", "index.js"), "");
+    writeFileSync(join(dir, "dist", "bundle.js"), "");
+
+    expect(collectFiles(dir)).toEqual([".github/workflows/tests.yml", "README.md"]);
+  });
+});

--- a/packages/setup-git-repo/vitest.config.mjs
+++ b/packages/setup-git-repo/vitest.config.mjs
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.mjs"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      reportsDirectory: "./coverage",
+      // bin/ is the interactive shell around src/; the logic worth covering
+      // lives in src/ and is exercised directly.
+      include: ["src/**/*.mjs"],
+    },
+  },
+});

--- a/skills/README.md
+++ b/skills/README.md
@@ -30,7 +30,9 @@ npx skills@latest add https://github.com/OpenSourceAGI/dev-tools-starter-agent -
 | [ask-create-cloud-db](./ask-create-cloud-db/SKILL.md) | `create-cloud-db` | Turso database creation and the `.env` rewrite |
 | [ask-create-starter-app](./ask-create-starter-app/SKILL.md) | `create-starter-app` | The template menu, how templates resolve, which ids actually exist |
 | [ask-export-svg-typescript](./ask-export-svg-typescript/SKILL.md) | `export-svg-icons-typescript` | SVG folder → tree-shakable TS barrel, runtime color and size options |
+| [ask-git-badges](./ask-git-badges/SKILL.md) | `setup-git-repo` | The README badge block: Shields grammar, per-badge setup, why a badge renders `invalid` |
 | [ask-git0](./ask-git0/SKILL.md) | `git0-repo-downloader` | Search, download, auto-install, IDE launch, rate limits |
+| [ask-github-actions-setup](./ask-github-actions-setup/SKILL.md) | `setup-git-repo` | The five CI workflows: what each needs, the secrets, and the failure modes worth knowing |
 | [ask-manage-storage](./ask-manage-storage/SKILL.md) | `manage-storage` | S3 / R2 / B2 through one call, provider detection, edge credentials |
 | [ask-native-app-wrapper](./ask-native-app-wrapper/SKILL.md) | `native-app-wrapper` | Website or CLI → native Tauri app: profiles, the sidecar bridge, icons, per-OS builds |
 | [ask-open-ready](./ask-open-ready/SKILL.md) | `open-when-ready` | Dev-server wrapper: ready/error detection, flags, log locations |

--- a/skills/ask-git-badges/API.md
+++ b/skills/ask-git-badges/API.md
@@ -1,0 +1,231 @@
+# Badge Catalog
+
+Every badge in `starter-templates/template-git-repo/README.md`, in README order.
+`OWNER`/`REPO`/`PACKAGE` are literal substitutions. Placeholders the
+`setup-git-repo` CLI fills are named in the "CLI flag" column; a badge with a
+`<!-- badge:NAME -->` marker is dropped when its flag is not given.
+
+| # | Badge | Marker | CLI flag | Needs |
+| --- | --- | --- | --- | --- |
+| 1 | DOI | `doi` | `--doi` | Zenodo account + a GitHub Release |
+| 2 | Ask DeepWiki | — | — | public repo |
+| 3 | Docs | `docs` | `--docs` | a URL |
+| 4 | API | `api` | `--api` | a URL |
+| 5 | YouTube | `youtube` | `--youtube` | a URL |
+| 6 | Deploy to Cloudflare | — | — | a wrangler config for the click-through |
+| 7 | GitHub Stars | — | — | public repo |
+| 8 | npm downloads | `npm` | `--package` | a published package |
+| 9 | Coverage | — | — | `CODECOV_TOKEN` + one upload |
+| 10 | Commit Activity | — | — | public repo |
+| 11 | Last Commit | — | — | public repo |
+| 12 | Tests (workflow status) | — | — | one run of `tests.yml` on that branch |
+| 13 | Uptime | `uptime` | `--uptime` | UptimeRobot status page |
+| 14 | npm version | `npm` | `--package` | a published package |
+| 15 | Discord | `discord` | `--discord-id`, `--discord-invite` | server id + invite + widget enabled |
+| 16 | PRs Welcome | — | — | nothing |
+| 17 | License | — | — | a detectable LICENSE file |
+| 18–21 | Stack chips | — | — | nothing |
+
+---
+
+## 1. DOI (Zenodo)
+
+```html
+<a href="https://doi.org/10.5281/zenodo.NNNNNNN"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.NNNNNNN.svg" alt="DOI" /></a>
+```
+
+1. Sign in to zenodo.org with GitHub.
+2. Zenodo → GitHub → switch the repo **on**. Only affects Releases made after.
+3. Create a GitHub **Release** (a bare tag is not enough).
+4. Use the **concept DOI** ("all versions"), not the version-specific one, so the
+   badge follows the newest release.
+
+Pass without the `https://doi.org/` prefix.
+
+## 2. Ask DeepWiki
+
+```html
+<a href="https://deepwiki.com/OWNER/REPO"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
+```
+
+The image is static and always renders; the first visit to the link triggers
+indexing if the repo has not been seen.
+
+## 3–5. Docs / API / YouTube
+
+```html
+<a href="URL"><img src="https://img.shields.io/badge/Docs-blue?logo=ReadTheDocs&logoColor=white" alt="Documentation" /></a>
+<a href="URL"><img src="https://img.shields.io/badge/API-blue?logo=fastapi&logoColor=white" alt="API" /></a>
+<a href="URL"><img height="20px" src="https://img.shields.io/badge/YouTube-red?style=for-the-badge&logo=youtube&logoColor=white" alt="YouTube" /></a>
+```
+
+Static link badges — the logo does the work, so keep labels to one word. The
+YouTube one is `style=for-the-badge` while its neighbors are flat, which renders
+taller; the `height` attribute pulls it back in line. Drop the style to match.
+
+## 6. Deploy to Cloudflare Workers
+
+```html
+<a href="https://deploy.workers.cloudflare.com/?url=https://github.com/OWNER/REPO"><img height="24px" src="https://deploy.workers.cloudflare.com/button" alt="Deploy to Cloudflare Workers" /></a>
+```
+
+Cloudflare hosts the image; no account needed to show it. The click-through needs
+a `wrangler.jsonc`/`wrangler.toml` where Cloudflare looks — in this template it
+lives in `apps/test-reports/`, so point the `url` at that subdirectory or add a
+root config.
+
+## 7, 10, 11, 17. GitHub metadata
+
+```html
+<img src="https://img.shields.io/github/stars/OWNER/REPO" alt="GitHub Stars" />
+<img src="https://img.shields.io/github/commit-activity/m/OWNER/REPO" alt="Commit Activity" />
+<img src="https://img.shields.io/github/last-commit/OWNER/REPO.svg" alt="Last Commit" />
+<img src="https://img.shields.io/github/license/OWNER/REPO" alt="License" />
+```
+
+| Variant | |
+| --- | --- |
+| `commit-activity/{w,m,y}/OWNER/REPO[/BRANCH]` | per week / month / year, optionally branch-scoped |
+| `last-commit/OWNER/REPO?display_timestamp=committer` | commit date instead of author date — what you mean after a rebase |
+| `github/stars/OWNER/REPO?style=social` | the classic star-count look |
+
+Public repos only: Shields has no token for your private repo and renders
+`not found`. The license badge reads GitHub's *detected* license; a `LICENSE.md`
+with custom text is often detected as `Other`, in which case use a static badge.
+
+## 8, 14. npm
+
+```html
+<a href="https://www.npmjs.com/package/PACKAGE"><img src="https://img.shields.io/npm/v/PACKAGE.svg" alt="npm version" /></a>
+<a href="https://www.npmjs.com/package/PACKAGE"><img src="https://img.shields.io/npm/dm/PACKAGE.svg" alt="NPM Monthly Downloads" /></a>
+```
+
+| Variant | |
+| --- | --- |
+| `npm/dt/` `npm/dw/` `npm/dm/` `npm/dy/` | total / weekly / monthly / yearly downloads |
+| `npm/v/PACKAGE/next` | a dist-tag other than `latest` |
+| `npm/v/%40scope%2Fname` | scoped packages — the slash must be encoded |
+| `npm/l/PACKAGE` `npm/unpacked-size/PACKAGE` | license, install size |
+
+`PACKAGE` is the name in `package.json`, not the repo name. Both render `invalid`
+until the first publish. In a monorepo, pick the package users install, or show
+one badge per package.
+
+## 9. Codecov
+
+```html
+<a href="https://codecov.io/gh/OWNER/REPO"><img src="https://codecov.io/gh/OWNER/REPO/graph/badge.svg" alt="Coverage" /></a>
+```
+
+1. codecov.io → sign in with GitHub → add the repo.
+2. Settings → General → **Repository Upload Token** → save as the `CODECOV_TOKEN`
+   repository secret.
+3. Push; `tests.yml` uploads `coverage/lcov.info` per package.
+
+Private repos also need a graph token in the badge URL — Codecov's repo
+Settings → Badges page prints the exact markdown. `?flag=NAME` scopes the badge
+to one package's flag; `?branch=NAME` to one branch.
+
+`codecov.yml` sets `carryforward: true`, so a package that did not run in a given
+PR keeps its last coverage instead of reading as a drop to 0%.
+
+## 12. Workflow status
+
+```html
+<a href="https://github.com/OWNER/REPO/actions/workflows/tests.yml"><img src="https://github.com/OWNER/REPO/actions/workflows/tests.yml/badge.svg?branch=main" alt="Tests" /></a>
+```
+
+Served by GitHub, not Shields.
+
+- The path segment is the workflow **file name**, not its `name:`. Renaming the
+  file breaks the badge silently ("no status").
+- Set `?branch=`. Without it the badge shows the latest run on *any* branch.
+- Also accepts `?event=push` to ignore PR runs.
+- Shows "no status" until the workflow has run once on that branch.
+
+One badge per workflow file — add `npm-publish.yml` or
+`deploy-test-reports.yml` the same way.
+
+## 13. UptimeRobot
+
+```html
+<a href="https://stats.uptimerobot.com/PAGE_ID"><img src="https://img.shields.io/badge/Uptime-Status-brightgreen?logo=uptimerobot&logoColor=white" alt="Uptime Status" /></a>
+```
+
+As shipped this is a **static** chip linking to a public status page:
+uptimerobot.com → add a monitor → Status Pages → create → copy the id from its
+URL.
+
+For live numbers, use a **monitor-specific** API key (Monitor → Settings → API
+key, the `m…` key — read-only for that one monitor, which is why it is safe in a
+README; never the account-wide key):
+
+```html
+<img src="https://img.shields.io/uptimerobot/status/MONITOR_KEY" alt="up/down" />
+<img src="https://img.shields.io/uptimerobot/ratio/7/MONITOR_KEY" alt="7-day uptime" />
+<img src="https://img.shields.io/uptimerobot/ratio/30/MONITOR_KEY" alt="30-day uptime" />
+```
+
+## 15. Discord
+
+```html
+<a href="https://discord.gg/INVITE"><img src="https://img.shields.io/discord/SERVER_ID.svg?label=Chat&logo=Discord&colorB=7289da&style=flat" alt="Join Discord" /></a>
+```
+
+Two different values:
+
+- **Server id** → the Shields path. Discord → User Settings → Advanced →
+  Developer Mode on, then right-click the server → Copy Server ID.
+- **Invite code** → the `href`. Make it **never-expiring**; the default expires
+  in 7 days and the badge quietly links to a dead page.
+
+Also requires Server Settings → Widget → **Enable Server Widget**, or Shields
+cannot read the member count and renders `invalid`.
+
+## 16. PRs Welcome
+
+```html
+<a href="CONTRIBUTING_OR_DOCS_URL"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" /></a>
+```
+
+Static. The template links GitHub's "creating a pull request" docs; repoint it at
+your own `CONTRIBUTING.md` once you have one.
+
+## 18–21. Stack chips
+
+```html
+<img src="https://img.shields.io/badge/Turborepo-EF4444?logo=turborepo&logoColor=white" alt="Turborepo" />
+```
+
+`badge/<label>-<hex>?logo=<slug>&logoColor=<color>`. Decoration only. A `-` in
+the label is written `--`, a space `_`. Slugs come from
+[simpleicons.org](https://simpleicons.org); an unknown slug renders the label
+with no icon and no error.
+
+Brand colors used in the template: Claude `D97757`, Cloudflare `F38020`,
+Turborepo `EF4444`, Bun `000000`.
+
+---
+
+## Shields URL grammar
+
+```
+https://img.shields.io/<type>/<args>[.svg][?options]
+```
+
+| Option | |
+| --- | --- |
+| `label=` | override the left half |
+| `color=` / `colorB=` | right-half color: a hex, or `brightgreen`, `green`, `yellow`, `orange`, `red`, `blue`, `lightgrey`, `success`, `important`, `critical`, `informational`, `inactive` |
+| `labelColor=` / `colorA=` | left-half color |
+| `logo=` | Simple Icons slug, or a `data:image/svg+xml;base64,…` URI |
+| `logoColor=` | recolors the logo (single-color logos only) |
+| `style=` | `flat` (default), `flat-square`, `plastic`, `for-the-badge`, `social` |
+| `cacheSeconds=` | minimum cache TTL; Shields enforces its own floor |
+
+## Caching
+
+GitHub proxies README images through camo, so a fixed badge can keep looking
+broken. Open the badge's `src` URL directly to see the real state — Shields
+renders its errors into the image. To force a refetch: `curl -X PURGE <camo url>`
+on the rendered image address, or wait; camo's TTL is minutes.

--- a/skills/ask-git-badges/SKILL.md
+++ b/skills/ask-git-badges/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: ask-git-badges
+description: Guide to the README badge block used across this org (starter-templates/template-git-repo, applied by `setup-git-repo --badges-only`) — the Shields.io URL grammar, which badges need an account or a secret and which just work, the centered-HTML layout, and per-badge setup for DOI/Zenodo, Codecov, npm, GitHub Actions status, Discord, UptimeRobot, DeepWiki and the Cloudflare deploy button. Use when adding or fixing README badges — a badge rendering "invalid" or "not found", a workflow badge stuck on "no status" or turning red from a feature branch, coverage showing "unknown", a Discord badge that will not read the member count, an npm badge before the first publish, or a fixed badge that still looks broken because of GitHub's image cache.
+---
+
+# The README Badge Block
+
+The badge header from `qwksearch-research-agent`, generalized into
+`starter-templates/template-git-repo/README.md` and applied by the
+`setup-git-repo` CLI.
+
+## Setup
+
+```bash
+bunx setup-git-repo --badges-only          # write the block into README.md
+bunx setup-git-repo --badges-only --force  # refresh an existing one
+```
+
+Owner, repo and default branch come from `git remote get-url origin`. Optional
+badges are prompted for, or passed as flags:
+
+```bash
+bunx setup-git-repo --badges-only -y \
+  --package my-package \
+  --doi 10.5281/zenodo.20951725 \
+  --discord-id 1110227955554209923 --discord-invite https://discord.gg/abc123
+```
+
+**A badge whose value you omit is dropped from the README**, rather than shipped
+pointing at a literal `{{DOI}}`. Each optional badge carries a
+`<!-- badge:NAME -->` marker on its line; the CLI drops the line when the badge's
+placeholders are not all filled, and strips the marker from the ones it keeps.
+That is why the template keeps one `<a>` per line.
+
+## Which badges need what
+
+| Setup needed | Badges |
+| --- | --- |
+| **Nothing** (public repo) | Stars, Commit Activity, Last Commit, License, PRs Welcome, DeepWiki, Deploy to Cloudflare, tech-stack chips |
+| **A workflow or service** | Workflow status, Codecov coverage, npm version, npm downloads |
+| **An external account + an id** | DOI (Zenodo), Discord, UptimeRobot, Docs/API/YouTube links |
+
+Full per-badge setup — where each id comes from, what the URL means, how it
+fails — is in [`API.md`](./API.md) and, in a generated repo, in `docs/BADGES.md`.
+
+## Shields.io in one paragraph
+
+`https://img.shields.io/<type>/<args>.svg?<options>`. Options: `label=`,
+`color=`/`colorB=`, `logo=` (any [Simple Icons](https://simpleicons.org) slug),
+`logoColor=`, `style=` (`flat`, `flat-square`, `for-the-badge`). Static badges are
+`badge/<label>-<hex>?logo=<slug>` — a literal `-` in the label must be written
+`--` and a space `_`. A logo slug that is not in Simple Icons renders the label
+with no icon and no error, so verify the slug before hunting elsewhere.
+
+## The four that bite
+
+**Workflow status.** The path segment is the workflow **file name**, not the
+`name:` inside it — rename the file and the badge silently reads "no status".
+Always set `?branch=`; without it the badge reflects the most recent run on *any*
+branch, so a red feature branch turns your README red.
+
+```html
+<a href="https://github.com/OWNER/REPO/actions/workflows/tests.yml"><img src="https://github.com/OWNER/REPO/actions/workflows/tests.yml/badge.svg?branch=main" alt="Tests" /></a>
+```
+
+**Codecov.** Needs `CODECOV_TOKEN` as a repository secret and at least one
+successful upload. If the badge says `unknown`, the upload never arrived — read
+the workflow step's log, not the badge. Private repos need a graph token in the
+badge URL too (Codecov → repo Settings → Badges gives the exact markdown).
+
+**Discord.** Two different values, and swapping them is the usual failure: the
+**server id** goes in the Shields path (it renders the online count), the
+**invite code** in the `href`. The server also needs Server Settings → Widget →
+Enable Server Widget, or Shields cannot read the count and the badge says
+`invalid`. Create a *never-expiring* invite — the default expires in 7 days and
+the badge quietly links to a dead page.
+
+**npm.** `PACKAGE` is the name in that package's `package.json`, not the repo
+name, and both the version and downloads badges render `invalid` until the
+package's first publish. Scoped names need the slash encoded:
+`npm/v/%40scope%2Fname`.
+
+## Layout
+
+Plain HTML inside `<p align="center">`, not markdown, because markdown image
+syntax cannot center or set a height. Consequences:
+
+- One `<a>` per line — the badge-pruning above is line-based, and it keeps the
+  block reorderable.
+- `<br />` between rows creates the grouping. GitHub collapses whitespace, so
+  blank lines do nothing.
+- GitHub's renderer strips `style` attributes. Sizing comes from the `height`
+  attribute or from Shields' own `style=` parameter.
+
+Group by meaning: identity and links first, health and freshness second,
+community third, stack chips last.
+
+## Recipes
+
+**Add a badge the template does not ship.** Put it on its own line at the right
+row, with four spaces of indentation. If it needs a value the user might not
+have, add `<!-- badge:NAME -->` at the start of the line and an entry in
+`OPTIONAL_BADGES` in `packages/setup-git-repo/src/template.mjs` mapping that name
+to the placeholders it needs — then it gets dropped rather than shipped broken.
+
+**Show a real uptime number** instead of the static "Status" chip, using a
+monitor-specific API key (read-only for one monitor, which is why it is safe in a
+README — never the account-wide key):
+
+```html
+<img src="https://img.shields.io/uptimerobot/ratio/7/MONITOR_API_KEY" alt="Uptime 7d" />
+```
+
+**Verify a badge.** Open its `src` URL directly in a browser: that bypasses
+GitHub's camo image proxy, and Shields renders its own errors into the image
+(`invalid`, `not found`, `inaccessible`), telling you which half of the URL is
+wrong.
+
+## Troubleshooting
+
+| Symptom | Cause → fix |
+| --- | --- |
+| Badge renders `invalid` | Shields could reach the service but not the resource — wrong id, wrong package name, or a private repo it cannot see |
+| Badge renders `not found` / `repo not found` | Private repo, or a typo in `owner/repo`. Shields has no token for private repos |
+| A fixed badge still looks broken on GitHub | GitHub's camo proxy cached the old image. Open the `src` URL directly to see the truth; `curl -X PURGE <camo url>` or wait a few minutes |
+| Workflow badge says "no status" | The workflow has never run on that branch, or the file was renamed — the URL uses the file name, not the workflow's `name:` |
+| Workflow badge is red but CI is green | No `?branch=` — it is showing a run from some other branch |
+| Coverage badge says `unknown` | No upload has landed. `CODECOV_TOKEN` missing, or the run wrote no `lcov.info` |
+| Coverage dropped to 0% for a package nobody touched | `carryforward` is off for that flag in `codecov.yml` |
+| npm badge `invalid` on a package that exists | Scoped name not URL-encoded, or you used the repo name instead of the package name |
+| Discord badge shows no count | Server widget disabled, or the server id and invite code are swapped |
+| Discord link is dead | The invite expired — the default is 7 days. Create a never-expiring one |
+| DOI badge points at an old release | You used the version-specific DOI. Use the *concept* DOI ("all versions") |
+| Zenodo never minted a DOI | A tag is not a Release. Create an actual GitHub Release, after enabling the repo in Zenodo → GitHub |
+| License badge says `Other` | GitHub could not detect the license from the file. Use a static `badge/license-MIT-green.svg` |
+| Deploy-to-Cloudflare button 404s after clicking | No `wrangler.jsonc`/`wrangler.toml` where Cloudflare looks. In this template it lives in `apps/test-reports/` |
+| A `{{PLACEHOLDER}}` shipped in the README | `setup-git-repo` leaves unknown placeholders visible on purpose. Re-run with the missing flag, or delete the line |
+| Badge icon missing, label fine | The `logo=` slug is not in Simple Icons |

--- a/skills/ask-github-actions-setup/SKILL.md
+++ b/skills/ask-github-actions-setup/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: ask-github-actions-setup
+description: Guide to setting up the GitHub Actions CI stack this org uses (starter-templates/template-git-repo, scaffolded by the setup-git-repo CLI) — an auto-discovering test matrix uploading to Codecov, a content-hash npm publish workflow with trusted publishing, agent PR auto-merge, and a Cloudflare-deployed HTML test report, plus the secrets and repo settings each one needs. Use when adding or debugging these workflows — npm publish failing with E404 or "cannot publish over previously staged version", "husky: not found" during a publish, EUNSUPPORTEDPROTOCOL on workspace:* deps, wrangler failing because assets.directory is missing, a package that never gets a CI job, Codecov showing no coverage, or `gh pr merge --auto` merging without waiting for checks.
+---
+
+# Setting Up These GitHub Actions
+
+Five workflows, learned from `OpenSourceAGI/qwksearch-research-agent` and packaged
+as `starter-templates/template-git-repo` in this repo. Each one exists because a
+specific failure cost hours; the comments in the YAML say which.
+
+## Setup
+
+```bash
+bunx setup-git-repo              # in the repo you want set up
+bunx setup-git-repo --workflows-only   # just .github/, leave the README alone
+bunx setup-git-repo --dry-run    # see the plan first
+```
+
+That writes the workflows with your default branch and owner already filled in,
+then prints the secrets to add. Nothing is overwritten without `--force`.
+
+To copy them by hand instead, the source is
+`starter-templates/template-git-repo/.github/`.
+
+## The five workflows
+
+| File | Runs on | Does |
+| --- | --- | --- |
+| `tests.yml` | PR, push to default | Discovers packages with a `test:ci` script, runs each as a matrix job, uploads to Codecov |
+| `npm-publish.yml` | push to default | Publishes every non-private package whose *content* changed, commits the bumps back |
+| `deploy-test-reports.yml` | push to default | Vitest HTML report → Cloudflare Workers |
+| `auto-merge-claude.yml` | PR opened/updated | Enables auto-merge for agent and maintainer PRs |
+| `auto-merge-and-create-prs.yml` | every 12h | Merges clean+green PRs, opens PRs for orphan branches |
+
+## Secrets
+
+| Secret | Needed by | Notes |
+| --- | --- | --- |
+| `CODECOV_TOKEN` | `tests.yml` | codecov.io → repo → Settings → Repository Upload Token |
+| `NPM_TOKEN` | `npm-publish.yml` | **Optional** — leaving it unset switches the workflow to trusted publishing (OIDC), which is preferred |
+| `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` | `deploy-test-reports.yml` | "Edit Cloudflare Workers" token template |
+| `GIT_TOKEN` | both auto-merge workflows | A PAT, **not** `GITHUB_TOKEN` |
+
+Plus repo settings: **Allow auto-merge** (Settings → General), **branch
+protection with at least one required check**, **Read and write permissions** for
+Actions, and **Allow Actions to create pull requests**.
+
+### Why `GIT_TOKEN` and not `GITHUB_TOKEN`
+
+Merges made with `GITHUB_TOKEN` do not trigger further workflows — an
+intentional loop guard. A PR merged by the auto-merge workflow with
+`GITHUB_TOKEN` would never fire `npm-publish.yml` or `deploy-test-reports.yml` on
+the default branch. Use a fine-grained PAT scoped to the one repo, with Contents
+and Pull requests read/write.
+
+## Which workflow to reach for
+
+**Adding CI to a new package** — nothing to edit. Give the package a `test:ci`
+script that writes `junit.xml` and `coverage/lcov.info`, and `tests.yml` finds it:
+
+```json
+"test:ci": "vitest run --reporter=junit --outputFile=junit.xml --coverage"
+```
+
+The matrix is discovered by a `discover` job that emits JSON consumed through
+`fromJSON`. It is two jobs because GitHub cannot compute a matrix inside the job
+that uses it. A hand-maintained matrix is the thing this replaces: it goes stale
+the first time someone adds a package and forgets, and that package silently has
+no CI.
+
+**Publishing** — nothing to edit either. `npm-publish.yml` walks
+`packages/*` and `apps/*`, skips `private: true`, and decides per package by
+comparing `npm pack --dry-run --json` integrity against
+`npm view <pkg>@<version> dist.integrity`. npm tarballs are reproducible, so
+identical hashes mean nothing to release; a different hash means bump the patch
+and publish. No one has to remember a version number.
+
+**Setting up trusted publishing** (preferred over `NPM_TOKEN`, nothing to
+rotate): at `npmjs.com/package/<name>/access`, add a trusted publisher — GitHub
+Actions, your `owner/repo`, workflow file `npm-publish.yml` — and leave
+`NPM_TOKEN` unset. A package's *first* publish cannot use it (there is no package
+page yet), so publish once by hand, then hand it to CI.
+
+## Recipes
+
+**Port these to a repo that uses npm instead of bun.** Replace
+`oven-sh/setup-bun@v2` with `actions/setup-node@v4`, `bun install
+--ignore-scripts` with `npm ci --ignore-scripts`, and `bunx turbo` with `npx
+turbo`. The `--no-workspaces` flags on `npm version` exist for bun's symlinks and
+are harmless otherwise.
+
+**Add a status badge for a workflow.** The URL uses the workflow **file name**,
+not its `name:`, and you want `?branch=`:
+
+```html
+<a href="https://github.com/OWNER/REPO/actions/workflows/tests.yml"><img src="https://github.com/OWNER/REPO/actions/workflows/tests.yml/badge.svg?branch=main" alt="Tests" /></a>
+```
+
+**Rename the default branch.** `setup-git-repo` writes it into three
+`branches:` filters. After a rename, grep the workflows for the old name — the
+badge's `?branch=` too.
+
+**Stop a package from publishing.** `"private": true` in its `package.json`. The
+loop skips it and says so in the log.
+
+**Debug a publish without releasing anything.** The integrity comparison is the
+whole decision, and you can run it locally:
+
+```bash
+cd packages/my-package
+npm pack --dry-run --ignore-scripts --json | jq -r '.[0].integrity'
+npm view my-package@$(node -p "require('./package.json').version") dist.integrity
+```
+
+Equal means the workflow will skip it.
+
+## Things in the YAML that look wrong but are not
+
+- **`set +e` in the publish loop.** GitHub runs `run:` steps with `bash -e -o
+  pipefail`, so *omitting* `set -e` does not disable errexit. Without turning it
+  off explicitly, the first package whose publish fails kills the step and every
+  later package goes unreleased without even being evaluated.
+- **`continue-on-error: true` on the test step in `deploy-test-reports.yml`.** A
+  red suite must still publish its report — that report is how you see what went
+  red. The step after it writes a placeholder page, because `wrangler deploy`
+  treats a missing `assets.directory` as a hard error and would end the run on a
+  config error instead of on the test signal.
+- **`if: ${{ !cancelled() }}` rather than `if: success()` on every upload.**
+  Otherwise uploads are skipped on exactly the runs whose results matter most.
+- **A no-op `husky` shim on PATH.** Some published dependencies ship
+  `prepare: "husky install"`. When npm reconciles bun's linked `node_modules` it
+  runs that hook and dies with exit 127 — and `--ignore-scripts` does **not**
+  suppress it for bun-linked packages.
+- **The credential preflight before any build.** npm answers an *unauthorized*
+  PUT with `E404 ... could not be found or you do not have permission to access
+  it`, which reads like a missing package. Without the preflight you pay a full
+  build for every package before the first one hits it, and each failed attempt
+  signs a provenance statement into the public sigstore transparency log.
+- **The version restore rewrites `package.json` by regex, not by
+  `JSON.stringify`.** Re-serializing would reformat every file the publish
+  touched. It matches `"version"\s*:\s*"..."` and errors if nothing matched:
+  a literal `'"version": "' + v + '"'` misses a `package.json` written without
+  the space after the colon, and drops the bump while logging that it kept it.
+- **`next-free-version.mjs` reads the release timeline, not just `latest`.** The
+  `latest` dist-tag lags any version an interrupted publish staged, and npm
+  answers a PUT for one of those with `E409 Cannot publish over previously staged
+  version`. Those numbers only show up in the full version list and in `time`.
+- **`git init` with no `actions/checkout` in the PR-sweep step.** It only needs
+  refs, so it fetches them into an empty workspace rather than paying for a
+  checkout.
+- **Counting *merged* PRs when deciding whether a branch needs one.** Reopening a
+  PR for a branch whose work already landed creates an empty, permanently open PR.
+
+## Troubleshooting
+
+| Symptom | Cause → fix |
+| --- | --- |
+| `npm error code E404` publishing a package that exists | Not a missing package — the credential cannot write to it. Rotate `NPM_TOKEN` (granular tokens last 90 days) or add this repo+workflow as the package's trusted publisher |
+| `E409 ... cannot publish over previously staged version` | A prior run reserved that version. The loop retries at the next free one, five times; if it exhausts them, publish once by hand to unstick it |
+| `husky: not found` (exit 127) during publish | A dependency's `prepare` hook. The shim step is missing or was moved after `bun install` — it must come first |
+| `EUNSUPPORTEDPROTOCOL workspace:*` | An `npm` command ran without `--no-workspaces` against bun's symlinks |
+| `vite: not found` when building in CI | `npm install` was used in a bun workspace. It cannot resolve sibling `workspace:*` deps, so devDependencies never install |
+| Versions bump on every single run | The build is not reproducible — a timestamp, absolute path or hash of the build dir is landing in `dist` |
+| Nothing publishes and there are no errors | Every package is `private: true`, or content genuinely did not change. The log says which per package |
+| A new package never gets a CI job | It has no `test:ci` script, or it lives outside `packages/` and `apps/` |
+| Codecov shows the run but no coverage | The runner wrote no `lcov.info`. Check that `--coverage` is in `test:ci` and that the provider supports your Node version |
+| An untouched package's coverage reads as 0% | `carryforward` is off for that flag in `codecov.yml` |
+| `wrangler deploy` fails on `assets.directory` | The report was never written. `--reporter=html` on the command line silently keeps its default `outputDir` — declare the reporter and its directory in `vitest.config.ts` instead |
+| Auto-merge merges immediately without waiting for CI | `--auto` was rejected and the fallback ran. Turn on "Allow auto-merge" **and** branch protection with at least one required check |
+| `gh: Bad credentials` in an auto-merge run | `GIT_TOKEN` expired or was never set |
+| The scheduled sweep runs hours late | Normal. Scheduled workflows are delayed under Actions load; both halves are idempotent for that reason |
+| Published version and repo version drift apart | The restore step could not find the version field to rewrite. It now errors instead of passing silently — check the `package.json` formatting it names |
+| The version-bump commit is rejected | Actions lacks write permission (Settings → Actions → General → Workflow permissions) |
+
+## Reference
+
+The workflows are documented in place, and the generated repo carries the long
+form: `docs/WORKFLOWS.md` (per workflow) and `docs/SECRETS.md` (per secret, with
+where each value comes from and how to rotate it).

--- a/starter-templates/template-git-repo/.github/scripts/next-free-version.mjs
+++ b/starter-templates/template-git-repo/.github/scripts/next-free-version.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * Print the next version of a package that the registry has not already spent.
+ *
+ * Bumping one patch above the `latest` dist-tag is not enough. `latest` lags
+ * any version that an interrupted publish staged, and npm answers a PUT for one
+ * of those with `E409 ... Cannot publish over previously staged version`. Those
+ * numbers show up in the full version list and in the release timeline, so both
+ * are consulted here.
+ *
+ *   node .github/scripts/next-free-version.mjs <package-name> <current-version>
+ */
+import { execFileSync } from "node:child_process";
+
+const [, , name, current] = process.argv;
+
+if (!name || !current) {
+  console.error("usage: next-free-version.mjs <package-name> <current-version>");
+  process.exit(2);
+}
+
+/** Run `npm view` and parse JSON, treating any failure as "no data". */
+function npmView(field) {
+  try {
+    const out = execFileSync("npm", ["view", name, field, "--json"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return JSON.parse(out);
+  } catch {
+    return null;
+  }
+}
+
+const taken = new Set();
+
+const versions = npmView("versions");
+if (Array.isArray(versions)) for (const v of versions) taken.add(v);
+else if (typeof versions === "string") taken.add(versions);
+
+// `time` carries every version the registry has a timestamp for, including ones
+// that were unpublished or staged and never completed.
+const time = npmView("time");
+if (time && typeof time === "object") {
+  for (const key of Object.keys(time)) {
+    if (key !== "created" && key !== "modified") taken.add(key);
+  }
+}
+
+const parse = (v) => {
+  const [core] = String(v).split(/[-+]/);
+  const parts = core.split(".").map((n) => Number.parseInt(n, 10) || 0);
+  return [parts[0] ?? 0, parts[1] ?? 0, parts[2] ?? 0];
+};
+
+// Start from the highest number the registry knows about, not from `current`:
+// a local version behind the registry would otherwise propose versions that are
+// all taken, one refused publish at a time.
+let [major, minor, patch] = parse(current);
+for (const v of taken) {
+  const [ma, mi, pa] = parse(v);
+  if (ma > major || (ma === major && (mi > minor || (mi === minor && pa > patch)))) {
+    [major, minor, patch] = [ma, mi, pa];
+  }
+}
+
+let next;
+do {
+  patch += 1;
+  next = `${major}.${minor}.${patch}`;
+} while (taken.has(next));
+
+console.log(next);

--- a/starter-templates/template-git-repo/.github/workflows/auto-merge-and-create-prs.yml
+++ b/starter-templates/template-git-repo/.github/workflows/auto-merge-and-create-prs.yml
@@ -1,0 +1,96 @@
+# A twice-daily sweep that keeps branches from going stale:
+#   1. merges open PRs that are already clean, approved (or unreviewed) and green
+#   2. opens a PR for any pushed branch that never got one
+#
+# Both halves are idempotent, so a delayed or duplicated run is harmless.
+name: Auto-merge PRs and create missing PRs
+
+on:
+  schedule:
+    # 00:00 and 12:00 UTC. Scheduled workflows can be delayed for hours during
+    # periods of high GitHub Actions load — never rely on the exact minute.
+    - cron: "0 */12 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: auto-merge-and-create-prs
+  cancel-in-progress: false
+
+jobs:
+  maintain-pull-requests:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GIT_TOKEN }}
+      GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
+      BASE_BRANCH: ${{ github.event.repository.default_branch }}
+    steps:
+      - name: Merge eligible existing pull requests
+        env:
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Eligible means: not a draft, mergeable with no conflicts (CLEAN),
+          # either approved or not reviewed at all, and every check that
+          # reported came back SUCCESS/SKIPPED/NEUTRAL.
+          gh pr list \
+            --repo "$REPOSITORY" \
+            --state open \
+            --json number,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup \
+            --jq '.[] | select(.isDraft == false) | select(.mergeStateStatus == "CLEAN") | select((.reviewDecision == "APPROVED") or (.reviewDecision == "")) | select(all(.statusCheckRollup[]?; (.conclusion == "SUCCESS" or .conclusion == "SKIPPED" or .conclusion == "NEUTRAL"))) | .number' \
+          | while read -r pr_number; do
+              echo "Attempting to merge PR #${pr_number}"
+              gh pr merge "$pr_number" \
+                --repo "$REPOSITORY" \
+                --merge \
+                --delete-branch \
+                --auto || echo "Could not merge PR #${pr_number}; it may require review, checks, or conflict resolution."
+            done
+
+      - name: Create pull requests for branches without one
+        env:
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # No actions/checkout above: this step only needs refs, so it fetches
+          # them into an empty workspace instead of paying for a full checkout.
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git init -q "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git remote add origin "https://x-access-token:${GIT_TOKEN}@github.com/${REPOSITORY}.git"
+          git fetch --quiet origin '+refs/heads/*:refs/remotes/origin/*'
+
+          base_sha="$(git rev-parse "origin/${BASE_BRANCH}")"
+
+          git for-each-ref --format='%(refname:strip=3)' refs/remotes/origin \
+            | grep -Ev "^(HEAD|${BASE_BRANCH})$" \
+            | while read -r branch; do
+                open_pr="$(gh pr list --repo "$REPOSITORY" --state open --head "$branch" --json number --jq 'length')"
+                merged_pr="$(gh pr list --repo "$REPOSITORY" --state merged --head "$branch" --json number --jq 'length')"
+                branch_sha="$(git rev-parse "origin/${branch}")"
+
+                # A merged PR counts: reopening one for a branch whose work
+                # already landed would create an empty, permanently open PR.
+                if [ "$open_pr" -gt 0 ] || [ "$merged_pr" -gt 0 ]; then
+                  echo "Skipping ${branch}: a pull request already exists or was previously merged."
+                  continue
+                fi
+
+                if git merge-base --is-ancestor "$branch_sha" "$base_sha"; then
+                  echo "Skipping ${branch}: it is already contained in ${BASE_BRANCH}."
+                  continue
+                fi
+
+                echo "Creating PR for ${branch} -> ${BASE_BRANCH}"
+                gh pr create \
+                  --repo "$REPOSITORY" \
+                  --head "$branch" \
+                  --base "$BASE_BRANCH" \
+                  --title "Merge ${branch} into ${BASE_BRANCH}" \
+                  --body "Automated pull request for branch \`${branch}\`."
+              done

--- a/starter-templates/template-git-repo/.github/workflows/auto-merge-claude.yml
+++ b/starter-templates/template-git-repo/.github/workflows/auto-merge-claude.yml
@@ -1,0 +1,50 @@
+# Enables auto-merge on pull requests opened by trusted agents and maintainers,
+# so an agent-authored change lands on its own once required checks pass.
+#
+# `--auto` is the safe path: GitHub holds the merge until branch protection is
+# satisfied. It only works when "Allow auto-merge" is on in repo settings AND
+# the base branch has protection with at least one required status check —
+# without both, GitHub rejects the flag and the fallback below merges directly.
+# On a repo with no branch protection, that fallback merges without waiting for
+# CI, which is why the actor allowlist matters.
+name: Auto-merge agent PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    # Extend this list with the bots and maintainers whose PRs may self-merge.
+    if: >
+      github.actor == 'claude[bot]' ||
+      github.actor == 'anthropic-claude[bot]' ||
+      github.actor == '{{OWNER}}'
+    steps:
+      - name: Enable auto-merge (or merge directly)
+        env:
+          # A PAT rather than GITHUB_TOKEN: merges made with GITHUB_TOKEN do not
+          # trigger further workflows, so deploy/publish runs on the default
+          # branch would never fire.
+          GH_TOKEN: ${{ secrets.GIT_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          # Long-lived branches must survive their own merges.
+          case "$HEAD_REF" in
+            production|prod|staging|develop) MERGE_OPTS="--squash" ;;
+            *) MERGE_OPTS="--squash --delete-branch" ;;
+          esac
+
+          if gh pr merge "$PR" --repo "$REPO" $MERGE_OPTS --auto; then
+            echo "Auto-merge enabled for PR #$PR"
+          else
+            echo "Auto-merge unavailable, attempting direct merge"
+            gh pr merge "$PR" --repo "$REPO" $MERGE_OPTS
+          fi

--- a/starter-templates/template-git-repo/.github/workflows/deploy-test-reports.yml
+++ b/starter-templates/template-git-repo/.github/workflows/deploy-test-reports.yml
@@ -1,0 +1,85 @@
+# Publishes a browsable HTML test report to Cloudflare Workers on every push to
+# the default branch, so the README's "Test Report" badge links somewhere real.
+name: Test Reports
+
+on:
+  push:
+    branches: [{{DEFAULT_BRANCH}}]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Generate & Deploy Test Reports
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --ignore-scripts
+
+      - name: Build workspace libraries consumed via dist
+        run: bunx turbo run build
+
+      - name: Run tests with HTML reporter
+        run: bun run test:report
+        # A red suite must still publish its report — that report is how you
+        # find out what went red.
+        continue-on-error: true
+
+      # What the step above must not do is leave `dist` missing: `wrangler
+      # deploy` treats an absent `assets.directory` as a hard error, so the run
+      # would end on a config error instead of on the test signal. Publish a
+      # placeholder rather than lose the deploy.
+      - name: Ensure a report exists to deploy
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -f apps/test-reports/dist/index.html ]; then
+            exit 0
+          fi
+          echo "::warning::Vitest wrote no HTML report; deploying a placeholder page."
+          mkdir -p apps/test-reports/dist
+          cat > apps/test-reports/dist/index.html <<HTML
+          <!doctype html>
+          <html lang="en">
+          <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <title>Test report unavailable</title>
+          <style>
+          :root { color-scheme: light dark; }
+          body { margin: 0; min-height: 100vh; display: grid; place-items: center;
+                 font: 16px/1.6 system-ui, sans-serif; padding: 24px; }
+          main { max-width: 34rem; }
+          h1 { font-size: 1.25rem; margin: 0 0 .75rem; }
+          p { margin: 0 0 .75rem; opacity: .85; }
+          </style>
+          </head>
+          <body>
+          <main>
+          <h1>Test report unavailable</h1>
+          <p>The last run of the test suite ended before the HTML reporter could
+          write a report, so there is nothing to show here yet.</p>
+          <p><a href="$RUN_URL">Open the workflow run</a> for the full output.</p>
+          <p>Commit $GITHUB_SHA</p>
+          </main>
+          </body>
+          </html>
+          HTML
+
+      - name: Deploy to Cloudflare Workers
+        working-directory: apps/test-reports
+        run: npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: apps/test-reports/dist/
+          if-no-files-found: ignore

--- a/starter-templates/template-git-repo/.github/workflows/npm-publish.yml
+++ b/starter-templates/template-git-repo/.github/workflows/npm-publish.yml
@@ -1,0 +1,394 @@
+# Publishes every non-private workspace package whose *content* changed, and
+# commits the resulting version bumps back to the default branch.
+#
+# The design rule here is: never ask a human to remember a version number.
+# Each package's tarball is compared against what is already on the registry;
+# identical content is skipped, changed content gets the next free patch.
+name: Publish to npm
+
+on:
+  push:
+    branches: [{{DEFAULT_BRANCH}}]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  # Required for trusted publishing (OIDC). Harmless when NPM_TOKEN is used.
+  id-token: write
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+jobs:
+  publish-packages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+
+      - uses: oven-sh/setup-bun@v2
+
+      # setup-node writes "always-auth=false" into the .npmrc it generates, but
+      # npm 10+ no longer knows that option and prints
+      # `npm warn Unknown user config "always-auth"` on every npm command.
+      - name: Remove deprecated always-auth npm config
+        run: |
+          if [ -n "${NPM_CONFIG_USERCONFIG:-}" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
+            sed -i '/^always-auth[ =]/d' "$NPM_CONFIG_USERCONFIG"
+          fi
+
+      # Some published dependencies ship a `prepare: "husky install"` in their
+      # package.json (fuse.js, among others). When npm reconciles bun's linked
+      # node_modules store it runs that hook, which dies with "husky: not found"
+      # (exit 127) — and npm's --ignore-scripts does NOT suppress it for
+      # bun-linked packages. A no-op `husky` on PATH turns it harmless.
+      - name: Neutralize unused husky hooks
+        run: |
+          mkdir -p "$RUNNER_TEMP/husky-shim"
+          printf '#!/bin/sh\nexit 0\n' > "$RUNNER_TEMP/husky-shim/husky"
+          chmod +x "$RUNNER_TEMP/husky-shim/husky"
+          echo "$RUNNER_TEMP/husky-shim" >> "$GITHUB_PATH"
+
+      # A credential that no longer authorizes writes is the likeliest reason
+      # for this workflow to fail, and it fails *late*: npm answers an
+      # unauthorized PUT with `E404 ... could not be found or you do not have
+      # permission to access it`, which reads like a missing package. Every
+      # package gets built (minutes) before the first one hits it, and each
+      # failed attempt still signs a provenance statement into the public
+      # sigstore transparency log. Check the credential up front instead.
+      #
+      # Two supported credentials, in order of preference:
+      #   1. Trusted publishing (OIDC). No secret: npm >= 11.5.1 trades this
+      #      job's id-token for a short-lived publish token. Nothing to rotate,
+      #      but each package must name this repo + workflow as its trusted
+      #      publisher (npmjs.com/package/<name>/access).
+      #   2. An NPM_TOKEN secret. Granular tokens expire (90 days max); classic
+      #      automation tokens no longer work for direct publishing.
+      # Setting the secret picks (2); leaving it unset picks (1).
+      - name: Verify npm publish credentials
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -uo pipefail
+
+          if [ -n "${NODE_AUTH_TOKEN:-}" ]; then
+            if whoami=$(npm whoami 2>&1); then
+              echo "🔑 Publishing as npm user '$whoami' (NPM_TOKEN)"
+              # Authenticating says nothing about *write* access: a read-only or
+              # differently scoped token gets the same E404 on PUT. Report what
+              # it can write to, without failing — `npm access` is not available
+              # to every token type, and the publish loop reports the truth.
+              if writable=$(npm access list packages --json 2>/dev/null); then
+                echo "$writable" | node -e "
+                  let s = '';
+                  process.stdin.on('data', d => s += d).on('end', () => {
+                    let perms = {};
+                    try { perms = JSON.parse(s) || {}; } catch { return; }
+                    const rw = Object.keys(perms).filter(k => perms[k] === 'read-write');
+                    console.log(rw.length
+                      ? '🔓 Token has write access to ' + rw.length + ' package(s)'
+                      : '::warning title=npm token may be read-only::The NPM_TOKEN secret authenticates but reports no packages with read-write access. Publishes will fail with E404.');
+                  });
+                "
+              fi
+              exit 0
+            fi
+            echo "$whoami"
+            echo "::error title=npm token rejected::The NPM_TOKEN secret no longer authenticates with registry.npmjs.org — it expired, was revoked, or was replaced. Mint a new token with write access at npmjs.com/settings/<user>/tokens and update the NPM_TOKEN repository secret, or remove the secret entirely and configure trusted publishing."
+            exit 1
+          fi
+
+          # No secret: trusted publishing. Make sure npm is new enough and that
+          # nothing left a half-configured empty token in the generated .npmrc,
+          # which would make npm try (and fail) to authenticate with it.
+          npm_version=$(npm --version)
+          if ! node -e "
+            const need = [11, 5, 1];
+            const have = '$npm_version'.split('.').map(Number);
+            for (let i = 0; i < 3; i++) {
+              if ((have[i] || 0) !== need[i]) process.exit((have[i] || 0) > need[i] ? 0 : 1);
+            }
+          "; then
+            echo "⏫ npm $npm_version is older than 11.5.1 — upgrading for trusted publishing (OIDC)"
+            npm install -g npm@latest
+          fi
+
+          if [ -n "${NPM_CONFIG_USERCONFIG:-}" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
+            sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG"
+          fi
+          echo "🔑 No NPM_TOKEN secret — publishing via trusted publishing (OIDC) with npm $(npm --version)"
+
+      # Install the whole workspace once with bun. bun understands the
+      # "workspace:*" protocol and links local packages, so every package gets
+      # its devDependencies and can be built. Plain `npm install` cannot do this
+      # inside a bun workspace — it dies on sibling "workspace:*" deps
+      # (EUNSUPPORTEDPROTOCOL), leaving devDependencies uninstalled and builds
+      # failing with "vite: not found".
+      - name: Install workspace dependencies
+        run: bun install --ignore-scripts
+
+      # Build everything up front, in dependency order, so a package that
+      # imports a sibling through its built `dist` finds real files instead of
+      # `exports` entries pointing at nothing. Turbo derives that order from the
+      # workspace graph, so nothing here needs maintaining by hand.
+      - name: Build all packages
+        run: bunx turbo run build
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Publish non-private packages with new content
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          # GitHub runs `run:` steps with `bash -e -o pipefail`, so omitting
+          # `set -e` does not disable errexit. With it on, the first package
+          # whose publish fails kills the step and every later package goes
+          # unreleased without even being evaluated. Turn it off explicitly;
+          # per-package outcomes travel through $rc, and the run still exits
+          # non-zero at the end if anything failed.
+          set -uo pipefail
+          set +e
+
+          failed_packages=""
+          skipped_builds=""
+          unauthorized_packages=""
+          unattempted_packages=""
+          auth_broken=""
+
+          for dir in packages/*/ apps/*/; do
+            pkg="${dir}package.json"
+            [ -f "$pkg" ] || continue
+
+            is_private=$(node -e "const p=require('./$pkg'); console.log(!!p.private)")
+            name=$(node -e "const p=require('./$pkg'); console.log(p.name || '')")
+
+            if [ "$is_private" = "true" ] || [ -z "$name" ]; then
+              echo "⏭ Skipping $dir (private or unnamed)"
+              continue
+            fi
+
+            # One rejected PUT means the credential cannot write, and every
+            # remaining package would fail the same way — after another build
+            # each, and after signing a provenance statement for a version that
+            # will never exist. Stop attempting them; the run still fails.
+            if [ -n "$auth_broken" ]; then
+              echo "⏭ Skipping $name (npm rejected the publish credential — see above)"
+              unattempted_packages="$unattempted_packages $name"
+              continue
+            fi
+
+            echo "📦 Evaluating $name from $dir"
+
+            # Each package runs in a subshell with its own `set -e`, so a failing
+            # step lands in $rc instead of killing the loop.
+            (
+              set -e
+              cd "$dir"
+
+              # npm keeps the literal "workspace:*" protocol in the tarball,
+              # which consumers cannot resolve. Replace each one with a real
+              # semver range taken from the referenced local package; drop
+              # local packages that are not published. Only the version field
+              # of this edit is committed back, in the final step.
+              node -e "
+                const fs = require('fs');
+                const path = require('path');
+                const localVersions = {};
+                for (const root of ['../../packages', '../../apps']) {
+                  if (!fs.existsSync(root)) continue;
+                  for (const d of fs.readdirSync(root)) {
+                    const sib = path.join(root, d, 'package.json');
+                    if (!fs.existsSync(sib)) continue;
+                    try {
+                      const sp = JSON.parse(fs.readFileSync(sib, 'utf8'));
+                      if (sp.name && sp.version && !sp.private) localVersions[sp.name] = sp.version;
+                    } catch {}
+                  }
+                }
+                const p = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+                for (const s of ['dependencies', 'devDependencies', 'peerDependencies']) {
+                  if (!p[s]) continue;
+                  for (const [k, v] of Object.entries(p[s])) {
+                    if (typeof v !== 'string' || !v.startsWith('workspace:')) continue;
+                    if (localVersions[k]) {
+                      p[s][k] = '^' + localVersions[k];
+                      console.log('Pinned workspace dependency', k, '->', p[s][k]);
+                    } else {
+                      delete p[s][k];
+                      console.log('Removed unresolved workspace dependency:', k);
+                    }
+                  }
+                }
+                fs.writeFileSync('package.json', JSON.stringify(p, null, 2));
+              "
+
+              version=$(node -e "const p=require('./package.json'); console.log(p.version)")
+              latest=$(npm view "$name" version 2>/dev/null || echo "")
+              already=$(npm view "$name@$version" version 2>/dev/null || echo "")
+
+              # If the local version has fallen behind the registry (a bump
+              # commit that never landed back), publishing fails with "Cannot
+              # implicitly apply the latest tag". Sync forward first, then let
+              # the content comparison decide whether to release at all.
+              if [ -z "$already" ] && [ -n "$latest" ]; then
+                behind=$(node -e "
+                  const cmp = (x, y) => { const a = x.split('.').map(Number), b = y.split('.').map(Number); for (let i = 0; i < 3; i++) { if ((a[i]||0) !== (b[i]||0)) return (a[i]||0) - (b[i]||0); } return 0; };
+                  console.log(cmp('$version', '$latest') < 0);
+                ")
+                if [ "$behind" = "true" ]; then
+                  echo "⏫ $name local version $version is behind npm latest $latest — syncing"
+                  npm version "$latest" --no-git-tag-version --no-workspaces
+                  version="$latest"
+                  already="$latest"
+                fi
+              fi
+
+              if [ -n "$already" ]; then
+                # This exact version is on npm. Publish anyway only if the
+                # content changed: npm tarballs are reproducible (normalized
+                # mtimes), so pack integrity is comparable against the registry.
+                local_integrity=$(npm pack --dry-run --ignore-scripts --json 2>/dev/null | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>console.log(JSON.parse(s)[0].integrity))")
+                remote_integrity=$(npm view "$name@$version" dist.integrity 2>/dev/null || echo "")
+
+                if [ "$local_integrity" = "$remote_integrity" ]; then
+                  echo "⏭ $name@$version already on npm with identical content — nothing new to release"
+                  exit 0
+                fi
+
+                next=$(node "$GITHUB_WORKSPACE/.github/scripts/next-free-version.mjs" "$name" "$version")
+                echo "🔼 $name content changed since $version — bumping to $next"
+                # --no-workspaces stops npm doing workspace-aware processing
+                # against bun's symlinks, which would raise EUNSUPPORTEDPROTOCOL.
+                npm version "$next" --no-git-tag-version --no-workspaces
+                version="$next"
+              fi
+
+              # --ignore-scripts: the build already ran, in dependency order.
+              # Exit 43 for an authorization failure so the loop can stop early.
+              #
+              # A version the registry has reserved but does not list is still
+              # possible (a reservation can land between the query above and the
+              # PUT), so E409 "cannot publish over" retries at the next free
+              # version. The attempt cap keeps a registry that rejects
+              # everything from looping forever.
+              log="$RUNNER_TEMP/npm-publish.log"
+              attempt=1
+
+              while :; do
+                echo "Publishing $name@$version"
+                if npm publish --provenance --access public --ignore-scripts 2>&1 | tee "$log"; then
+                  exit 0
+                fi
+
+                if grep -qE "npm error code (E401|E404|ENEEDAUTH|EAUTHUNKNOWN|EOTP)" "$log"; then
+                  exit 43
+                fi
+                if grep -q "npm error code E403" "$log" && ! grep -qi "cannot publish over" "$log"; then
+                  exit 43
+                fi
+                if ! grep -qi "cannot publish over" "$log"; then
+                  exit 1
+                fi
+                if [ "$attempt" -ge 5 ]; then
+                  echo "⚠ npm refused $attempt versions in a row for $name — giving up"
+                  exit 1
+                fi
+
+                next=$(node "$GITHUB_WORKSPACE/.github/scripts/next-free-version.mjs" "$name" "$version")
+                echo "↩ npm has $name@$version reserved — retrying as $next"
+                npm version "$next" --no-git-tag-version --no-workspaces
+                version="$next"
+                attempt=$((attempt + 1))
+              done
+            )
+            rc=$?
+
+            if [ "$rc" = "42" ]; then
+              skipped_builds="$skipped_builds $name"
+            elif [ "$rc" = "43" ]; then
+              unauthorized_packages="$unauthorized_packages $name"
+              auth_broken="1"
+            elif [ "$rc" != "0" ]; then
+              failed_packages="$failed_packages $name"
+            fi
+          done
+
+          if [ -n "$skipped_builds" ]; then
+            echo "::warning::Skipped (build failed, not published):$skipped_builds"
+          fi
+
+          if [ -n "$unattempted_packages" ]; then
+            echo "⏭ Not attempted (the credential was already rejected):$unattempted_packages"
+          fi
+
+          if [ -n "$unauthorized_packages" ]; then
+            echo "❌ Not authorized to publish:$unauthorized_packages"
+            echo "::error title=npm rejected the publish credential::npm answers an unauthorized PUT with E404 ('could not be found or you do not have permission to access it'), so this reads as a missing package — the packages exist, the write was refused. The NPM_TOKEN secret is read-only, scoped to a different set of packages, or expired; or, with trusted publishing, this repo + workflow is not yet named as the trusted publisher for these packages."
+          fi
+
+          if [ -n "$failed_packages" ]; then
+            echo "❌ Failed to publish:$failed_packages"
+          fi
+
+          if [ -n "$failed_packages" ] || [ -n "$unauthorized_packages" ] || [ -n "$unattempted_packages" ]; then
+            exit 1
+          fi
+
+      - name: Commit version bumps
+        if: success()
+        run: |
+          # Version bumps made during publish must land back in the repo so the
+          # next run sees them. Restore the workspace:* pinning done for the
+          # tarballs first — only the "version" field should be committed.
+          node -e "
+            const fs = require('fs');
+            const cp = require('child_process');
+            for (const root of ['packages', 'apps']) {
+              if (!fs.existsSync(root)) continue;
+              for (const d of fs.readdirSync(root)) {
+                const f = root + '/' + d + '/package.json';
+                if (!fs.existsSync(f)) continue;
+                const now = JSON.parse(fs.readFileSync(f, 'utf8'));
+                let raw;
+                try {
+                  raw = cp.execSync('git show HEAD:' + f, { encoding: 'utf8' });
+                } catch { continue; }
+                const orig = JSON.parse(raw);
+                if (orig.version !== now.version) {
+                  // Patch only the version string so the file keeps whatever
+                  // formatting it had. Matching on a literal '\"version\": \"x\"'
+                  // would miss a package.json written without the space after
+                  // the colon, and silently drop the bump while claiming to
+                  // keep it — so match the field, then assert it changed.
+                  const before = raw;
+                  raw = raw.replace(
+                    /(\"version\"\s*:\s*\")[^\"]*(\")/,
+                    (m, open_, close) => open_ + now.version + close
+                  );
+                  if (raw === before) {
+                    console.log('::error title=Version bump lost::Could not rewrite the version field in ' + f + '. ' + now.name + ' was published as ' + now.version + ' but the repo still says ' + orig.version + '.');
+                    process.exitCode = 1;
+                    continue;
+                  }
+                  console.log('Keeping version bump for', now.name, '->', now.version);
+                }
+                fs.writeFileSync(f, raw);
+              }
+            }
+          "
+          git add packages/*/package.json apps/*/package.json 2>/dev/null || true
+          git diff --staged --quiet && echo "No version changes to commit" && exit 0
+          # [skip ci] so the bump commit does not retrigger this workflow.
+          git commit -m "chore: bump published package versions [skip ci]"
+          git push

--- a/starter-templates/template-git-repo/.github/workflows/tests.yml
+++ b/starter-templates/template-git-repo/.github/workflows/tests.yml
@@ -1,0 +1,116 @@
+# Runs every workspace package that has a `test:ci` script and ships the results
+# to Codecov Test Analytics, which tracks run time, failure rate and flakiness
+# per test and comments the failing ones on the pull request.
+#
+# The matrix is discovered at run time rather than hand-maintained: adding a
+# package with a `test:ci` script is all it takes to get it tested here. That
+# script must write, relative to the package directory:
+#
+#   junit.xml         - test results, the input Test Analytics ingests
+#   coverage/lcov.info - coverage, uploaded when the runner can produce it
+#
+# For Vitest that is:
+#   "test:ci": "vitest run --reporter=junit --outputFile=junit.xml --coverage"
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [{{DEFAULT_BRANCH}}]
+  workflow_dispatch:
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Emits the list of packages to test. Kept separate so the test job below can
+  # stay a plain matrix — GitHub cannot compute a matrix inside the job that
+  # uses it.
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.list.outputs.packages }}
+      any: ${{ steps.list.outputs.any }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: list
+        name: Find packages with a test:ci script
+        run: |
+          node --input-type=module -e '
+            import { readdirSync, readFileSync, existsSync, appendFileSync } from "node:fs";
+            const out = [];
+            for (const root of ["packages", "apps"]) {
+              if (!existsSync(root)) continue;
+              for (const dir of readdirSync(root)) {
+                const file = `${root}/${dir}/package.json`;
+                if (!existsSync(file)) continue;
+                let pkg;
+                try { pkg = JSON.parse(readFileSync(file, "utf8")); } catch { continue; }
+                if (!pkg.scripts?.["test:ci"]) continue;
+                out.push({ name: pkg.name ?? dir, dir: `${root}/${dir}` });
+              }
+            }
+            out.sort((a, b) => a.dir.localeCompare(b.dir));
+            appendFileSync(process.env.GITHUB_OUTPUT, `packages=${JSON.stringify(out)}\n`);
+            appendFileSync(process.env.GITHUB_OUTPUT, `any=${out.length > 0}\n`);
+            console.log(out.length ? out.map((p) => p.dir).join("\n") : "No package defines a test:ci script.");
+          '
+
+  test:
+    needs: discover
+    if: needs.discover.outputs.any == 'true'
+    name: ${{ matrix.package.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      # One package's failure must not cancel the others' uploads.
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.discover.outputs.packages) }}
+    steps:
+      # Codecov needs the parent commit to attribute results to the right base.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - uses: oven-sh/setup-bun@v2
+
+      # Postinstall hooks in a workspace tend to need env vars CI does not have
+      # (database URLs, Tauri toolchains, doc generators) and none of them
+      # affect the tests, so they are skipped.
+      - name: Install workspace dependencies
+        run: bun install --ignore-scripts
+
+      # `turbo run` builds this package's workspace dependencies first, so a
+      # package that imports a sibling through its built `dist` output finds it.
+      - name: Run tests
+        run: bunx turbo run test:ci --filter=./${{ matrix.package.dir }}
+
+      # `!cancelled()` so a red suite still reports: without it the upload is
+      # skipped on exactly the runs whose results matter most.
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ matrix.package.dir }}/junit.xml
+          flags: ${{ matrix.package.name }}
+
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ matrix.package.dir }}/coverage/lcov.info
+          flags: ${{ matrix.package.name }}
+          fail_ci_if_error: false
+
+      - name: Upload coverage artifact
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.package.name }}
+          path: ${{ matrix.package.dir }}/coverage/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/starter-templates/template-git-repo/README.md
+++ b/starter-templates/template-git-repo/README.md
@@ -1,0 +1,89 @@
+<p align="center">
+<!-- badge:doi --><a href="https://doi.org/{{DOI}}"><img src="https://zenodo.org/badge/DOI/{{DOI}}.svg" alt="DOI" /></a>
+    <a href="https://deepwiki.com/{{OWNER}}/{{REPO}}"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
+<!-- badge:docs --><a href="{{DOCS_URL}}"><img src="https://img.shields.io/badge/Docs-blue?logo=ReadTheDocs&logoColor=white" alt="Documentation" /></a>
+<!-- badge:api --><a href="{{API_URL}}"><img src="https://img.shields.io/badge/API-blue?logo=fastapi&logoColor=white" alt="API" /></a>
+<!-- badge:youtube --><a href="{{YOUTUBE_URL}}"><img height="20px" src="https://img.shields.io/badge/YouTube-red?style=for-the-badge&logo=youtube&logoColor=white" alt="YouTube" /></a>
+    <a href="https://deploy.workers.cloudflare.com/?url=https://github.com/{{OWNER}}/{{REPO}}"><img height="24px" src="https://deploy.workers.cloudflare.com/button" alt="Deploy to Cloudflare Workers" /></a>
+    <a href="https://github.com/{{OWNER}}/{{REPO}}/stargazers"><img src="https://img.shields.io/github/stars/{{OWNER}}/{{REPO}}" alt="GitHub Stars" /></a>
+<br />
+<!-- badge:npm --><a href="https://www.npmjs.com/package/{{PACKAGE}}"><img src="https://img.shields.io/npm/dm/{{PACKAGE}}.svg" alt="NPM Monthly Downloads" /></a>
+    <a href="https://codecov.io/gh/{{OWNER}}/{{REPO}}"><img src="https://codecov.io/gh/{{OWNER}}/{{REPO}}/graph/badge.svg" alt="Coverage" /></a>
+    <a href="https://github.com/{{OWNER}}/{{REPO}}/graphs/contributors"><img src="https://img.shields.io/github/commit-activity/m/{{OWNER}}/{{REPO}}" alt="Commit Activity" /></a>
+    <a href="https://github.com/{{OWNER}}/{{REPO}}/commits/{{DEFAULT_BRANCH}}/"><img src="https://img.shields.io/github/last-commit/{{OWNER}}/{{REPO}}.svg" alt="Last Commit" /></a>
+    <a href="https://github.com/{{OWNER}}/{{REPO}}/actions/workflows/tests.yml"><img src="https://github.com/{{OWNER}}/{{REPO}}/actions/workflows/tests.yml/badge.svg?branch={{DEFAULT_BRANCH}}" alt="Tests" /></a>
+<br />
+<!-- badge:uptime --><a href="https://stats.uptimerobot.com/{{UPTIME_ID}}"><img src="https://img.shields.io/badge/Uptime-Status-brightgreen?logo=uptimerobot&logoColor=white" alt="Uptime Status" /></a>
+<!-- badge:npm --><a href="https://www.npmjs.com/package/{{PACKAGE}}"><img src="https://img.shields.io/npm/v/{{PACKAGE}}.svg" alt="npm version" /></a>
+<!-- badge:discord --><a href="{{DISCORD_INVITE}}"><img src="https://img.shields.io/discord/{{DISCORD_ID}}.svg?label=Chat&logo=Discord&colorB=7289da&style=flat" alt="Join Discord" /></a>
+    <a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" /></a>
+    <a href="./LICENSE.md"><img src="https://img.shields.io/github/license/{{OWNER}}/{{REPO}}" alt="License" /></a>
+<br />
+    <img src="https://img.shields.io/badge/Claude-D97757?logo=claude&logoColor=fff" alt="Claude AI" />
+    <img src="https://img.shields.io/badge/Cloudflare-F38020?logo=Cloudflare&logoColor=white" alt="Cloudflare" />
+    <img src="https://img.shields.io/badge/Turborepo-EF4444?logo=turborepo&logoColor=white" alt="Turborepo" />
+    <img src="https://img.shields.io/badge/Bun-000000?logo=bun&logoColor=white" alt="Bun" />
+</p>
+
+# {{REPO}}
+
+{{DESCRIPTION}}
+
+```bash
+bun install
+bun run dev
+```
+
+## Layout
+
+```
+packages/          publishable libraries, one directory per package
+apps/              deployable applications, one directory per app
+  test-reports/    the HTML test report deployed to Cloudflare Workers
+.github/workflows/ CI: tests, publishing, auto-merge, report deploys
+turbo.json         the task graph every script above runs through
+codecov.yml        coverage flags and pull-request comment layout
+docs/              how to set up the badges, workflows and secrets
+```
+
+Everything is driven by [Turborepo](https://turborepo.com): `bun run build`,
+`bun run test`, `bun run lint` and `bun run typecheck` at the root fan out to
+every workspace package in dependency order, and cache what has not changed.
+
+| Script | What it does |
+| --- | --- |
+| `bun run build` | `turbo run build` across the workspace, in dependency order |
+| `bun run dev` | every package's watch/dev task, in parallel |
+| `bun run test` | every package's `test` task |
+| `bun run test:ci` | the CI variant: writes `junit.xml` and `coverage/lcov.info` |
+| `bun run test:report` | the whole suite with the HTML reporter, into `apps/test-reports/dist` |
+| `bun run coverage` | every package's coverage task |
+| `bun run lint` / `typecheck` | the corresponding task per package |
+| `bun run clean` | drops build output, `.turbo` and `node_modules` |
+
+Filter to one package with `--filter`:
+
+```bash
+bunx turbo run test --filter=./packages/my-package
+```
+
+## Docs
+
+| Doc | Covers |
+| --- | --- |
+| [docs/BADGES.md](./docs/BADGES.md) | Every badge above: what it needs, where the id comes from, how to verify it |
+| [docs/WORKFLOWS.md](./docs/WORKFLOWS.md) | Every workflow in `.github/workflows`: what it does, what it needs, how it fails |
+| [docs/SECRETS.md](./docs/SECRETS.md) | The repository secrets and settings CI depends on |
+
+## Adding a package
+
+1. `mkdir packages/my-package` with a `package.json` (`"name"`, `"version"`, and
+   a `build`/`test` script as needed).
+2. Give it a `test:ci` script that writes `junit.xml` and `coverage/lcov.info`:
+
+   ```json
+   "test:ci": "vitest run --reporter=junit --outputFile=junit.xml --coverage"
+   ```
+
+3. That is all: `.github/workflows/tests.yml` discovers packages by that script,
+   and `npm-publish.yml` publishes any non-private package whose content changed.

--- a/starter-templates/template-git-repo/apps/test-reports/package.json
+++ b/starter-templates/template-git-repo/apps/test-reports/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "test-reports",
+  "private": true,
+  "version": "0.0.1",
+  "scripts": {
+    "generate": "cd ../.. && VITEST_HTML_REPORT_DIR=apps/test-reports/dist vitest run",
+    "generate:coverage": "cd ../.. && VITEST_HTML_REPORT_DIR=apps/test-reports/dist vitest run --coverage",
+    "preview": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "^4.130.0"
+  }
+}

--- a/starter-templates/template-git-repo/apps/test-reports/wrangler.jsonc
+++ b/starter-templates/template-git-repo/apps/test-reports/wrangler.jsonc
@@ -1,0 +1,10 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "{{REPO}}-test-reports",
+  "compatibility_date": "2026-07-29",
+  "assets": {
+    "directory": "./dist",
+    // Vitest's HTML reporter is a client-routed single page app.
+    "not_found_handling": "single-page-application"
+  }
+}

--- a/starter-templates/template-git-repo/codecov.yml
+++ b/starter-templates/template-git-repo/codecov.yml
@@ -1,0 +1,50 @@
+# Codecov configuration for the packages tested by .github/workflows/tests.yml.
+#
+# Statuses are informational: they annotate a pull request without ever blocking
+# it. Test Analytics — the failed-test comment and the flake dashboard — is the
+# part meant to be acted on.
+
+codecov:
+  # Publish and deploy workflows run on the default branch only, so a pull
+  # request often has no CI for Codecov to wait on before reporting.
+  require_ci_to_pass: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        informational: true
+
+# One flag per package. `carryforward` means a package that skipped a run (its
+# paths were untouched) keeps its last known coverage instead of reading as a
+# drop to zero.
+#
+# Flags are created on first upload, so this block only needs entries when a
+# flag's paths differ from the default. Add one per package as the repo grows:
+#
+#   individual_flags:
+#     - name: my-package
+#       paths:
+#         - packages/my-package/
+flag_management:
+  default_rules:
+    carryforward: true
+
+comment:
+  layout: "header, diff, flags, files"
+  # Don't post on pull requests that changed nothing Codecov measures.
+  require_changes: true
+
+ignore:
+  - "**/test/**"
+  - "**/tests/**"
+  - "**/__tests__/**"
+  - "**/examples/**"
+  - "**/docs/**"
+  - "**/dist/**"
+  - "**/build/**"

--- a/starter-templates/template-git-repo/docs/BADGES.md
+++ b/starter-templates/template-git-repo/docs/BADGES.md
@@ -1,0 +1,271 @@
+# Badges: what each one needs and how to set it up
+
+Every badge in the README falls into one of three groups:
+
+| Group | Setup | Badges |
+| --- | --- | --- |
+| **Zero setup** — works the moment the repo is public | none | Stars, Commit Activity, Last Commit, License, PRs Welcome, Deploy to Cloudflare, DeepWiki, tech-stack chips |
+| **Needs a workflow or service connected** | one repo secret or one app install | Tests status, Coverage, npm version, npm downloads |
+| **Needs an account and an id you paste in** | an external account | DOI, Discord, UptimeRobot, YouTube, Docs, API |
+
+`setup-git-repo` drops the badge lines for group 3 unless you pass the id, so the
+README never ships a badge pointing at `{{DOI}}`. Add them back later by copying
+the snippet from this file.
+
+Almost everything is [Shields.io](https://shields.io), whose URL shape is
+`https://img.shields.io/<type>/<args>.svg?<options>`. Common options: `label=`,
+`color=`/`colorB=`, `logo=` (any [Simple Icons](https://simpleicons.org) slug),
+`logoColor=`, `style=` (`flat`, `flat-square`, `for-the-badge`).
+
+---
+
+## Zero setup
+
+### GitHub Stars
+
+```html
+<a href="https://github.com/OWNER/REPO/stargazers"><img src="https://img.shields.io/github/stars/OWNER/REPO" alt="GitHub Stars" /></a>
+```
+
+Nothing to configure. Works on public repos only — Shields has no token for
+your private repo and renders `invalid` or `repo not found`.
+
+### Commit Activity
+
+```html
+<img src="https://img.shields.io/github/commit-activity/m/OWNER/REPO" alt="Commit Activity" />
+```
+
+`m` is commits per month; `w` and `y` also work. Add `/BRANCH` to scope it:
+`commit-activity/m/OWNER/REPO/main`.
+
+### Last Commit
+
+```html
+<img src="https://img.shields.io/github/last-commit/OWNER/REPO.svg" alt="Last Commit" />
+```
+
+Defaults to the default branch. `?display_timestamp=committer` switches from
+author date to commit date, which is what you usually mean after a rebase.
+
+### License
+
+```html
+<img src="https://img.shields.io/github/license/OWNER/REPO" alt="License" />
+```
+
+Reads GitHub's detected license, which comes from a recognized `LICENSE` file.
+A `LICENSE.md` with a custom or modified text is often detected as `Other` —
+if that bothers you, use a static badge instead:
+`https://img.shields.io/badge/license-MIT-green.svg`.
+
+### PRs Welcome
+
+A static badge; it links to GitHub's "creating a pull request" docs. Point it at
+your own `CONTRIBUTING.md` once you have one.
+
+### Deploy to Cloudflare Workers
+
+```html
+<a href="https://deploy.workers.cloudflare.com/?url=https://github.com/OWNER/REPO"><img src="https://deploy.workers.cloudflare.com/button" alt="Deploy to Cloudflare Workers" /></a>
+```
+
+The button image is hosted by Cloudflare; no account needed to *show* it. For the
+click-through to actually work, the repo must be deployable: a `wrangler.jsonc`
+(or `wrangler.toml`) at the root, or a `workers/` directory Cloudflare can find.
+This template's Worker config lives in `apps/test-reports/`, so either move it,
+add a root config, or point the button at a subdirectory URL.
+
+### Ask DeepWiki
+
+```html
+<a href="https://deepwiki.com/OWNER/REPO"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
+```
+
+DeepWiki indexes public repos automatically. The first visit to the link
+triggers indexing if the repo has not been seen; the badge image itself is
+static, so it renders even before indexing finishes.
+
+### Tech-stack chips
+
+Pure decoration — static Shields badges with a brand color and a Simple Icons
+slug:
+
+```html
+<img src="https://img.shields.io/badge/Turborepo-EF4444?logo=turborepo&logoColor=white" alt="Turborepo" />
+```
+
+Format is `badge/<label>-<hex color>?logo=<slug>`. A slug that isn't in Simple
+Icons renders the label with no icon and no error, so check
+[simpleicons.org](https://simpleicons.org) before assuming a typo elsewhere. A
+literal `-` in the label must be written `--`, and a space `_`.
+
+---
+
+## Needs a workflow or service connected
+
+### Workflow status (Tests)
+
+```html
+<a href="https://github.com/OWNER/REPO/actions/workflows/tests.yml"><img src="https://github.com/OWNER/REPO/actions/workflows/tests.yml/badge.svg?branch=main" alt="Tests" /></a>
+```
+
+Served by GitHub, not Shields. Three things to get right:
+
+- The path segment is the workflow **file name**, not the `name:` inside it.
+  `tests.yml` here; renaming the file breaks the badge silently (it renders
+  "no status").
+- `?branch=` is worth setting. Without it the badge shows the most recent run on
+  *any* branch, so a red feature branch turns your README red.
+- The badge shows `no status` until the workflow has run at least once on that
+  branch. Push to the branch or use "Run workflow" from the Actions tab.
+
+One badge per workflow file: add `npm-publish.yml` or `deploy-test-reports.yml`
+the same way if you want them visible.
+
+### Coverage (Codecov)
+
+```html
+<a href="https://codecov.io/gh/OWNER/REPO"><img src="https://codecov.io/gh/OWNER/REPO/graph/badge.svg" alt="Coverage" /></a>
+```
+
+Setup:
+
+1. Sign in at [codecov.io](https://codecov.io) with GitHub and add the repo.
+2. Copy the **repository upload token** and save it as the `CODECOV_TOKEN`
+   repository secret (Settings → Secrets and variables → Actions → New secret).
+   Public repos on GitHub Actions can often upload tokenless, but rate limits
+   make that unreliable in CI — set the secret.
+3. Push. `tests.yml` uploads `coverage/lcov.info` per package.
+
+Getting the token from Codecov's UI: repo page → Settings → General → Repository
+Upload Token. If the badge stays `unknown`, the upload never arrived — check the
+"Upload coverage to Codecov" step's log, not the badge.
+
+Private repos need the token in the badge URL too; Codecov's repo Settings →
+Badges page shows the exact markdown with the graph token included.
+
+`codecov.yml` in this template sets `carryforward: true` per flag, so a package
+that didn't run in a given PR keeps its last coverage instead of reading as a
+drop to 0%.
+
+### npm version and downloads
+
+```html
+<a href="https://www.npmjs.com/package/PACKAGE"><img src="https://img.shields.io/npm/v/PACKAGE.svg" alt="npm version" /></a>
+<a href="https://www.npmjs.com/package/PACKAGE"><img src="https://img.shields.io/npm/dm/PACKAGE.svg" alt="NPM Monthly Downloads" /></a>
+```
+
+`PACKAGE` is the name in that package's `package.json`, not the repo name. Both
+badges render `invalid` until the package's **first** publish — `npm-publish.yml`
+does that on the first push to the default branch. Scoped packages work with the
+scope included and URL-encoded slash: `npm/v/%40scope%2Fname`.
+
+`dm` is downloads/month; `dw` weekly, `dt` total. In a monorepo, pick the package
+users actually install — or show several, one badge each.
+
+---
+
+## Needs an account and an id you paste in
+
+### DOI (Zenodo)
+
+```html
+<a href="https://doi.org/10.5281/zenodo.NNNNNNN"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.NNNNNNN.svg" alt="DOI" /></a>
+```
+
+A DOI makes the repo citable in academic work. Setup:
+
+1. Sign in to [zenodo.org](https://zenodo.org) with GitHub.
+2. Zenodo → GitHub → flip the repo's switch **on**. This installs a webhook; it
+   only affects releases created *after* the switch.
+3. Create a GitHub Release (a tag alone is not enough — it must be a Release).
+   Zenodo archives the tarball and mints a DOI within a few minutes.
+4. Zenodo shows two DOIs. Use the **concept DOI** ("all versions"), not the
+   version-specific one, so the badge keeps pointing at the newest release.
+
+Pass it to the CLI without the `https://doi.org/` prefix: `--doi 10.5281/zenodo.NNNNNNN`.
+
+### Discord
+
+```html
+<a href="https://discord.gg/INVITE"><img src="https://img.shields.io/discord/SERVER_ID.svg?label=Chat&logo=Discord&colorB=7289da&style=flat" alt="Join Discord" /></a>
+```
+
+Two different values, and mixing them up is the usual failure:
+
+- **Server id** goes in the Shields path (it renders the online count). Get it
+  with Discord → User Settings → Advanced → Developer Mode on, then right-click
+  the server → Copy Server ID.
+- **Invite code** goes in the `href`. Create a *never-expiring* invite —
+  a default invite expires in 7 days and the badge quietly links to a dead page.
+
+The server also needs the **Widget** enabled (Server Settings → Widget → Enable
+Server Widget); without it Shields cannot read the member count and the badge
+reads `invalid`.
+
+### UptimeRobot
+
+```html
+<a href="https://stats.uptimerobot.com/PAGE_ID"><img src="https://img.shields.io/badge/Uptime-Status-brightgreen?logo=uptimerobot&logoColor=white" alt="Uptime Status" /></a>
+```
+
+As written this is a **static** badge — it always says "Status" and links to your
+public status page. Setup: [uptimerobot.com](https://uptimerobot.com) → add a
+monitor for your URL → Status Pages → create one → copy the id out of its URL.
+
+For a badge that reports the *real* number, use a monitor-specific API key
+(Monitor → Settings → API key, the `m` key) with Shields' UptimeRobot endpoints:
+
+```html
+<img src="https://img.shields.io/uptimerobot/ratio/7/MONITOR_API_KEY" alt="Uptime 7d" />
+<img src="https://img.shields.io/uptimerobot/status/MONITOR_API_KEY" alt="Up or down" />
+```
+
+That key is read-only for one monitor, which is why it is safe in a README —
+never paste your account-wide API key there.
+
+### Docs / API / YouTube links
+
+```html
+<a href="https://your.docs"><img src="https://img.shields.io/badge/Docs-blue?logo=ReadTheDocs&logoColor=white" alt="Documentation" /></a>
+<a href="https://your.api/docs"><img src="https://img.shields.io/badge/API-blue?logo=fastapi&logoColor=white" alt="API" /></a>
+<a href="https://youtu.be/VIDEO_ID"><img height="20px" src="https://img.shields.io/badge/YouTube-red?style=for-the-badge&logo=youtube&logoColor=white" alt="YouTube" /></a>
+```
+
+Static badges whose only "setup" is having somewhere to point them. They exist
+to make the top of the README a navigation bar rather than a status board — the
+logo does the work, so keep the label to one word.
+
+Note the YouTube badge is `style=for-the-badge` while its neighbors are flat.
+That is deliberate in the original layout but it renders taller; the `height`
+attribute pulls it back in line. Drop `style=for-the-badge` if you would rather
+they match.
+
+---
+
+## Layout
+
+The block is plain HTML inside `<p align="center">`, not markdown, because
+markdown image syntax cannot center or set a height. Consequences:
+
+- Keep each `<a>` on one line. A newline inside the tag is fine for HTML but
+  makes the block much harder to reorder later.
+- `<br />` between rows is what creates the grouping — GitHub collapses
+  whitespace, so blank lines do nothing.
+- GitHub's markdown renderer strips `style` attributes. Sizing has to come from
+  the `height` attribute or from Shields' own `style=` parameter.
+
+Group by meaning: identity and links on row one, health and freshness on row two,
+community on row three, stack chips last.
+
+## Verifying
+
+Badges are cached by GitHub's image proxy (camo), so a fixed badge can keep
+looking broken for a while. To check the real state, open the badge's `src` URL
+directly in a browser — that bypasses camo. Shields renders its own errors into
+the image (`invalid`, `not found`, `inaccessible`), so the image itself tells you
+which half of the URL is wrong.
+
+To force GitHub to refetch: `curl -X PURGE <the camo URL>` on the rendered image
+address, or simply wait — camo's TTL is minutes, not hours.

--- a/starter-templates/template-git-repo/docs/SECRETS.md
+++ b/starter-templates/template-git-repo/docs/SECRETS.md
@@ -1,0 +1,77 @@
+# Secrets and settings CI depends on
+
+Repository secrets live at **Settings → Secrets and variables → Actions → New
+repository secret**. Names are case-sensitive and must match exactly.
+
+| Secret | Used by | Required? | Where it comes from |
+| --- | --- | --- | --- |
+| `CODECOV_TOKEN` | `tests.yml` | For coverage and Test Analytics | codecov.io → your repo → Settings → General → Repository Upload Token |
+| `NPM_TOKEN` | `npm-publish.yml` | Only if you are not using trusted publishing | npmjs.com → Access Tokens → Generate → **Granular**, write access to the packages |
+| `CLOUDFLARE_API_TOKEN` | `deploy-test-reports.yml` | For the report deploy | dash.cloudflare.com → My Profile → API Tokens → "Edit Cloudflare Workers" template |
+| `CLOUDFLARE_ACCOUNT_ID` | `deploy-test-reports.yml` | For the report deploy | Cloudflare dashboard → Workers & Pages → the id in the right sidebar (or the URL) |
+| `GIT_TOKEN` | both auto-merge workflows | For auto-merge | github.com → Settings → Developer settings → Personal access tokens |
+
+`GITHUB_TOKEN` is provided automatically — never create a secret with that name;
+GitHub rejects it.
+
+## Which workflows you can run without any secrets
+
+`tests.yml` still runs the suites without `CODECOV_TOKEN`; only the two upload
+steps fail, and both are `fail_ci_if_error: false`, so the job stays green while
+you set the token up. Everything else needs its secret to do anything at all.
+
+## GIT_TOKEN scopes
+
+A fine-grained personal access token, scoped to this repository, with:
+
+- **Contents**: Read and write
+- **Pull requests**: Read and write
+
+A classic token needs `repo` (and `workflow` if the merged PRs ever touch
+`.github/workflows`).
+
+**Why not `GITHUB_TOKEN`?** Merges made with `GITHUB_TOKEN` do not trigger
+further workflows — an [intentional loop guard][loop]. With it, a PR merged by
+the auto-merge workflow would never fire `npm-publish.yml` or
+`deploy-test-reports.yml` on the default branch. A PAT is a real user, so its
+pushes trigger workflows normally.
+
+The tradeoff: that token carries whatever access its owner has. Prefer a
+fine-grained token limited to this one repository, and set an expiry you will
+actually notice.
+
+[loop]: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+
+## npm: trusted publishing instead of a token
+
+Preferred, because there is nothing to rotate. Per package, on npmjs.com:
+
+1. Go to `npmjs.com/package/<name>/access`.
+2. Under **Trusted publisher**, add: GitHub Actions, this `owner/repo`, workflow
+   file `npm-publish.yml`.
+3. Leave `NPM_TOKEN` **unset** in the repo. The workflow detects the absence and
+   authenticates via OIDC — that is what `permissions: id-token: write` is for.
+
+A package's *first* publish cannot use trusted publishing (there is no package
+page yet to configure). Publish once by hand — `npm publish --access public` —
+then set the trusted publisher and let CI take over.
+
+## Repository settings, not secrets
+
+| Setting | Where | Needed for |
+| --- | --- | --- |
+| Allow auto-merge | Settings → General → Pull Requests | `gh pr merge --auto` in both auto-merge workflows |
+| Branch protection with ≥1 required check | Settings → Branches | Makes `--auto` actually wait for CI instead of merging immediately |
+| Read and write permissions for Actions | Settings → Actions → General → Workflow permissions | The version-bump commit in `npm-publish.yml` |
+| Allow GitHub Actions to create and approve pull requests | Settings → Actions → General | `gh pr create` in `auto-merge-and-create-prs.yml` |
+
+## Rotation
+
+- `NPM_TOKEN`: granular tokens expire after **90 days maximum**. The workflow's
+  preflight step turns an expired token into a clear error instead of a
+  late `E404`, but it still stops the release. Trusted publishing avoids this
+  entirely.
+- `GIT_TOKEN`: set an expiry and a calendar reminder. An expired PAT makes the
+  auto-merge workflows fail with `gh: Bad credentials`.
+- `CLOUDFLARE_API_TOKEN`: does not expire unless you set a TTL, but scope it to
+  Workers Scripts:Edit on one account rather than using a global API key.

--- a/starter-templates/template-git-repo/docs/WORKFLOWS.md
+++ b/starter-templates/template-git-repo/docs/WORKFLOWS.md
@@ -1,0 +1,205 @@
+# The workflows
+
+Five files in `.github/workflows`, plus one helper script. Each is described
+here by what it does, what it needs, and how it fails — the failure modes are
+the part that costs hours if you meet them cold.
+
+| Workflow | Trigger | Needs |
+| --- | --- | --- |
+| `tests.yml` | PR, push to default branch | `CODECOV_TOKEN` |
+| `npm-publish.yml` | push to default branch | `NPM_TOKEN` *or* trusted publishing |
+| `deploy-test-reports.yml` | push to default branch | `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` |
+| `auto-merge-claude.yml` | PR opened/updated | `GIT_TOKEN`, "Allow auto-merge" |
+| `auto-merge-and-create-prs.yml` | every 12h, manual | `GIT_TOKEN` |
+
+---
+
+## tests.yml
+
+Discovers every workspace package with a `test:ci` script, runs each as its own
+matrix job, and uploads results to Codecov Test Analytics and coverage to
+Codecov.
+
+**Why the matrix is discovered rather than listed.** A hand-maintained matrix
+goes stale the first time someone adds a package and forgets to edit the
+workflow — the package silently has no CI. A `discover` job emits the list as
+JSON; the `test` job consumes it through `fromJSON`. GitHub cannot compute a
+matrix inside the job that uses it, which is why it is two jobs.
+
+**What your package must produce.** Relative to the package directory:
+
+```
+junit.xml            test results — what Test Analytics ingests
+coverage/lcov.info   coverage — uploaded when the runner can produce it
+```
+
+For Vitest:
+
+```json
+"test:ci": "vitest run --reporter=junit --outputFile=junit.xml --coverage"
+```
+
+**Details that matter:**
+
+- `fail-fast: false` — one package's red suite must not cancel the other jobs
+  before they upload. Their results are the ones you need to compare against.
+- `if: ${{ !cancelled() }}` on both upload steps, not `if: success()`. Without
+  it, the upload is skipped on exactly the runs whose results matter most.
+- `bun install --ignore-scripts` — postinstall hooks in a workspace tend to want
+  env vars CI does not have (database URLs, Tauri toolchains, doc generators),
+  and none of them affect tests.
+- Tests run through `bunx turbo run test:ci --filter=...` rather than `cd` +
+  `bun test`, so a package that imports a sibling through its built `dist` gets
+  that sibling built first.
+
+**Failure modes:**
+
+| Symptom | Cause → fix |
+| --- | --- |
+| A package you added never appears as a job | It has no `test:ci` script, or it lives outside `packages/`, `apps/` |
+| `Error: Unable to process file command 'output'` in `discover` | A package name contains a newline or the JSON exceeded the 1MB output cap |
+| Codecov shows the run but no coverage | The runner wrote no `lcov.info` — `--coverage` missing, or a provider that writes nothing on your Node version |
+| Coverage drops to 0% for an untouched package | `carryforward` is off for that flag in `codecov.yml` |
+
+## npm-publish.yml
+
+Publishes every non-private workspace package **whose content changed**, then
+commits the version bumps back.
+
+**The rule it exists to enforce:** nobody has to remember a version number. Each
+package is packed with `npm pack --dry-run --json` and its integrity hash
+compared against `npm view <pkg>@<version> dist.integrity`. npm tarballs are
+reproducible (mtimes are normalized), so identical hashes mean nothing to
+release; a different hash means bump the patch and publish.
+
+**Credentials — two supported paths:**
+
+1. **Trusted publishing (OIDC), preferred.** No secret at all. npm ≥ 11.5.1
+   trades the job's `id-token` for a short-lived publish token. Each package
+   must name this repo + workflow as its trusted publisher at
+   `npmjs.com/package/<name>/access`. Nothing to rotate.
+2. **`NPM_TOKEN` secret.** A granular access token with write access. These
+   expire after at most 90 days; classic automation tokens no longer work for
+   direct publishing.
+
+Setting the secret picks (2); leaving it unset picks (1).
+
+**Why the credential is checked in its own step, before anything is built.** npm
+answers an *unauthorized* PUT with `E404 ... could not be found or you do not
+have permission to access it` — which reads like a missing package, not a
+permissions problem. Without the preflight you pay a full build for every
+package before the first one hits it, and each failed attempt still signs a
+provenance statement into the public sigstore transparency log.
+
+**Details that matter:**
+
+- `set +e` in the publish loop. GitHub runs `run:` steps with `bash -e -o
+  pipefail`, so *not* writing `set -e` does not disable errexit — the first
+  failing package would kill the step and leave every later package unevaluated.
+  Outcomes travel through `$rc`; the step still exits non-zero at the end.
+- Exit 43 means "npm rejected the credential". The loop stops attempting further
+  packages: they would all fail the same way, after another build and another
+  provenance signature each.
+- `workspace:*` dependencies are rewritten to real semver ranges before packing.
+  npm keeps the literal protocol in the tarball, and consumers cannot resolve it.
+  Only the `version` field of that edit is committed back.
+- A local version *behind* the registry is synced forward first, otherwise the
+  publish fails with "Cannot implicitly apply the latest tag".
+- `E409 cannot publish over previously staged version` is retried at the next
+  free version, up to five times. `latest` lags versions an interrupted publish
+  reserved; `.github/scripts/next-free-version.mjs` reads the full version list
+  *and* the release timeline, which is where those numbers appear.
+- The final step rewrites only the `version` field back into each
+  `package.json`, by regex rather than by re-serializing the parsed object, so
+  the file keeps its own formatting. It matches `"version"\s*:\s*"..."` rather
+  than a literal `"version": "x"`, and fails the step if the replace found
+  nothing — a package.json written without the space after the colon would
+  otherwise silently lose the bump while the log claimed to keep it.
+- The bump commit ends in `[skip ci]` so it does not retrigger the workflow.
+- A no-op `husky` is put on PATH. Some published dependencies ship
+  `prepare: "husky install"`; when npm reconciles bun's linked `node_modules` it
+  runs that hook and dies with exit 127 — and `--ignore-scripts` does **not**
+  suppress it for bun-linked packages.
+
+**Failure modes:**
+
+| Symptom | Cause → fix |
+| --- | --- |
+| `E404` on publish for a package that exists | The credential cannot write to it. Read the error annotation the workflow emits |
+| `EUNSUPPORTEDPROTOCOL workspace:*` | An `npm` command ran without `--no-workspaces` against bun's symlinks |
+| `vite: not found` during build | Someone replaced `bun install` with `npm install`; npm cannot install a bun workspace |
+| Versions bump on every run | The build is not reproducible — a timestamp or absolute path is landing in `dist` |
+| Nothing publishes, no errors | Every package is `private: true`, or content genuinely did not change |
+
+## deploy-test-reports.yml
+
+Runs the whole suite with Vitest's HTML reporter and deploys the result to
+Cloudflare Workers, so the report has a permanent URL.
+
+**The two non-obvious parts:**
+
+- `continue-on-error: true` on the test step. A red suite must still publish its
+  report — that report is how you see what went red.
+- The "Ensure a report exists to deploy" step. What a red suite must *not* do is
+  leave `dist` missing: `wrangler deploy` treats an absent `assets.directory` as
+  a hard error, so the run would end on a config error instead of on the test
+  signal. A placeholder page is written instead.
+
+**The reporter gotcha.** Vitest's HTML reporter ignores `outputFile` and writes
+`<outputDir>/index.html` plus a UI bundle, where `outputDir` is a *reporter
+option* defaulting to `.vitest`. A reporter named on the command line
+(`--reporter=html`) is constructed without options and silently keeps that
+default — so the deploy finds nothing. `vitest.config.ts` declares the reporter
+and its destination together, keyed off `VITEST_HTML_REPORT_DIR`; `test:report`
+sets it.
+
+## auto-merge-claude.yml
+
+Enables auto-merge on PRs opened by trusted agents and maintainers.
+
+`gh pr merge --auto` is the safe path: GitHub holds the merge until branch
+protection is satisfied. It works **only** when both are true:
+
+- "Allow auto-merge" is on in Settings → General → Pull Requests, and
+- the base branch has protection with at least one **required** status check.
+
+Without both, GitHub rejects `--auto` and the fallback merges immediately —
+without waiting for CI. That is why the actor allowlist in the `if:` matters,
+and why you should turn on branch protection before turning on this workflow.
+
+It uses `GIT_TOKEN` (a PAT) rather than `GITHUB_TOKEN` deliberately: merges made
+with `GITHUB_TOKEN` do not trigger further workflows, so the publish and deploy
+runs on the default branch would never fire.
+
+Branches named `production`, `prod`, `staging` or `develop` are merged without
+`--delete-branch`.
+
+## auto-merge-and-create-prs.yml
+
+A twice-daily sweep that merges PRs already clean/approved/green, and opens a PR
+for any pushed branch that never got one. Both halves are idempotent, so a
+delayed or duplicated run is harmless — and scheduled workflows **are** delayed,
+sometimes by hours, during periods of high Actions load. Never rely on the exact
+minute.
+
+A *merged* PR counts when checking whether a branch already has one: reopening a
+PR for a branch whose work already landed creates an empty, permanently open PR.
+
+The second step deliberately skips `actions/checkout` — it only needs refs, so
+it fetches them into an empty workspace rather than paying for a full checkout.
+
+---
+
+## Adapting these to another repo
+
+- **Different package manager.** Replace `oven-sh/setup-bun@v2` with
+  `actions/setup-node@v4` and the `bun install --ignore-scripts` /
+  `bunx turbo` lines with `npm ci --ignore-scripts` / `npx turbo`. The publish
+  loop's `--no-workspaces` flags exist for bun's symlinks and are harmless
+  otherwise.
+- **Not a monorepo.** `tests.yml`'s discovery finds nothing; either add a
+  `packages/` layout, or replace the matrix with a single job that runs
+  `npm run test:ci` at the root.
+- **`main` instead of `master`.** Every `branches:` filter in this template is
+  written by `setup-git-repo` from your repo's actual default branch. If you
+  rename the branch later, grep the workflows for the old name.

--- a/starter-templates/template-git-repo/gitignore
+++ b/starter-templates/template-git-repo/gitignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+build/
+.next/
+.turbo/
+coverage/
+junit.xml
+*.tsbuildinfo
+.env
+.env.local
+.DS_Store

--- a/starter-templates/template-git-repo/package.json
+++ b/starter-templates/template-git-repo/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "{{REPO}}",
+  "version": "0.0.0",
+  "private": true,
+  "description": "{{DESCRIPTION}}",
+  "type": "module",
+  "packageManager": "bun@1.3.11",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/{{OWNER}}/{{REPO}}"
+  },
+  "workspaces": [
+    "packages/*",
+    "apps/*"
+  ],
+  "scripts": {
+    "build": "turbo run build",
+    "dev": "turbo run dev",
+    "lint": "turbo run lint",
+    "typecheck": "turbo run typecheck",
+    "test": "turbo run test",
+    "test:ci": "turbo run test:ci",
+    "test:report": "VITEST_HTML_REPORT_DIR=apps/test-reports/dist vitest run",
+    "test:watch": "turbo run test:watch",
+    "coverage": "turbo run coverage",
+    "clean": "turbo run clean && rm -rf .turbo node_modules"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^4.1.0",
+    "turbo": "^2.10.12",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.0"
+  }
+}

--- a/starter-templates/template-git-repo/packages/README.md
+++ b/starter-templates/template-git-repo/packages/README.md
@@ -1,0 +1,1 @@
+Placeholder — publishable libraries live here, one directory per package.

--- a/starter-templates/template-git-repo/turbo.json
+++ b/starter-templates/template-git-repo/turbo.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "ui": "stream",
+  "globalDependencies": ["codecov.yml", "tsconfig.json"],
+  "globalEnv": ["NODE_ENV", "CI"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**", "build/**"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "lint": {
+      "dependsOn": ["^build"]
+    },
+    "typecheck": {
+      "dependsOn": ["^build"],
+      "outputs": ["*.tsbuildinfo"]
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "test:ci": {
+      "dependsOn": ["^build"],
+      "outputs": ["junit.xml", "coverage/**"]
+    },
+    "test:watch": {
+      "cache": false,
+      "persistent": true
+    },
+    "coverage": {
+      "dependsOn": ["^build"],
+      "outputs": ["coverage/**"]
+    },
+    "clean": {
+      "cache": false
+    }
+  }
+}

--- a/starter-templates/template-git-repo/vitest.config.ts
+++ b/starter-templates/template-git-repo/vitest.config.ts
@@ -1,0 +1,54 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Root Vitest project registry.
+ *
+ * Vitest 4 dropped support for `vitest.workspace.ts`; if you still have one it
+ * is silently ignored and a root `vitest run` falls back to globbing every test
+ * file with no per-package settings. Declare projects here instead.
+ *
+ * The globs pick up any workspace package that has its own `vitest.config.*`,
+ * which owns that package's environment, include globs and coverage scope. A
+ * package on a different runner (bun test, jest, pytest) simply has no vitest
+ * config and is left to its own `test:ci` script.
+ */
+
+/**
+ * Vitest's HTML reporter ignores `outputFile` and writes `<outputDir>/index.html`
+ * plus its UI bundle, where `outputDir` is a *reporter option* defaulting to
+ * `.vitest`. A reporter named on the command line (`--reporter=html`) is
+ * constructed without options and silently keeps that default — which is how a
+ * deploy step comes to find `apps/test-reports/dist` missing. So the reporter
+ * and its destination both have to be declared here.
+ *
+ * The report stays opt-in so a plain `vitest run` does not pay for copying the
+ * UI bundle; `test:report` sets this to the directory Wrangler deploys.
+ */
+const htmlReportDir = process.env.VITEST_HTML_REPORT_DIR;
+
+export default defineConfig({
+  test: {
+    reporters: htmlReportDir
+      ? ['default', ['html', { outputDir: htmlReportDir }]]
+      : ['default'],
+    projects: ['packages/*', 'apps/*'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html', 'lcov'],
+      reportsDirectory: './coverage',
+      exclude: [
+        '**/node_modules/**',
+        '**/dist/**',
+        '**/build/**',
+        '**/.next/**',
+        '**/.output/**',
+        '**/coverage/**',
+        '**/test/**',
+        '**/tests/**',
+        '**/__tests__/**',
+        '**/*.config.*',
+        '**/*.d.ts',
+      ],
+    },
+  },
+});


### PR DESCRIPTION
Packages the GitHub Actions and README badge setup from `qwksearch-research-agent` into something a new repo can get in one command.

```bash
bunx setup-git-repo
```

## `starter-templates/template-git-repo/`

Turborepo task graph (`turbo.json`, root scripts, a glob-based Vitest project registry), `codecov.yml`, the badge block, and five workflows:

| Workflow | What it does |
| --- | --- |
| `tests.yml` | Discovers packages by their `test:ci` script and runs each as a matrix job → Codecov Test Analytics |
| `npm-publish.yml` | Publishes packages whose *content* changed, decided by pack-integrity comparison against the registry |
| `deploy-test-reports.yml` | Vitest HTML report → Cloudflare Workers |
| `auto-merge-claude.yml` | Auto-merge for agent and maintainer PRs |
| `auto-merge-and-create-prs.yml` | Twice-daily sweep: merge clean+green PRs, open PRs for orphan branches |

Two changes from the originals worth calling out:

- **The test matrix is discovered, not listed.** A `discover` job emits the package list as JSON and the `test` job consumes it through `fromJSON`. A hand-maintained matrix goes stale the first time someone adds a package and forgets, and that package silently has no CI.
- **Build ordering comes from Turborepo** rather than a repo-specific `workspace-build-order.mjs`, since the template ships turbo anyway.

Everything else carries over intact, including the parts that look wrong and are not: `set +e` in the publish loop (GitHub runs `run:` with `bash -e`, so omitting `set -e` does not disable errexit), the credential preflight before any build (npm answers an unauthorized PUT with `E404`, and each late failure signs a provenance statement into the public sigstore log), the no-op husky shim, the `E409` retry via `next-free-version.mjs`, and the placeholder page that keeps `wrangler deploy` from failing on a missing `assets.directory` when the suite is red.

`docs/BADGES.md`, `docs/WORKFLOWS.md` and `docs/SECRETS.md` ship with the template and explain every badge, workflow and secret — where each id comes from, and how each one fails.

## `packages/setup-git-repo/`

One command that applies the template to a repo. Owner, name and default branch come from `git remote get-url origin`; optional badges are prompted for and **their lines dropped when unset**, so the README never ships a badge pointing at a literal `{{DOI}}`. Existing files are left alone without `--force`, so it is safe on a repo that already has some of this. `--workflows-only` / `--badges-only` / `--docs-only` / `--turbo-only` narrow the run; `--dry-run` prints the plan.

The template is bundled into the package at `prepack` time and checked before the monorepo path — a CLI that only climbs out of its own package works in the repo and breaks the moment it is installed from npm, which is the trap `create-starter-app` currently falls into. Its `.gitignore` is stored undotted because npm strips `.gitignore` from published tarballs.

32 tests, 95% statement coverage on `src/`. Wired into `codecov.yml` and both existing test workflows.

## Skills

- `skills/ask-github-actions-setup` — the five workflows: what each needs, the secrets and repo settings, the things in the YAML that look wrong but are not, and a symptom/cause/fix table (`E404` on a package that exists, `husky: not found`, `EUNSUPPORTEDPROTOCOL`, `--auto` merging without waiting for CI, …).
- `skills/ask-git-badges` + `API.md` — the Shields grammar, the four badges that bite, the centered-HTML layout constraints, and a per-badge catalog.

## Bug fixed along the way

The publish workflow's version-restore step matched a literal `'"version": "' + v + '"'`. A `package.json` written without the space after the colon silently lost its bump **while logging that it kept it**, leaving the registry ahead of the repo. It now matches the field with a regex and fails the step if the rewrite found nothing. Verified against both formats.

## Verification

- 32 unit tests pass; `bunx turbo run coverage --filter=./packages/setup-git-repo` green through the repo's own task graph; `test:ci` writes `junit.xml` and `coverage/lcov.info` as `tests.yml` expects.
- All five template workflows parse as YAML, and every `run:` block passes `bash -n`.
- The two non-trivial inline Node snippets in `npm-publish.yml` (the `workspace:*` rewrite and the version restore) were extracted and run against fixtures.
- The `discover` job's script was run against a fixture workspace and emitted the right matrix.
- End-to-end: the CLI run against a fresh `git init` with an `origin` remote produced 18 files with zero leftover placeholders, correct owner/branch substitution in the badges and workflow filters, and correct badge pruning when values are omitted.

Not verified: the workflows have not run on GitHub — they are template files and only execute once a repo adopts them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7Yr7Q3hetDz2yQpsELS9y

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7Yr7Q3hetDz2yQpsELS9y)_