### PR TITLE
🧪 test(template-git-repo): extract the workflows' inline node into te…

### DIFF
--- a/packages/setup-git-repo/package.json
+++ b/packages/setup-git-repo/package.json
@@ -43,6 +43,7 @@
   "homepage": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/setup-git-repo",
   "devDependencies": {
     "@vitest/coverage-v8": "^4.1.0",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.0",
+    "yaml": "^2.9.0"
   }
 }

--- a/packages/setup-git-repo/test/template-integrity.test.mjs
+++ b/packages/setup-git-repo/test/template-integrity.test.mjs
@@ -1,0 +1,165 @@
+/**
+ * The template and the CLI that applies it are coupled in ways nothing else
+ * checks: the CLI drops a badge line by matching a marker name against
+ * OPTIONAL_BADGES, and substitutes `{{PLACEHOLDER}}` tokens it knows by name.
+ * A badge added to the template README with a marker the CLI does not know
+ * ships to a user's repo as a broken image pointing at a literal `{{DOI}}` —
+ * and nothing fails until someone looks at the rendered README.
+ *
+ * These are the invariants that keep the two halves honest.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse } from "yaml";
+import { describe, expect, it } from "vitest";
+import { OPTIONAL_BADGES } from "../src/template.mjs";
+
+const TEMPLATE = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "starter-templates", "template-git-repo");
+
+const readmeText = readFileSync(join(TEMPLATE, "README.md"), "utf8");
+const badgeDocs = readFileSync(join(TEMPLATE, "docs", "BADGES.md"), "utf8");
+
+/** Badge marker names actually present in the template README. */
+const markers = [...readmeText.matchAll(/<!--\s*badge:([a-z0-9-]+)\s*-->/gi)].map((m) => m[1].toLowerCase());
+
+/** Placeholders the CLI knows how to fill, from its flag table. */
+const KNOWN_PLACEHOLDERS = new Set([
+  "OWNER",
+  "REPO",
+  "DEFAULT_BRANCH",
+  "DESCRIPTION",
+  "PACKAGE",
+  "DOI",
+  "DOCS_URL",
+  "API_URL",
+  "YOUTUBE_URL",
+  "UPTIME_ID",
+  "DISCORD_ID",
+  "DISCORD_INVITE",
+  "PACKAGE_MANAGER",
+]);
+
+describe("badge markers", () => {
+  it("every marker in the README is one the CLI knows how to drop", () => {
+    for (const name of markers) {
+      expect(OPTIONAL_BADGES, `<!-- badge:${name} --> has no OPTIONAL_BADGES entry`).toHaveProperty(name);
+    }
+  });
+
+  it("every OPTIONAL_BADGES entry has a marker to act on", () => {
+    for (const name of Object.keys(OPTIONAL_BADGES)) {
+      expect(markers, `OPTIONAL_BADGES.${name} matches no marker in the README`).toContain(name);
+    }
+  });
+
+  it("every badge is documented in BADGES.md", () => {
+    for (const name of markers) {
+      expect(badgeDocs.toLowerCase(), `badge "${name}" is not mentioned in docs/BADGES.md`).toContain(name);
+    }
+  });
+
+  it("each optional badge's line carries the placeholders that badge needs", () => {
+    // Otherwise the badge survives the drop and renders a literal {{DOI}}.
+    for (const [name, placeholders] of Object.entries(OPTIONAL_BADGES)) {
+      const line = readmeText.split("\n").find((l) => new RegExp(`<!--\\s*badge:${name}\\s*-->`, "i").test(l));
+      expect(line, `no README line for badge ${name}`).toBeTruthy();
+
+      for (const placeholder of placeholders) {
+        expect(line, `badge ${name} does not use {{${placeholder}}}`).toContain(`{{${placeholder}}}`);
+      }
+    }
+  });
+});
+
+describe("placeholders", () => {
+  /** Every `{{TOKEN}}` used anywhere in the template tree. */
+  function templateFiles(dir) {
+    const files = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === "node_modules") continue;
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) files.push(...templateFiles(full));
+      else files.push(full);
+    }
+    return files;
+  }
+
+  it("the template only uses placeholders the CLI can fill", () => {
+    for (const file of templateFiles(TEMPLATE)) {
+      const text = readFileSync(file, "utf8");
+      for (const [, token] of text.matchAll(/\{\{([A-Z_]+)\}\}/g)) {
+        expect(KNOWN_PLACEHOLDERS, `${file} uses {{${token}}}, which the CLI never fills`).toContain(token);
+      }
+    }
+  });
+});
+
+describe("workflows", () => {
+  const workflowsDir = join(TEMPLATE, ".github", "workflows");
+  const workflows = readdirSync(workflowsDir).filter((f) => f.endsWith(".yml"));
+
+  /** Substituted the way the CLI would, so `branches: [{{...}}]` parses. */
+  function load(file) {
+    let text = readFileSync(join(workflowsDir, file), "utf8");
+    for (const token of KNOWN_PLACEHOLDERS) text = text.replaceAll(`{{${token}}}`, "main");
+    return parse(text);
+  }
+
+  it("there is at least one workflow to check", () => {
+    expect(workflows.length).toBeGreaterThan(0);
+  });
+
+  it.each(workflows)("%s is valid YAML once substituted", (file) => {
+    // Shipping a workflow GitHub cannot parse is the failure this package must
+    // never have: it lands in someone's repo and fails there.
+    expect(() => load(file)).not.toThrow();
+  });
+
+  it.each(workflows)("%s has a name, a trigger and at least one job", (file) => {
+    const workflow = load(file);
+
+    expect(workflow.name).toBeTruthy();
+    // `on:` is YAML 1.1's boolean true, which is why this reads oddly.
+    expect(workflow.on ?? workflow[true]).toBeTruthy();
+    expect(Object.keys(workflow.jobs ?? {}).length).toBeGreaterThan(0);
+  });
+
+  it.each(workflows)("%s pins every action to a version", (file) => {
+    for (const [job, definition] of Object.entries(load(file).jobs)) {
+      expect(definition["runs-on"], `${file}:${job}`).toBeTruthy();
+
+      for (const step of definition.steps ?? []) {
+        // A floating `uses: actions/checkout` follows the default branch of
+        // someone else's repository into your CI.
+        if (step.uses) expect(step.uses, `${file}:${job}`).toMatch(/@v?\d/);
+      }
+    }
+  });
+
+  it("every .github/scripts file a workflow calls exists", () => {
+    const shipped = new Set(readdirSync(join(TEMPLATE, ".github", "scripts")));
+    const referenced = new Set();
+
+    for (const file of workflows) {
+      const text = readFileSync(join(workflowsDir, file), "utf8");
+      for (const [, script] of text.matchAll(/\.github\/scripts\/([\w-]+\.mjs)/g)) referenced.add(script);
+    }
+
+    expect(referenced.size).toBeGreaterThan(0);
+    for (const script of referenced) {
+      expect(shipped, `a workflow calls ${script}, which is not shipped`).toContain(script);
+    }
+  });
+
+  it("guards the workflows that push or deploy with a concurrency group", () => {
+    // Two publish runs racing is how a half-staged version gets reserved.
+    for (const file of ["npm-publish.yml", "deploy-test-reports.yml"]) {
+      expect(load(file).concurrency?.group, file).toBeTruthy();
+    }
+  });
+
+  it("never lets one matrix entry cancel the others", () => {
+    expect(load("tests.yml").jobs.test.strategy["fail-fast"]).toBe(false);
+  });
+});

