### PR TITLE
📦 fix(verify-phone-sms): publish under the name it ships on npm, add …

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@
 [![npm downloads](https://img.shields.io/npm/dm/template-git-repo.svg)](https://www.npmjs.com/package/template-git-repo) **[template-git-repo](packages/template-git-repo/)** - One command to give a repo the CI setup from qwksearch-research-agent: GitHub Actions for a discovered per-package test matrix, content-based npm publishing, agent PR auto-merge and hosted test reports, plus `turbo.json`, `codecov.yml` and a README badge block. Detects the repo slug, default branch, package manager and workspace layout; skips badges it has no input for instead of rendering them broken.
 `bunx template-git-repo` · `bunx template-git-repo --dry-run`
 
-**[verify-phone-sms](packages/verify-phone-sms/)** - SMS phone verification API server built with Hono on Cloudflare Workers, backed by AWS SNS. Sends one-time codes, blocks VoIP numbers, enforces API-key authentication, applies rate limiting, and exposes auto-generated OpenAPI documentation. Includes health-check endpoints and CORS/security-header middleware.
-`bun deploy` · `wrangler deploy`
+[![npm downloads](https://img.shields.io/npm/dm/verify-phone-sms.svg)](https://www.npmjs.com/package/verify-phone-sms) **[verify-phone-sms](packages/verify-phone-sms/)** - SMS phone verification API server built with Hono on Cloudflare Workers, backed by AWS SNS. Sends one-time codes, blocks VoIP numbers, enforces API-key authentication, applies rate limiting, and exposes auto-generated OpenAPI documentation. Includes health-check endpoints and CORS/security-header middleware.
+`npm install verify-phone-sms` · `wrangler deploy`
 
 [![npm downloads](https://img.shields.io/npm/dm/setup-git-repo.svg)](https://www.npmjs.com/package/setup-git-repo) **[setup-git-repo](packages/setup-git-repo/)** - One command to give a repo its whole GitHub setup: Turborepo, five CI workflows (auto-discovering test matrix to Codecov, content-hash npm publishing, agent PR auto-merge, Cloudflare-deployed test reports), the centered README badge block filled in from your git remote, and docs explaining how to set up every badge, workflow and secret.
 `bunx setup-git-repo` · `npx setup-git-repo`

--- a/apps/docs/content/docs/(index)/packages/verify-phone-sms.mdx
+++ b/apps/docs/content/docs/(index)/packages/verify-phone-sms.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'sms-verification-api'
+title: 'verify-phone-sms'
 description: 'SMS Phone Verification API using AWS SNS HTTP API with Hono server on Cloudflare Workers'
 icon: Shield
 ---

--- a/apps/docs/scripts/sync-readme-docs.ts
+++ b/apps/docs/scripts/sync-readme-docs.ts
@@ -112,7 +112,7 @@ const PACKAGES: Entry[] = [
   },
   {
     dir: 'packages/verify-phone-sms',
-    title: 'sms-verification-api',
+    title: 'verify-phone-sms',
     icon: 'Shield',
   },
   {

--- a/packages/verify-phone-sms/README.md
+++ b/packages/verify-phone-sms/README.md
@@ -1,5 +1,12 @@
 # SMS Verification API Server
 
+<p align="center">
+    <a href="https://www.npmjs.com/package/verify-phone-sms"><img src="https://img.shields.io/npm/dm/verify-phone-sms.svg" alt="NPM Monthly Downloads" /></a>
+    <a href="https://www.npmjs.com/package/verify-phone-sms"><img src="https://img.shields.io/npm/dt/verify-phone-sms.svg" alt="NPM Total Downloads" /></a>
+    <a href="https://www.npmjs.com/package/verify-phone-sms"><img src="https://img.shields.io/npm/v/verify-phone-sms.svg" alt="npm version" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/blob/master/LICENSE.md"><img src="https://img.shields.io/npm/l/verify-phone-sms.svg" alt="license" /></a>
+</p>
+
 A complete Hono-based server for SMS verification using AWS SNS. Built for Cloudflare Workers with comprehensive API documentation and security features.
 
 ## Features
@@ -34,7 +41,13 @@ A complete Hono-based server for SMS verification using AWS SNS. Built for Cloud
 
 ## Quick Start
 
-### 1. Install Dependencies
+### 1. Install
+
+```bash
+npm install verify-phone-sms   # use verifyPhone() from your own backend
+```
+
+Or clone the repo and install its dependencies to run the server itself:
 
 ```bash
 npm install

--- a/packages/verify-phone-sms/package-lock.json
+++ b/packages/verify-phone-sms/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "sms-verification-api",
+  "name": "verify-phone-sms",
   "version": "0.9.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "sms-verification-api",
+      "name": "verify-phone-sms",
       "version": "0.9.51",
       "license": "MIT",
       "dependencies": {

--- a/packages/verify-phone-sms/package.json
+++ b/packages/verify-phone-sms/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sms-verification-api",
+  "name": "verify-phone-sms",
   "version": "0.9.51",
   "description": "SMS Phone Verification API using AWS SNS HTTP API with Hono server on Cloudflare Workers",
   "main": "src/verify-phone.ts",

--- a/skills/ask-verify-phone-sms/SKILL.md
+++ b/skills/ask-verify-phone-sms/SKILL.md
@@ -5,7 +5,7 @@ description: Guide to the SMS verification API in packages/verify-phone-sms — 
 
 # Working With verify-phone-sms
 
-The service in `packages/verify-phone-sms` (npm name `sms-verification-api`). Two layers: a `verifyPhone()` function that sends an SMS through AWS SNS's HTTP API, and a Hono server (`@hono/zod-openapi`) that exposes it on Cloudflare Workers with auth, rate limiting, and Swagger docs. Exact request/response schemas and options live in [API.md](API.md).
+The service in `packages/verify-phone-sms` (npm name `verify-phone-sms`). Two layers: a `verifyPhone()` function that sends an SMS through AWS SNS's HTTP API, and a Hono server (`@hono/zod-openapi`) that exposes it on Cloudflare Workers with auth, rate limiting, and Swagger docs. Exact request/response schemas and options live in [API.md](API.md).
 
 ## The one thing to know first
 
@@ -38,8 +38,8 @@ wrangler secret put API_KEY
 
 | You want | Use |
 | --- | --- |
-| Send a code from your own backend | `import verifyPhone from "sms-verification-api"` — default export, `verifyPhone({ phoneNumber, code, … })` |
-| Just a VoIP check | `import { isPhoneNumberVoip } from "sms-verification-api"` |
+| Send a code from your own backend | `import verifyPhone from "verify-phone-sms"` — default export, `verifyPhone({ phoneNumber, code, … })` |
+| Just a VoIP check | `import { isPhoneNumberVoip } from "verify-phone-sms"` |
 | A hosted endpoint | `POST /api/send` with `X-API-Key` |
 | Any non-verification SMS | `POST /api/sms` with `message` |
 | Interactive docs | `GET /docs` (Swagger UI); `GET /` and `GET /health` are unauthenticated health checks |


### PR DESCRIPTION
…download badges

The package directory, the README link, the docs entry and the npm page all say `verify-phone-sms`, but package.json said `sms-verification-api`. The publish workflow reads the name from package.json, so every push to master has been releasing `sms-verification-api` while `verify-phone-sms` sat at 0.9.4 from the old appdemo-dev-tools repo — four months stale and 0 downloads a week.

Rename the package to `verify-phone-sms`. resolve-publish-version.mjs now resolves 0.9.51 against that name ("unpublished version already in package.json"), so the next push to master moves its `latest` tag from 0.9.4 to 0.9.51 in one release.

Worker names in wrangler.toml and the example URLs in openapi.json stay `sms-verification-api` — those are Cloudflare deployment names, and renaming them would create a new Worker and break the deployed URL.

Download counts: monthly/total/version/license badges on the package README, and the monthly-downloads badge the root README's package list gives every other published package. Its command line now shows the install instead of only the deploy.


Claude-Session: https://claude.ai/code/session_017dHNDDp1Sb1PrMMVgF9Sc9