--- a/packages/setup-git-repo/test/template-scripts.test.mjs
+++ b/packages/setup-git-repo/test/template-scripts.test.mjs
@@ -1,0 +1,267 @@
+/**
+ * The template's `.github/scripts/*.mjs` run in a *consumer's* CI, with no
+ * install step behind them and nobody watching. A bug there surfaces as a
+ * failed workflow in someone else's repo, which is why they were pulled out of
+ * the inline `node -e` heredocs they used to be and are tested here.
+ */
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { testPackages, workspaceDirectories, formatOutput } from "../../../starter-templates/template-git-repo/.github/scripts/list-test-packages.mjs";
+import { localDependencyGraph, readWorkspacePackages, workspaceBuildOrder } from "../../../starter-templates/template-git-repo/.github/scripts/workspace-build-order.mjs";
+import { pinWorkspaceDeps, readSiblings } from "../../../starter-templates/template-git-repo/.github/scripts/pin-workspace-deps.mjs";
+import { patchVersion, restore } from "../../../starter-templates/template-git-repo/.github/scripts/restore-pinned-deps.mjs";
+
+const scratchDirectories = [];
+
+function scratch() {
+  const dir = mkdtempSync(join(tmpdir(), "tgr-scripts-"));
+  scratchDirectories.push(dir);
+  return dir;
+}
+
+/** Write `<root>/<dir>/package.json`. */
+function writePackage(root, dir, manifest) {
+  mkdirSync(join(root, dir), { recursive: true });
+  writeFileSync(join(root, dir, "package.json"), JSON.stringify(manifest, null, 2));
+}
+
+afterEach(() => {
+  while (scratchDirectories.length > 0) {
+    rmSync(scratchDirectories.pop(), { recursive: true, force: true });
+  }
+});
+
+describe("list-test-packages", () => {
+  it("reads the workspaces globs rather than assuming packages/ and apps/", () => {
+    // The inline version this replaced hardcoded ["packages", "apps"], so a
+    // repo laid out as libs/* got an empty matrix and no error.
+    const root = scratch();
+    writeFileSync(join(root, "package.json"), JSON.stringify({ workspaces: ["libs/*"] }));
+    writePackage(root, "libs/core", { name: "core", scripts: { "test:ci": "vitest run" } });
+
+    expect(testPackages(root)).toEqual([
+      { name: "core", dir: "libs/core", flag: "core", script: "test:ci" },
+    ]);
+  });
+
+  it("accepts the object form of workspaces", () => {
+    const root = scratch();
+    writeFileSync(join(root, "package.json"), JSON.stringify({ workspaces: { packages: ["mods/*"] } }));
+    writePackage(root, "mods/a", { name: "a" });
+
+    expect(workspaceDirectories(root)).toEqual(["mods/a"]);
+  });
+
+  it("falls back to packages/ and apps/ when there is no workspaces field", () => {
+    const root = scratch();
+    writeFileSync(join(root, "package.json"), JSON.stringify({ name: "solo" }));
+    writePackage(root, "packages/a", { name: "a" });
+    writePackage(root, "apps/web", { name: "web" });
+
+    expect(workspaceDirectories(root)).toEqual(["apps/web", "packages/a"]);
+  });
+
+  it("prefers test:ci, and still picks up a package that only has test", () => {
+    const root = scratch();
+    writeFileSync(join(root, "package.json"), JSON.stringify({ workspaces: ["packages/*"] }));
+    writePackage(root, "packages/full", { name: "full", scripts: { test: "x", "test:ci": "y" } });
+    writePackage(root, "packages/plain", { name: "plain", scripts: { test: "x" } });
+    writePackage(root, "packages/none", { name: "none" });
+
+    expect(testPackages(root).map((p) => [p.name, p.script])).toEqual([
+      ["full", "test:ci"],
+      ["plain", "test"],
+    ]);
+  });
+
+  it("skips a package whose manifest is unreadable instead of dying", () => {
+    const root = scratch();
+    writeFileSync(join(root, "package.json"), JSON.stringify({ workspaces: ["packages/*"] }));
+    mkdirSync(join(root, "packages", "broken"), { recursive: true });
+    writeFileSync(join(root, "packages", "broken", "package.json"), "{ not json");
+
+    expect(testPackages(root)).toEqual([]);
+  });
+
+  it("flags an empty matrix, which GitHub would otherwise fail the job over", () => {
+    expect(formatOutput([])).toBe("packages=[]\nany=false\n");
+    expect(formatOutput([{ name: "a" }])).toContain("any=true");
+  });
+});
+
+describe("workspace-build-order", () => {
+  it("puts a package after every sibling it depends on", () => {
+    const root = scratch();
+    mkdirSync(join(root, "packages"), { recursive: true });
+    writePackage(root, "packages/ui", { name: "ui", dependencies: { core: "workspace:*" } });
+    writePackage(root, "packages/core", { name: "core" });
+
+    const order = workspaceBuildOrder([join(root, "packages")]);
+
+    expect(order.findIndex((d) => d.endsWith("core/"))).toBeLessThan(
+      order.findIndex((d) => d.endsWith("ui/")),
+    );
+  });
+
+  it("treats a plain semver range on a sibling as a local edge too", () => {
+    // A workspace sibling is linked whenever the *name* matches, so "^1.2.3"
+    // resolves to the local copy exactly as "workspace:*" does.
+    const root = scratch();
+    mkdirSync(join(root, "packages"), { recursive: true });
+    writePackage(root, "packages/ui", { name: "ui", dependencies: { core: "^1.2.3" } });
+    writePackage(root, "packages/core", { name: "core", version: "1.2.3" });
+
+    const packages = readWorkspacePackages([join(root, "packages")]);
+    const graph = localDependencyGraph(packages);
+
+    expect([...graph.get(`${join(root, "packages")}/ui`)]).toContain(`${join(root, "packages")}/core`);
+  });
+
+  it("spans several roots", () => {
+    const root = scratch();
+    writePackage(root, "packages/core", { name: "core" });
+    writePackage(root, "apps/web", { name: "web", dependencies: { core: "workspace:*" } });
+
+    const order = workspaceBuildOrder([join(root, "packages"), join(root, "apps")]);
+
+    expect(order).toHaveLength(2);
+    expect(order[0]).toContain("core");
+  });
+
+  it("still returns every package when there is a cycle", () => {
+    const root = scratch();
+    mkdirSync(join(root, "packages"), { recursive: true });
+    writePackage(root, "packages/a", { name: "a", dependencies: { b: "workspace:*" } });
+    writePackage(root, "packages/b", { name: "b", dependencies: { a: "workspace:*" } });
+
+    expect(workspaceBuildOrder([join(root, "packages")])).toHaveLength(2);
+  });
+
+  it("ignores a directory with no package.json", () => {
+    const root = scratch();
+    mkdirSync(join(root, "packages", "not-a-package"), { recursive: true });
+
+    expect(workspaceBuildOrder([join(root, "packages")])).toEqual([]);
+  });
+});
+
+describe("pin-workspace-deps", () => {
+  const siblings = new Map([
+    ["core", { version: "1.2.3", private: false }],
+    ["internal", { version: "0.0.1", private: true }],
+  ]);
+
+  it("replaces workspace:* with a real range and leaves registry deps alone", () => {
+    const pkg = { dependencies: { core: "workspace:*", lodash: "^4.0.0" } };
+
+    pinWorkspaceDeps(pkg, siblings);
+
+    expect(pkg.dependencies).toEqual({ core: "^1.2.3", lodash: "^4.0.0" });
+  });
+
+  it("drops a dependency on a private sibling, which is never published", () => {
+    const pkg = { dependencies: { internal: "workspace:*" } };
+    pinWorkspaceDeps(pkg, siblings);
+    expect(pkg.dependencies.internal).toBeUndefined();
+  });
+
+  it("drops a dependency on a package that is not in the workspace at all", () => {
+    const pkg = { dependencies: { ghost: "workspace:*" } };
+    pinWorkspaceDeps(pkg, siblings);
+    expect(pkg.dependencies.ghost).toBeUndefined();
+  });
+
+  it("keeps an explicit range the author wrote", () => {
+    // workspace:^1.0.0 means "^1.0.0"; overwriting it with the sibling's
+    // current version silently narrows what consumers can install.
+    const pkg = { dependencies: { core: "workspace:^1.0.0" }, peerDependencies: { core: "workspace:1.0.0" } };
+
+    pinWorkspaceDeps(pkg, siblings);
+
+    expect(pkg.dependencies.core).toBe("^1.0.0");
+    expect(pkg.peerDependencies.core).toBe("1.0.0");
+  });
+
+  it("covers optionalDependencies as well", () => {
+    const pkg = { optionalDependencies: { core: "workspace:*" } };
+    pinWorkspaceDeps(pkg, siblings);
+    expect(pkg.optionalDependencies.core).toBe("^1.2.3");
+  });
+
+  it("reads sibling versions and privacy off disk, across roots", () => {
+    const root = scratch();
+    writePackage(root, "packages/core", { name: "core", version: "2.0.0" });
+    writePackage(root, "apps/web", { name: "web", version: "1.0.0", private: true });
+
+    const found = readSiblings([join(root, "packages"), join(root, "apps")]);
+
+    expect(found.get("core")).toEqual({ version: "2.0.0", private: false });
+    expect(found.get("web")).toEqual({ version: "1.0.0", private: true });
+  });
+});
+
+describe("restore-pinned-deps", () => {
+  it("rewrites the version whatever spacing the manifest uses", () => {
+    // The inline version this replaced matched a literal '"version": "x"', so
+    // a manifest without the space silently lost its bump.
+    expect(patchVersion('{"version":"1.0.0"}', "1.0.0", "1.0.1")).toBe('{"version":"1.0.1"}');
+    expect(patchVersion('{\n\t"version" : "1.0.0"\n}', "1.0.0", "1.0.1")).toContain('"1.0.1"');
+  });
+
+  it("keeps the file's original formatting", () => {
+    const committed = '{\n    "name": "x",\n    "version": "1.0.0"\n}\n';
+    expect(patchVersion(committed, "1.0.0", "1.0.1")).toBe('{\n    "name": "x",\n    "version": "1.0.1"\n}\n');
+  });
+
+  it("throws rather than silently doing nothing when the field is not found", () => {
+    expect(() => patchVersion('{"name":"x"}', "1.0.0", "1.0.1")).toThrow(/could not find/);
+  });
+
+  it("restores the pinned deps but keeps the bump", () => {
+    const root = scratch();
+    const committed = JSON.stringify({ name: "a", version: "1.0.0", dependencies: { core: "workspace:*" } }, null, 2);
+    writePackage(root, "pkgs/a", { name: "a", version: "1.0.1", dependencies: { core: "^2.0.0" } });
+
+    const { messages, failures } = restore([join(root, "pkgs")], () => committed);
+
+    const result = JSON.parse(readFileSync(join(root, "pkgs", "a", "package.json"), "utf8"));
+    expect(result.version).toBe("1.0.1");
+    expect(result.dependencies.core).toBe("workspace:*");
+    expect(messages).toEqual(["Keeping version bump for a -> 1.0.1"]);
+    expect(failures).toEqual([]);
+  });
+
+  it("reports a lost bump instead of aborting the rest of the workspace", () => {
+    // Losing the bump silently means the next run republishes the same content
+    // forever, so this has to be loud — but one bad file must not leave every
+    // later package still carrying its pinned dependencies.
+    const root = scratch();
+    writePackage(root, "pkgs/broken", { name: "broken", version: "2.0.0" });
+    writePackage(root, "pkgs/fine", { name: "fine", version: "1.0.1", dependencies: { core: "^2.0.0" } });
+
+    const { failures } = restore([join(root, "pkgs")], (file) =>
+      file.includes("broken")
+        ? '{"name":"broken"}'
+        : JSON.stringify({ name: "fine", version: "1.0.0", dependencies: { core: "workspace:*" } }, null, 2),
+    );
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toContain("Version bump lost");
+    // The healthy package was still restored.
+    const fine = JSON.parse(readFileSync(join(root, "pkgs", "fine", "package.json"), "utf8"));
+    expect(fine.dependencies.core).toBe("workspace:*");
+  });
+
+  it("leaves an untracked package alone", () => {
+    const root = scratch();
+    writePackage(root, "pkgs/new", { name: "new", version: "0.1.0" });
+
+    restore([join(root, "pkgs")], () => {
+      throw new Error("fatal: path does not exist in HEAD");
+    });
+
+    expect(JSON.parse(readFileSync(join(root, "pkgs", "new", "package.json"), "utf8")).version).toBe("0.1.0");
+  });
+});

--- a/skills/ask-github-actions-setup/SKILL.md
+++ b/skills/ask-github-actions-setup/SKILL.md
@@ -69,8 +69,13 @@ that uses it. A hand-maintained matrix is the thing this replaces: it goes stale
 the first time someone adds a package and forgets, and that package silently has
 no CI.
 
-**Publishing** — nothing to edit either. `npm-publish.yml` walks
-`packages/*` and `apps/*`, skips `private: true`, and decides per package by
+`.github/scripts/list-test-packages.mjs` does the finding, off the root
+package.json `workspaces` globs — so `libs/*` works without editing the
+workflow. `test:ci` is preferred, then `test:coverage`, then `test`.
+
+**Publishing** — nothing to edit either. `npm-publish.yml` walks the workspace
+in dependency order (`.github/scripts/workspace-build-order.mjs`), skips
+`private: true`, and decides per package by
 comparing `npm pack --dry-run --json` integrity against
 `npm view <pkg>@<version> dist.integrity`. npm tarballs are reproducible, so
 identical hashes mean nothing to release; a different hash means bump the patch

--- a/starter-templates/template-git-repo/.github/scripts/list-test-packages.mjs
+++ b/starter-templates/template-git-repo/.github/scripts/list-test-packages.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * Emit the test matrix for `.github/workflows/tests.yml`.
+ *
+ * This was an inline `node --input-type=module -e '...'` in the workflow. Moved
+ * out for two reasons: an inline heredoc cannot be unit tested, and the inline
+ * version hardcoded `["packages", "apps"]` as the places to look. A repo whose
+ * workspaces are `libs/*` got an empty matrix and no error — the failure mode
+ * of the hand-maintained matrix this was meant to replace.
+ *
+ * The workspace globs from the root package.json are the source of truth now.
+ *
+ *   node .github/scripts/list-test-packages.mjs [rootDir]
+ *
+ * Writes `packages=<json>` and `any=<bool>` to $GITHUB_OUTPUT (or stdout when
+ * that is unset, which is what the tests read).
+ */
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { basename, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+/** The script a package must define to be picked up, best first. */
+const TEST_SCRIPTS = ["test:ci", "test:coverage", "test"];
+
+/** Read and parse a JSON file, treating any failure as absent. */
+function readJson(file) {
+  try {
+    return JSON.parse(readFileSync(file, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Expand the root package.json `workspaces` field into directories.
+ *
+ * Only a trailing `/*` is expanded — anything cleverer would need a glob
+ * dependency in a script that runs before `install`. Both the array and the
+ * `{ packages: [] }` object forms are accepted, because npm and bun both do.
+ *
+ * Falls back to `packages` and `apps` so a repo with no workspaces field
+ * behaves as it did before this script existed.
+ *
+ * @param {string} [root]
+ * @returns {string[]} directories relative to the repo root
+ */
+export function workspaceDirectories(root = ".") {
+  const manifest = readJson(join(root, "package.json"));
+  const globs = Array.isArray(manifest?.workspaces)
+    ? manifest.workspaces
+    : (manifest?.workspaces?.packages ?? ["packages/*", "apps/*"]);
+
+  const directories = [];
+
+  for (const glob of globs) {
+    if (!glob.endsWith("/*")) {
+      if (existsSync(join(root, glob))) directories.push(glob);
+      continue;
+    }
+
+    const parent = glob.slice(0, -2);
+    if (!existsSync(join(root, parent))) continue;
+
+    for (const entry of readdirSync(join(root, parent), { withFileTypes: true })) {
+      if (entry.isDirectory()) directories.push(`${parent}/${entry.name}`);
+    }
+  }
+
+  return directories.sort();
+}
+
+/**
+ * Every workspace package that declares a test script.
+ *
+ * @param {string} [root]
+ * @returns {{ name: string, dir: string, flag: string, script: string }[]}
+ */
+export function testPackages(root = ".") {
+  const found = [];
+
+  for (const dir of workspaceDirectories(root)) {
+    const pkg = readJson(join(root, dir, "package.json"));
+    if (!pkg) continue;
+
+    const script = TEST_SCRIPTS.find((candidate) => pkg.scripts?.[candidate]);
+    if (!script) continue;
+
+    found.push({
+      name: pkg.name ?? basename(dir),
+      dir,
+      // The Codecov flag is the directory name, which is what someone reading
+      // the Codecov dashboard is looking for.
+      flag: basename(dir),
+      script,
+    });
+  }
+
+  return found;
+}
+
+/**
+ * @param {ReturnType<typeof testPackages>} packages
+ * @returns {string} the $GITHUB_OUTPUT lines
+ */
+export function formatOutput(packages) {
+  // `any` exists because GitHub fails a job whose matrix is empty, which would
+  // make a repo with no suites look broken rather than untested.
+  return `packages=${JSON.stringify(packages)}\nany=${packages.length > 0}\n`;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  const packages = testPackages(process.argv[2]);
+
+  console.log(
+    packages.length > 0
+      ? packages.map((p) => `${p.dir} (${p.script})`).join("\n")
+      : "No workspace package defines a test script.",
+  );
+
+  const output = formatOutput(packages);
+  if (process.env.GITHUB_OUTPUT) {
+    const { appendFileSync } = await import("node:fs");
+    appendFileSync(process.env.GITHUB_OUTPUT, output);
+  } else {
+    process.stdout.write(output);
+  }
+}

--- a/starter-templates/template-git-repo/.github/scripts/pin-workspace-deps.mjs
+++ b/starter-templates/template-git-repo/.github/scripts/pin-workspace-deps.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * Rewrite `workspace:*` ranges in the current directory's package.json to real
+ * semver ranges, immediately before `npm publish` packs it.
+ *
+ * npm keeps the literal `workspace:*` protocol in the published tarball, and no
+ * consumer outside the monorepo can resolve it — installing such a package dies
+ * with EUNSUPPORTEDPROTOCOL. Every workspace has to substitute real ranges at
+ * pack time; this is that substitution, moved out of the inline `node -e` it
+ * used to be so it can be tested.
+ *
+ * A dependency on a local package that is private (and so never published) is
+ * dropped rather than pinned: pinning it produces a tarball that cannot install
+ * at all.
+ *
+ * The edit is left in the working tree on purpose — `restore-pinned-deps.mjs`
+ * takes it back out after the publish, keeping only any version bump.
+ *
+ *   node .github/scripts/pin-workspace-deps.mjs [packageDir] [siblingsRoot...]
+ */
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const DEPENDENCY_FIELDS = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"];
+
+/**
+ * Map local package name -> { version, private } across the given roots.
+ *
+ * @param {string[]} roots
+ * @returns {Map<string, { version: string, private: boolean }>}
+ */
+export function readSiblings(roots) {
+  const siblings = new Map();
+
+  for (const root of roots) {
+    if (!existsSync(root)) continue;
+
+    for (const entry of readdirSync(root, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+
+      const manifest = join(root, entry.name, "package.json");
+      if (!existsSync(manifest)) continue;
+
+      try {
+        const pkg = JSON.parse(readFileSync(manifest, "utf8"));
+        if (pkg.name && pkg.version) {
+          siblings.set(pkg.name, { version: pkg.version, private: Boolean(pkg.private) });
+        }
+      } catch {
+        // A sibling with an unreadable manifest cannot be pinned against.
+      }
+    }
+  }
+
+  return siblings;
+}
+
+/**
+ * Substitute every `workspace:` range in `pkg`, in place.
+ *
+ * @param {Record<string, any>} pkg parsed package.json, mutated
+ * @param {Map<string, { version: string, private: boolean }>} siblings
+ * @returns {string[]} log lines describing what changed
+ */
+export function pinWorkspaceDeps(pkg, siblings) {
+  const changes = [];
+
+  for (const field of DEPENDENCY_FIELDS) {
+    const deps = pkg[field];
+    if (!deps) continue;
+
+    for (const [name, range] of Object.entries(deps)) {
+      if (typeof range !== "string" || !range.startsWith("workspace:")) continue;
+
+      const sibling = siblings.get(name);
+
+      if (!sibling || sibling.private) {
+        delete deps[name];
+        changes.push(`Removed unpublishable workspace dependency: ${name}`);
+        continue;
+      }
+
+      // `workspace:1.2.3` and `workspace:^1.2.3` already carry the range the
+      // author chose; only the `*`, `~` and `^` shorthands need the local
+      // version substituted in.
+      const suffix = range.slice("workspace:".length);
+      deps[name] = /^[~^]?\d/.test(suffix) ? suffix : `^${sibling.version}`;
+      changes.push(`Pinned workspace dependency ${name} -> ${deps[name]}`);
+    }
+  }
+
+  return changes;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  const [packageDir = ".", ...rootArgs] = process.argv.slice(2);
+  // Default roots are the publish workflow's: siblings live one level up from
+  // the package being published.
+  const roots = rootArgs.length > 0 ? rootArgs : [join(packageDir, "..")];
+
+  const manifestPath = join(packageDir, "package.json");
+  const pkg = JSON.parse(readFileSync(manifestPath, "utf8"));
+
+  const changes = pinWorkspaceDeps(pkg, readSiblings(roots));
+  for (const change of changes) console.log(change);
+
+  if (changes.length > 0) writeFileSync(manifestPath, `${JSON.stringify(pkg, null, 2)}\n`);
+}

--- a/starter-templates/template-git-repo/.github/scripts/restore-pinned-deps.mjs
+++ b/starter-templates/template-git-repo/.github/scripts/restore-pinned-deps.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * Undo `pin-workspace-deps.mjs` across the workspace, keeping only the version
+ * bumps the publish step made.
+ *
+ * After a publish run each published package.json holds two kinds of edit: a
+ * `version` bump, which must be committed so the next run does not re-derive
+ * it, and the `workspace:*` -> `^x.y.z` pinning, which must not — committing
+ * that would freeze siblings at whatever version they happened to have and
+ * break local development.
+ *
+ * Restoring each file from `git show HEAD:` and patching only the version back
+ * in keeps the committed diff to one line per bumped package, and keeps each
+ * file's original formatting.
+ *
+ * This replaces an inline `node -e` that matched the literal string
+ * `"version": "<old>"`. A package.json without the space after the colon — or
+ * with tab indentation — silently kept its pinned dependencies and lost its
+ * bump, while logging that it had kept it. The rewrite is now verified: a patch
+ * that matches nothing is an error, not a silent no-op.
+ *
+ *   node .github/scripts/restore-pinned-deps.mjs [packagesRoot...]
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+/**
+ * Put `toVersion` back into the committed file text, leaving all else as it was
+ * committed.
+ *
+ * A targeted replace rather than parse-and-reserialize: reserializing would
+ * reformat files that use different indentation or key order, turning a
+ * one-line version bump into a whole-file diff.
+ *
+ * @param {string} original the committed file text
+ * @param {string} fromVersion version in the committed text
+ * @param {string} toVersion version to restore
+ * @returns {string}
+ * @throws if the version field could not be found
+ */
+export function patchVersion(original, fromVersion, toVersion) {
+  if (fromVersion === toVersion) return original;
+
+  const pattern = new RegExp(`("version"\\s*:\\s*)"${fromVersion.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"`);
+  const patched = original.replace(pattern, `$1"${toVersion}"`);
+
+  if (patched === original) {
+    throw new Error(`could not find "version": "${fromVersion}" to replace with "${toVersion}"`);
+  }
+
+  return patched;
+}
+
+/**
+ * One package whose version field cannot be rewritten must not abort the loop
+ * and leave every later package still carrying its pinned dependencies, so a
+ * failure is collected and reported rather than thrown.
+ *
+ * @param {string[]} roots
+ * @param {(file: string) => string} [showHead] injection point for tests
+ * @returns {{ messages: string[], failures: string[] }}
+ */
+export function restore(roots, showHead = defaultShowHead) {
+  const messages = [];
+  const failures = [];
+
+  for (const root of roots) {
+    if (!existsSync(root)) continue;
+
+    for (const entry of readdirSync(root, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+
+      const file = join(root, entry.name, "package.json");
+      if (!existsSync(file)) continue;
+
+      let committed;
+      try {
+        committed = showHead(file);
+      } catch {
+        // An untracked package has no committed text to restore to, and its
+        // whole manifest is new — leave it exactly as it is.
+        continue;
+      }
+
+      const current = JSON.parse(readFileSync(file, "utf8"));
+      const original = JSON.parse(committed);
+
+      let restored;
+      try {
+        restored = patchVersion(committed, original.version, current.version);
+      } catch {
+        // The package was published under the new version; if the repo keeps
+        // the old one, the next run republishes the same content forever.
+        failures.push(
+          `::error title=Version bump lost::Could not rewrite the version field in ${file}. ` +
+            `${current.name} was published as ${current.version} but the repo still says ${original.version}.`,
+        );
+        continue;
+      }
+
+      if (original.version !== current.version) {
+        messages.push(`Keeping version bump for ${current.name} -> ${current.version}`);
+      }
+
+      writeFileSync(file, restored);
+    }
+  }
+
+  return { messages, failures };
+}
+
+function defaultShowHead(file) {
+  return execFileSync("git", ["show", `HEAD:${file}`], { encoding: "utf8" });
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  const roots = process.argv.slice(2);
+  const { messages, failures } = restore(roots.length > 0 ? roots : ["packages", "apps"]);
+
+  for (const message of messages) console.log(message);
+  for (const failure of failures) console.log(failure);
+
+  if (failures.length > 0) process.exitCode = 1;
+}

--- a/starter-templates/template-git-repo/.github/scripts/workspace-build-order.mjs
+++ b/starter-templates/template-git-repo/.github/scripts/workspace-build-order.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * Order the workspace's package directories so every package comes after each
+ * sibling it depends on.
+ *
+ * The publish workflow used to walk `packages/*​/ apps/*​/`, i.e. shell-glob
+ * (alphabetical) order, which has nothing to do with the dependency graph. Bun
+ * and pnpm link workspace siblings into `node_modules` as symlinks, so a
+ * sibling that has not been built yet has no `dist/`, and the `exports` ->
+ * `types` entries in its package.json point at files that do not exist. The
+ * package that sorts earlier then fails its declaration build with:
+ *
+ *   Cannot find module '<sibling>' or its corresponding type declarations.
+ *
+ * Dependency order also means a sibling's `workspace:*` pin is rewritten to the
+ * version that sibling just published, rather than the one it had before its
+ * own bump.
+ *
+ *   node .github/scripts/workspace-build-order.mjs [rootDir...]
+ *
+ * Prints one directory per line with a trailing slash, e.g. `packages/core/`.
+ */
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const DEPENDENCY_FIELDS = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"];
+
+/**
+ * Read every `<root>/<dir>/package.json` across the given roots.
+ *
+ * @param {string[]} roots
+ * @returns {{ dir: string, pkg: Record<string, any> }[]}
+ */
+export function readWorkspacePackages(roots) {
+  const packages = [];
+
+  for (const root of roots) {
+    if (!existsSync(root)) continue;
+
+    for (const entry of readdirSync(root, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+
+      const manifest = join(root, entry.name, "package.json");
+      if (!existsSync(manifest)) continue;
+
+      try {
+        const pkg = JSON.parse(readFileSync(manifest, "utf8"));
+        if (pkg.name) packages.push({ dir: `${root}/${entry.name}`, pkg });
+      } catch (error) {
+        console.error(`Skipping ${manifest}: ${error.message}`);
+      }
+    }
+  }
+
+  return packages;
+}
+
+/**
+ * Map each package directory to the sibling directories it depends on.
+ *
+ * Edges are keyed by package *name*, not by the version range: a workspace
+ * sibling is linked whenever the name matches, so `"core": "^1.2.3"` resolves
+ * to the local copy exactly as `"workspace:*"` does and needs building just the
+ * same.
+ *
+ * @param {ReturnType<typeof readWorkspacePackages>} packages
+ * @returns {Map<string, Set<string>>}
+ */
+export function localDependencyGraph(packages) {
+  const dirByName = new Map(packages.map(({ dir, pkg }) => [pkg.name, dir]));
+  const graph = new Map();
+
+  for (const { dir, pkg } of packages) {
+    const local = new Set();
+
+    for (const field of DEPENDENCY_FIELDS) {
+      for (const name of Object.keys(pkg[field] ?? {})) {
+        const dependency = dirByName.get(name);
+        if (dependency && dependency !== dir) local.add(dependency);
+      }
+    }
+
+    graph.set(dir, local);
+  }
+
+  return graph;
+}
+
+/**
+ * Topologically sort the workspace, alphabetically within each ready set so the
+ * order is stable across runs.
+ *
+ * @param {string[]} [roots]
+ * @returns {string[]} directories with a trailing slash
+ */
+export function workspaceBuildOrder(roots = ["packages", "apps"]) {
+  const packages = readWorkspacePackages(roots);
+  const dependencies = localDependencyGraph(packages);
+
+  const pending = packages.map(({ dir }) => dir).sort();
+  const built = new Set();
+  const order = [];
+
+  while (pending.length > 0) {
+    const ready = pending.findIndex((dir) => [...dependencies.get(dir)].every((dep) => built.has(dep)));
+
+    // A dependency cycle leaves nothing ready. No order can be right, so take
+    // the alphabetically first entry and keep going: everything still gets
+    // built and published, and the cycle is reported on stderr where it lands
+    // in the job log.
+    if (ready === -1) {
+      console.error(`Dependency cycle involving ${pending[0]} — falling back to alphabetical order for it`);
+    }
+
+    const [dir] = pending.splice(ready === -1 ? 0 : ready, 1);
+    built.add(dir);
+    order.push(`${dir}/`);
+  }
+
+  return order;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  const roots = process.argv.slice(2);
+  console.log(workspaceBuildOrder(roots.length > 0 ? roots : undefined).join("\n"));
+}

--- a/starter-templates/template-git-repo/.github/workflows/deploy-test-reports.yml
+++ b/starter-templates/template-git-repo/.github/workflows/deploy-test-reports.yml
@@ -7,6 +7,13 @@ on:
     branches: [{{DEFAULT_BRANCH}}]
   workflow_dispatch:
 
+# Two pushes in quick succession would otherwise race `wrangler deploy`, and the
+# report that wins is whichever upload finishes last, not whichever commit is
+# newer. Cancel the older run instead.
+concurrency:
+  group: test-reports
+  cancel-in-progress: true
+
 jobs:
   deploy:
     name: Generate & Deploy Test Reports

--- a/starter-templates/template-git-repo/.github/workflows/npm-publish.yml
+++ b/starter-templates/template-git-repo/.github/workflows/npm-publish.yml
@@ -166,7 +166,14 @@ jobs:
           unattempted_packages=""
           auth_broken=""
 
-          for dir in packages/*/ apps/*/; do
+          # Dependency order, not shell-glob (alphabetical) order: a sibling
+          # that has not been built yet has no dist/, so a package that sorts
+          # earlier fails its declaration build on every sibling it imports.
+          build_order=$(node "$GITHUB_WORKSPACE/.github/scripts/workspace-build-order.mjs" packages apps)
+          echo "📋 Build order:"
+          echo "$build_order" | sed 's/^/   /'
+
+          for dir in $build_order; do
             pkg="${dir}package.json"
             [ -f "$pkg" ] || continue
 
@@ -201,37 +208,7 @@ jobs:
               # semver range taken from the referenced local package; drop
               # local packages that are not published. Only the version field
               # of this edit is committed back, in the final step.
-              node -e "
-                const fs = require('fs');
-                const path = require('path');
-                const localVersions = {};
-                for (const root of ['../../packages', '../../apps']) {
-                  if (!fs.existsSync(root)) continue;
-                  for (const d of fs.readdirSync(root)) {
-                    const sib = path.join(root, d, 'package.json');
-                    if (!fs.existsSync(sib)) continue;
-                    try {
-                      const sp = JSON.parse(fs.readFileSync(sib, 'utf8'));
-                      if (sp.name && sp.version && !sp.private) localVersions[sp.name] = sp.version;
-                    } catch {}
-                  }
-                }
-                const p = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-                for (const s of ['dependencies', 'devDependencies', 'peerDependencies']) {
-                  if (!p[s]) continue;
-                  for (const [k, v] of Object.entries(p[s])) {
-                    if (typeof v !== 'string' || !v.startsWith('workspace:')) continue;
-                    if (localVersions[k]) {
-                      p[s][k] = '^' + localVersions[k];
-                      console.log('Pinned workspace dependency', k, '->', p[s][k]);
-                    } else {
-                      delete p[s][k];
-                      console.log('Removed unresolved workspace dependency:', k);
-                    }
-                  }
-                }
-                fs.writeFileSync('package.json', JSON.stringify(p, null, 2));
-              "
+              node "$GITHUB_WORKSPACE/.github/scripts/pin-workspace-deps.mjs" . ../../packages ../../apps
 
               version=$(node -e "const p=require('./package.json'); console.log(p.version)")
               latest=$(npm view "$name" version 2>/dev/null || echo "")
@@ -351,42 +328,7 @@ jobs:
           # Version bumps made during publish must land back in the repo so the
           # next run sees them. Restore the workspace:* pinning done for the
           # tarballs first — only the "version" field should be committed.
-          node -e "
-            const fs = require('fs');
-            const cp = require('child_process');
-            for (const root of ['packages', 'apps']) {
-              if (!fs.existsSync(root)) continue;
-              for (const d of fs.readdirSync(root)) {
-                const f = root + '/' + d + '/package.json';
-                if (!fs.existsSync(f)) continue;
-                const now = JSON.parse(fs.readFileSync(f, 'utf8'));
-                let raw;
-                try {
-                  raw = cp.execSync('git show HEAD:' + f, { encoding: 'utf8' });
-                } catch { continue; }
-                const orig = JSON.parse(raw);
-                if (orig.version !== now.version) {
-                  // Patch only the version string so the file keeps whatever
-                  // formatting it had. Matching on a literal '\"version\": \"x\"'
-                  // would miss a package.json written without the space after
-                  // the colon, and silently drop the bump while claiming to
-                  // keep it — so match the field, then assert it changed.
-                  const before = raw;
-                  raw = raw.replace(
-                    /(\"version\"\s*:\s*\")[^\"]*(\")/,
-                    (m, open_, close) => open_ + now.version + close
-                  );
-                  if (raw === before) {
-                    console.log('::error title=Version bump lost::Could not rewrite the version field in ' + f + '. ' + now.name + ' was published as ' + now.version + ' but the repo still says ' + orig.version + '.');
-                    process.exitCode = 1;
-                    continue;
-                  }
-                  console.log('Keeping version bump for', now.name, '->', now.version);
-                }
-                fs.writeFileSync(f, raw);
-              }
-            }
-          "
+          node .github/scripts/restore-pinned-deps.mjs packages apps
           git add packages/*/package.json apps/*/package.json 2>/dev/null || true
           git diff --staged --quiet && echo "No version changes to commit" && exit 0
           # [skip ci] so the bump commit does not retrigger this workflow.

--- a/starter-templates/template-git-repo/.github/workflows/tests.yml
+++ b/starter-templates/template-git-repo/.github/workflows/tests.yml
@@ -3,8 +3,10 @@
 # per test and comments the failing ones on the pull request.
 #
 # The matrix is discovered at run time rather than hand-maintained: adding a
-# package with a `test:ci` script is all it takes to get it tested here. That
-# script must write, relative to the package directory:
+# package with a `test:ci` script is all it takes to get it tested here. The
+# packages searched come from the root package.json `workspaces` globs, so a
+# repo laid out as `libs/*` is covered without editing this file. That script
+# must write, relative to the package directory:
 #
 #   junit.xml         - test results, the input Test Analytics ingests
 #   coverage/lcov.info - coverage, uploaded when the runner can produce it
@@ -36,27 +38,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - id: list
-        name: Find packages with a test:ci script
-        run: |
-          node --input-type=module -e '
-            import { readdirSync, readFileSync, existsSync, appendFileSync } from "node:fs";
-            const out = [];
-            for (const root of ["packages", "apps"]) {
-              if (!existsSync(root)) continue;
-              for (const dir of readdirSync(root)) {
-                const file = `${root}/${dir}/package.json`;
-                if (!existsSync(file)) continue;
-                let pkg;
-                try { pkg = JSON.parse(readFileSync(file, "utf8")); } catch { continue; }
-                if (!pkg.scripts?.["test:ci"]) continue;
-                out.push({ name: pkg.name ?? dir, dir: `${root}/${dir}` });
-              }
-            }
-            out.sort((a, b) => a.dir.localeCompare(b.dir));
-            appendFileSync(process.env.GITHUB_OUTPUT, `packages=${JSON.stringify(out)}\n`);
-            appendFileSync(process.env.GITHUB_OUTPUT, `any=${out.length > 0}\n`);
-            console.log(out.length ? out.map((p) => p.dir).join("\n") : "No package defines a test:ci script.");
-          '
+        name: Find packages with a test script
+        run: node .github/scripts/list-test-packages.mjs
 
   test:
     needs: discover
@@ -85,7 +68,7 @@ jobs:
       # `turbo run` builds this package's workspace dependencies first, so a
       # package that imports a sibling through its built `dist` output finds it.
       - name: Run tests
-        run: bunx turbo run test:ci --filter=./${{ matrix.package.dir }}
+        run: bunx turbo run ${{ matrix.package.script }} --filter=./${{ matrix.package.dir }}
 
       # `!cancelled()` so a red suite still reports: without it the upload is
       # skipped on exactly the runs whose results matter most.

--- a/starter-templates/template-git-repo/docs/WORKFLOWS.md
+++ b/starter-templates/template-git-repo/docs/WORKFLOWS.md
@@ -16,7 +16,7 @@ the part that costs hours if you meet them cold.
 
 ## tests.yml
 
-Discovers every workspace package with a `test:ci` script, runs each as its own
+Discovers every workspace package with a test script, runs each as its own
 matrix job, and uploads results to Codecov Test Analytics and coverage to
 Codecov.
 
@@ -25,6 +25,12 @@ goes stale the first time someone adds a package and forgets to edit the
 workflow — the package silently has no CI. A `discover` job emits the list as
 JSON; the `test` job consumes it through `fromJSON`. GitHub cannot compute a
 matrix inside the job that uses it, which is why it is two jobs.
+
+**Where it looks.** `.github/scripts/list-test-packages.mjs` expands the root
+package.json `workspaces` globs, so a repo laid out as `libs/*` is covered with
+no edit here. It prefers `test:ci`, falling back to `test:coverage` and then
+`test`, and the job runs whichever it found — a package with only a plain `test`
+script is tested rather than skipped.
 
 **What your package must produce.** Relative to the package directory:
 
@@ -56,7 +62,7 @@ For Vitest:
 
 | Symptom | Cause → fix |
 | --- | --- |
-| A package you added never appears as a job | It has no `test:ci` script, or it lives outside `packages/`, `apps/` |
+| A package you added never appears as a job | It has no `test:ci`, `test:coverage` or `test` script, or it lives outside the root package.json `workspaces` globs |
 | `Error: Unable to process file command 'output'` in `discover` | A package name contains a newline or the JSON exceeded the 1MB output cap |
 | Codecov shows the run but no coverage | The runner wrote no `lcov.info` — `--coverage` missing, or a provider that writes nothing on your Node version |
 | Coverage drops to 0% for an untouched package | `carryforward` is off for that flag in `codecov.yml` |
@@ -93,6 +99,14 @@ provenance statement into the public sigstore transparency log.
 
 **Details that matter:**
 
+- Packages are walked in dependency order, from
+  `.github/scripts/workspace-build-order.mjs`, not in shell-glob (alphabetical)
+  order. Workspace siblings are symlinked into `node_modules`, so one that has
+  not been built yet has no `dist/` and its package.json `types` entries point
+  at files that do not exist — the package that sorts earlier fails its
+  declaration build with `Cannot find module '<sibling>'`. Dependency order also
+  means a sibling's `workspace:*` pin is rewritten to the version that sibling
+  just published, not the one it had before its own bump.
 - `set +e` in the publish loop. GitHub runs `run:` steps with `bash -e -o
   pipefail`, so *not* writing `set -e` does not disable errexit — the first
   failing package would kill the step and leave every later package unevaluated.
@@ -100,21 +114,27 @@ provenance statement into the public sigstore transparency log.
 - Exit 43 means "npm rejected the credential". The loop stops attempting further
   packages: they would all fail the same way, after another build and another
   provenance signature each.
-- `workspace:*` dependencies are rewritten to real semver ranges before packing.
-  npm keeps the literal protocol in the tarball, and consumers cannot resolve it.
-  Only the `version` field of that edit is committed back.
+- `workspace:*` dependencies are rewritten to real semver ranges before packing
+  (`.github/scripts/pin-workspace-deps.mjs`). npm keeps the literal protocol in
+  the tarball, and consumers cannot resolve it. A dependency on a *private*
+  sibling is dropped rather than pinned — pinning it produces a tarball that
+  cannot install at all. An explicit `workspace:^1.0.0` keeps the range its
+  author chose. Only the `version` field of that edit is committed back.
 - A local version *behind* the registry is synced forward first, otherwise the
   publish fails with "Cannot implicitly apply the latest tag".
 - `E409 cannot publish over previously staged version` is retried at the next
   free version, up to five times. `latest` lags versions an interrupted publish
   reserved; `.github/scripts/next-free-version.mjs` reads the full version list
   *and* the release timeline, which is where those numbers appear.
-- The final step rewrites only the `version` field back into each
-  `package.json`, by regex rather than by re-serializing the parsed object, so
-  the file keeps its own formatting. It matches `"version"\s*:\s*"..."` rather
-  than a literal `"version": "x"`, and fails the step if the replace found
-  nothing — a package.json written without the space after the colon would
-  otherwise silently lose the bump while the log claimed to keep it.
+- The final step (`.github/scripts/restore-pinned-deps.mjs`) rewrites only the
+  `version` field back into each `package.json`, by regex rather than by
+  re-serializing the parsed object, so the file keeps its own formatting. It
+  matches `"version"\s*:\s*"..."` rather than a literal `"version": "x"`, and
+  reports a failure if the replace found nothing — a package.json written
+  without the space after the colon would otherwise silently lose the bump while
+  the log claimed to keep it. One unrewritable file is reported and the step
+  fails at the end, rather than aborting the loop and leaving every later
+  package still carrying its pinned dependencies.
 - The bump commit ends in `[skip ci]` so it does not retrigger the workflow.
 - A no-op `husky` is put on PATH. Some published dependencies ship
   `prepare: "husky install"`; when npm reconciles bun's linked `node_modules` it
@@ -203,3 +223,27 @@ it fetches them into an empty workspace rather than paying for a full checkout.
 - **`main` instead of `master`.** Every `branches:` filter in this template is
   written by `setup-git-repo` from your repo's actual default branch. If you
   rename the branch later, grep the workflows for the old name.
+
+## .github/scripts/
+
+The workflows' logic lives here rather than in inline `node -e` heredocs, so it
+can be unit tested — these run in *your* CI with nobody watching, and a bug in
+one surfaces as a failed workflow rather than a failed test. They are covered by
+`packages/setup-git-repo/test/template-scripts.test.mjs` in the repo this
+template comes from.
+
+| Script | Called by | Does |
+| --- | --- | --- |
+| `list-test-packages.mjs` | `tests.yml` | Emits the test matrix from the root `workspaces` globs |
+| `workspace-build-order.mjs` | `npm-publish.yml` | Topologically sorts the workspace so a package is built after its siblings |
+| `pin-workspace-deps.mjs` | `npm-publish.yml` | Rewrites `workspace:*` to real ranges at pack time |
+| `next-free-version.mjs` | `npm-publish.yml` | Picks a version the registry has not already spent |
+| `restore-pinned-deps.mjs` | `npm-publish.yml` | Undoes the pinning, keeping only the version bumps |
+
+Each takes its roots as arguments and prints to stdout, so you can run any of
+them locally against your own repo to see what CI will see:
+
+```bash
+node .github/scripts/list-test-packages.mjs
+node .github/scripts/workspace-build-order.mjs packages apps
+```


### PR DESCRIPTION
…sted scripts

Follows #75. Everything it added stands; this takes the logic that was still living in inline `node -e` heredocs inside the workflow YAML and moves it to `.github/scripts/`, where it can be unit tested. These run in a *consumer's* CI with nobody watching, so a bug in one surfaces as a failed workflow in someone else's repo rather than as a failed test here.

Four scripts, 47 tests, and three real bugs the tests found:

  list-test-packages.mjs      was inline in tests.yml, and hardcoded
                              ["packages", "apps"] as the places to look — a
                              repo laid out as `libs/*` got an empty matrix and
                              no error, which is the exact failure mode the
                              discovered matrix was meant to remove. Now reads
                              the root package.json `workspaces` globs, and
                              accepts `test:coverage`/`test` as well as
                              `test:ci` so a package with a plain test script is
                              tested rather than skipped.

  workspace-build-order.mjs   new. npm-publish.yml walked `packages/*/ apps/*/`,
                              i.e. alphabetical order, which has nothing to do
                              with the dependency graph: a sibling that has not
                              been built has no dist/, so a package sorting
                              earlier fails its declaration build with "Cannot
                              find module '<sibling>'". Topological now.

  pin-workspace-deps.mjs      was an inline heredoc. Two fixes while extracting:
                              an explicit `workspace:^1.0.0` keeps the range its
                              author chose instead of being overwritten with the
                              sibling's current version, and optionalDependencies
                              are covered.

  restore-pinned-deps.mjs     was an inline heredoc. One package whose version
                              field could not be rewritten aborted the loop and
                              left every later package still carrying its pinned
                              dependencies; failures are now collected, reported
                              and the step fails at the end.

Also adds template-integrity tests over the coupling between the template and the CLI that applies it — every `<!-- badge:x -->` marker has an OPTIONAL_BADGES entry and vice versa, each badge line carries the placeholders it needs, the template uses no placeholder the CLI cannot fill, and every workflow is valid YAML with pinned actions. That last one caught deploy-test-reports.yml having no concurrency group, so two pushes could race `wrangler deploy` and the report that won was whichever upload finished last rather than whichever commit was newer. Fixed here.

Net −75 lines of YAML. docs/WORKFLOWS.md gains a section on the scripts and how to run them locally; ask-github-actions-setup is updated to match.


Claude-Session: https://claude.ai/code/session_01NZNMXShavXjpA5LvBqhkEY