### PR TITLE
🐛 fix(ci): stop the PR sweep failing when no branch needs a PR

### DIFF
--- a/.github/workflows/auto-merge-and-create-prs.yml
+++ b/.github/workflows/auto-merge-and-create-prs.yml
@@ -19,8 +19,8 @@ jobs:
   maintain-pull-requests:
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ secrets.GIT_TOKEN }}
-      GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
+      GH_TOKEN: ${{ secrets.GIT_TOKEN || secrets.GITHUB_TOKEN }}
+      GIT_TOKEN: ${{ secrets.GIT_TOKEN || secrets.GITHUB_TOKEN }}
       BASE_BRANCH: ${{ github.event.repository.default_branch }}
     steps:
       - name: Merge eligible existing pull requests
@@ -33,15 +33,21 @@ jobs:
             --repo "$REPOSITORY" \
             --state open \
             --json number,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup \
-            --jq '.[] | select(.isDraft == false) | select(.mergeStateStatus == "CLEAN") | select((.reviewDecision == "APPROVED") or (.reviewDecision == "")) | select(all(.statusCheckRollup[]?; (.conclusion == "SUCCESS" or .conclusion == "SKIPPED" or .conclusion == "NEUTRAL"))) | .number' \
-          | while read -r pr_number; do
-              echo "Attempting to merge PR #${pr_number}"
-              gh pr merge "$pr_number" \
-                --repo "$REPOSITORY" \
-                --merge \
-                --delete-branch \
-                --auto || echo "Could not merge PR #${pr_number}; it may require review, checks, or conflict resolution."
-            done
+            --jq '.[] | select(.isDraft == false) | select(.mergeStateStatus == "CLEAN") | select((.reviewDecision // "") as $decision | $decision == "APPROVED" or $decision == "") | select(all(.statusCheckRollup[]?; (.conclusion == "SUCCESS" or .conclusion == "SKIPPED" or .conclusion == "NEUTRAL"))) | .number' \
+            > "$RUNNER_TEMP/mergeable-prs.txt"
+
+          # The numbers go through a file rather than a pipe: a piped `while`
+          # runs in a subshell that shares its stdin with `gh`, and a pipeline
+          # under `pipefail` fails the step for a producer that merely had
+          # nothing to say.
+          while read -r pr_number; do
+            echo "Attempting to merge PR #${pr_number}"
+            gh pr merge "$pr_number" \
+              --repo "$REPOSITORY" \
+              --merge \
+              --delete-branch \
+              --auto || echo "Could not merge PR #${pr_number}; it may require review, checks, or conflict resolution."
+          done < "$RUNNER_TEMP/mergeable-prs.txt"
 
       - name: Create pull requests for branches without one
         env:
@@ -57,28 +63,39 @@ jobs:
 
           base_sha="$(git rev-parse "origin/${BASE_BRANCH}")"
 
+          # Not `for-each-ref | grep | while`: `grep` exits 1 when it filters
+          # every ref out, and `pipefail` turns that into a failed run on the
+          # ordinary "only the default branch is left" case. The refs go
+          # through a file, and the ones to leave alone are skipped inside the
+          # loop, so an empty list is a no-op.
           git for-each-ref --format='%(refname:strip=3)' refs/remotes/origin \
-            | grep -Ev "^(HEAD|${BASE_BRANCH})$" \
-            | while read -r branch; do
-                open_pr="$(gh pr list --repo "$REPOSITORY" --state open --head "$branch" --json number --jq 'length')"
-                merged_pr="$(gh pr list --repo "$REPOSITORY" --state merged --head "$branch" --json number --jq 'length')"
-                branch_sha="$(git rev-parse "origin/${branch}")"
+            > "$RUNNER_TEMP/branches.txt"
 
-                if [ "$open_pr" -gt 0 ] || [ "$merged_pr" -gt 0 ]; then
-                  echo "Skipping ${branch}: a pull request already exists or was previously merged."
-                  continue
-                fi
+          while read -r branch; do
+            if [ "$branch" = "HEAD" ] || [ "$branch" = "$BASE_BRANCH" ]; then
+              continue
+            fi
 
-                if git merge-base --is-ancestor "$branch_sha" "$base_sha"; then
-                  echo "Skipping ${branch}: it is already contained in ${BASE_BRANCH}."
-                  continue
-                fi
+            open_pr="$(gh pr list --repo "$REPOSITORY" --state open --head "$branch" --json number --jq 'length')"
+            merged_pr="$(gh pr list --repo "$REPOSITORY" --state merged --head "$branch" --json number --jq 'length')"
+            branch_sha="$(git rev-parse "origin/${branch}")"
 
-                echo "Creating PR for ${branch} -> ${BASE_BRANCH}"
-                gh pr create \
-                  --repo "$REPOSITORY" \
-                  --head "$branch" \
-                  --base "$BASE_BRANCH" \
-                  --title "Merge ${branch} into ${BASE_BRANCH}" \
-                  --body "Automated pull request for branch \`${branch}\`."
-              done
+            if [ "$open_pr" -gt 0 ] || [ "$merged_pr" -gt 0 ]; then
+              echo "Skipping ${branch}: a pull request already exists or was previously merged."
+              continue
+            fi
+
+            if git merge-base --is-ancestor "$branch_sha" "$base_sha"; then
+              echo "Skipping ${branch}: it is already contained in ${BASE_BRANCH}."
+              continue
+            fi
+
+            echo "Creating PR for ${branch} -> ${BASE_BRANCH}"
+            gh pr create \
+              --repo "$REPOSITORY" \
+              --head "$branch" \
+              --base "$BASE_BRANCH" \
+              --title "Merge ${branch} into ${BASE_BRANCH}" \
+              --body "Automated pull request for branch \`${branch}\`." \
+              || echo "Could not open a PR for ${branch}."
+          done < "$RUNNER_TEMP/branches.txt"

--- a/packages/template-git-repo/template/.github/workflows/auto-merge-and-create-prs.yml
+++ b/packages/template-git-repo/template/.github/workflows/auto-merge-and-create-prs.yml
@@ -44,15 +44,21 @@ jobs:
             --repo "$REPOSITORY" \
             --state open \
             --json number,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup \
-            --jq '.[] | select(.isDraft == false) | select(.mergeStateStatus == "CLEAN") | select((.reviewDecision == "APPROVED") or (.reviewDecision == "")) | select(all(.statusCheckRollup[]?; (.conclusion == "SUCCESS" or .conclusion == "SKIPPED" or .conclusion == "NEUTRAL"))) | .number' \
-          | while read -r pr_number; do
-              echo "Attempting to merge PR #${pr_number}"
-              gh pr merge "$pr_number" \
-                --repo "$REPOSITORY" \
-                --squash \
-                --delete-branch \
-                --auto || echo "Could not merge PR #${pr_number}; it may require review, checks, or conflict resolution."
-            done
+            --jq '.[] | select(.isDraft == false) | select(.mergeStateStatus == "CLEAN") | select((.reviewDecision // "") as $decision | $decision == "APPROVED" or $decision == "") | select(all(.statusCheckRollup[]?; (.conclusion == "SUCCESS" or .conclusion == "SKIPPED" or .conclusion == "NEUTRAL"))) | .number' \
+            > "$RUNNER_TEMP/mergeable-prs.txt"
+
+          # The numbers go through a file rather than a pipe: a piped `while`
+          # runs in a subshell that shares its stdin with `gh`, and a pipeline
+          # under `pipefail` fails the step for a producer that merely had
+          # nothing to say.
+          while read -r pr_number; do
+            echo "Attempting to merge PR #${pr_number}"
+            gh pr merge "$pr_number" \
+              --repo "$REPOSITORY" \
+              --squash \
+              --delete-branch \
+              --auto || echo "Could not merge PR #${pr_number}; it may require review, checks, or conflict resolution."
+          done < "$RUNNER_TEMP/mergeable-prs.txt"
 
       - name: Create pull requests for branches without one
         env:
@@ -71,32 +77,43 @@ jobs:
 
           base_sha="$(git rev-parse "origin/${BASE_BRANCH}")"
 
+          # Not `for-each-ref | grep | while`: `grep` exits 1 when it filters
+          # every ref out, and `pipefail` turns that into a failed run on the
+          # ordinary "only the default branch is left" case. The refs go
+          # through a file, and the ones to leave alone are skipped inside the
+          # loop, so an empty list is a no-op.
           git for-each-ref --format='%(refname:strip=3)' refs/remotes/origin \
-            | grep -Ev "^(HEAD|${BASE_BRANCH})$" \
-            | while read -r branch; do
-                open_pr="$(gh pr list --repo "$REPOSITORY" --state open --head "$branch" --json number --jq 'length')"
-                # `merged` too: a branch whose PR was merged but which was never
-                # deleted would otherwise get a fresh PR opened on every sweep.
-                merged_pr="$(gh pr list --repo "$REPOSITORY" --state merged --head "$branch" --json number --jq 'length')"
-                branch_sha="$(git rev-parse "origin/${branch}")"
+            > "$RUNNER_TEMP/branches.txt"
 
-                if [ "$open_pr" -gt 0 ] || [ "$merged_pr" -gt 0 ]; then
-                  echo "Skipping ${branch}: a pull request already exists or was previously merged."
-                  continue
-                fi
+          while read -r branch; do
+            if [ "$branch" = "HEAD" ] || [ "$branch" = "$BASE_BRANCH" ]; then
+              continue
+            fi
 
-                # An ancestor of the base branch has nothing to contribute; a PR
-                # for it would be empty.
-                if git merge-base --is-ancestor "$branch_sha" "$base_sha"; then
-                  echo "Skipping ${branch}: it is already contained in ${BASE_BRANCH}."
-                  continue
-                fi
+            open_pr="$(gh pr list --repo "$REPOSITORY" --state open --head "$branch" --json number --jq 'length')"
+            # `merged` too: a branch whose PR was merged but which was never
+            # deleted would otherwise get a fresh PR opened on every sweep.
+            merged_pr="$(gh pr list --repo "$REPOSITORY" --state merged --head "$branch" --json number --jq 'length')"
+            branch_sha="$(git rev-parse "origin/${branch}")"
 
-                echo "Creating PR for ${branch} -> ${BASE_BRANCH}"
-                gh pr create \
-                  --repo "$REPOSITORY" \
-                  --head "$branch" \
-                  --base "$BASE_BRANCH" \
-                  --title "Merge ${branch} into ${BASE_BRANCH}" \
-                  --body "Automated pull request for branch \`${branch}\`."
-              done
+            if [ "$open_pr" -gt 0 ] || [ "$merged_pr" -gt 0 ]; then
+              echo "Skipping ${branch}: a pull request already exists or was previously merged."
+              continue
+            fi
+
+            # An ancestor of the base branch has nothing to contribute; a PR
+            # for it would be empty.
+            if git merge-base --is-ancestor "$branch_sha" "$base_sha"; then
+              echo "Skipping ${branch}: it is already contained in ${BASE_BRANCH}."
+              continue
+            fi
+
+            echo "Creating PR for ${branch} -> ${BASE_BRANCH}"
+            gh pr create \
+              --repo "$REPOSITORY" \
+              --head "$branch" \
+              --base "$BASE_BRANCH" \
+              --title "Merge ${branch} into ${BASE_BRANCH}" \
+              --body "Automated pull request for branch \`${branch}\`." \
+              || echo "Could not open a PR for ${branch}."
+          done < "$RUNNER_TEMP/branches.txt"

--- a/starter-templates/template-git-repo/.github/workflows/auto-merge-and-create-prs.yml
+++ b/starter-templates/template-git-repo/.github/workflows/auto-merge-and-create-prs.yml
@@ -24,8 +24,8 @@ jobs:
   maintain-pull-requests:
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ secrets.GIT_TOKEN }}
-      GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
+      GH_TOKEN: ${{ secrets.GIT_TOKEN || secrets.GITHUB_TOKEN }}
+      GIT_TOKEN: ${{ secrets.GIT_TOKEN || secrets.GITHUB_TOKEN }}
       BASE_BRANCH: ${{ github.event.repository.default_branch }}
     steps:
       - name: Merge eligible existing pull requests
@@ -41,15 +41,21 @@ jobs:
             --repo "$REPOSITORY" \
             --state open \
             --json number,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup \
-            --jq '.[] | select(.isDraft == false) | select(.mergeStateStatus == "CLEAN") | select((.reviewDecision == "APPROVED") or (.reviewDecision == "")) | select(all(.statusCheckRollup[]?; (.conclusion == "SUCCESS" or .conclusion == "SKIPPED" or .conclusion == "NEUTRAL"))) | .number' \
-          | while read -r pr_number; do
-              echo "Attempting to merge PR #${pr_number}"
-              gh pr merge "$pr_number" \
-                --repo "$REPOSITORY" \
-                --merge \
-                --delete-branch \
-                --auto || echo "Could not merge PR #${pr_number}; it may require review, checks, or conflict resolution."
-            done
+            --jq '.[] | select(.isDraft == false) | select(.mergeStateStatus == "CLEAN") | select((.reviewDecision // "") as $decision | $decision == "APPROVED" or $decision == "") | select(all(.statusCheckRollup[]?; (.conclusion == "SUCCESS" or .conclusion == "SKIPPED" or .conclusion == "NEUTRAL"))) | .number' \
+            > "$RUNNER_TEMP/mergeable-prs.txt"
+
+          # The numbers go through a file rather than a pipe: a piped `while`
+          # runs in a subshell that shares its stdin with `gh`, and a pipeline
+          # under `pipefail` fails the step for a producer that merely had
+          # nothing to say.
+          while read -r pr_number; do
+            echo "Attempting to merge PR #${pr_number}"
+            gh pr merge "$pr_number" \
+              --repo "$REPOSITORY" \
+              --merge \
+              --delete-branch \
+              --auto || echo "Could not merge PR #${pr_number}; it may require review, checks, or conflict resolution."
+          done < "$RUNNER_TEMP/mergeable-prs.txt"
 
       - name: Create pull requests for branches without one
         env:
@@ -67,30 +73,41 @@ jobs:
 
           base_sha="$(git rev-parse "origin/${BASE_BRANCH}")"
 
+          # Not `for-each-ref | grep | while`: `grep` exits 1 when it filters
+          # every ref out, and `pipefail` turns that into a failed run on the
+          # ordinary "only the default branch is left" case. The refs go
+          # through a file, and the ones to leave alone are skipped inside the
+          # loop, so an empty list is a no-op.
           git for-each-ref --format='%(refname:strip=3)' refs/remotes/origin \
-            | grep -Ev "^(HEAD|${BASE_BRANCH})$" \
-            | while read -r branch; do
-                open_pr="$(gh pr list --repo "$REPOSITORY" --state open --head "$branch" --json number --jq 'length')"
-                merged_pr="$(gh pr list --repo "$REPOSITORY" --state merged --head "$branch" --json number --jq 'length')"
-                branch_sha="$(git rev-parse "origin/${branch}")"
+            > "$RUNNER_TEMP/branches.txt"
 
-                # A merged PR counts: reopening one for a branch whose work
-                # already landed would create an empty, permanently open PR.
-                if [ "$open_pr" -gt 0 ] || [ "$merged_pr" -gt 0 ]; then
-                  echo "Skipping ${branch}: a pull request already exists or was previously merged."
-                  continue
-                fi
+          while read -r branch; do
+            if [ "$branch" = "HEAD" ] || [ "$branch" = "$BASE_BRANCH" ]; then
+              continue
+            fi
 
-                if git merge-base --is-ancestor "$branch_sha" "$base_sha"; then
-                  echo "Skipping ${branch}: it is already contained in ${BASE_BRANCH}."
-                  continue
-                fi
+            open_pr="$(gh pr list --repo "$REPOSITORY" --state open --head "$branch" --json number --jq 'length')"
+            merged_pr="$(gh pr list --repo "$REPOSITORY" --state merged --head "$branch" --json number --jq 'length')"
+            branch_sha="$(git rev-parse "origin/${branch}")"
 
-                echo "Creating PR for ${branch} -> ${BASE_BRANCH}"
-                gh pr create \
-                  --repo "$REPOSITORY" \
-                  --head "$branch" \
-                  --base "$BASE_BRANCH" \
-                  --title "Merge ${branch} into ${BASE_BRANCH}" \
-                  --body "Automated pull request for branch \`${branch}\`."
-              done
+            # A merged PR counts: reopening one for a branch whose work
+            # already landed would create an empty, permanently open PR.
+            if [ "$open_pr" -gt 0 ] || [ "$merged_pr" -gt 0 ]; then
+              echo "Skipping ${branch}: a pull request already exists or was previously merged."
+              continue
+            fi
+
+            if git merge-base --is-ancestor "$branch_sha" "$base_sha"; then
+              echo "Skipping ${branch}: it is already contained in ${BASE_BRANCH}."
+              continue
+            fi
+
+            echo "Creating PR for ${branch} -> ${BASE_BRANCH}"
+            gh pr create \
+              --repo "$REPOSITORY" \
+              --head "$branch" \
+              --base "$BASE_BRANCH" \
+              --title "Merge ${branch} into ${BASE_BRANCH}" \
+              --body "Automated pull request for branch \`${branch}\`." \
+              || echo "Could not open a PR for ${branch}."
+          done < "$RUNNER_TEMP/branches.txt"


### PR DESCRIPTION
## What was failing

[Run #1 of `Auto-merge PRs and create missing PRs`](https://github.com/OpenSourceAGI/dev-tools-starter-agent/actions/runs/34432009146/job/102729292346) ended with `Run set -euo pipefail` / `Error: Process completed with exit code 1` and **no command output at all**. The exit happened in the second step, whose only silent failure mode is this pipeline:

```bash
git for-each-ref --format='%(refname:strip=3)' refs/remotes/origin \
  | grep -Ev "^(HEAD|${BASE_BRANCH})$" \
  | while read -r branch; do
```

`grep` exits 1 when it filters every ref out — the ordinary "only the default branch is left, nothing needs a PR" case — and `set -o pipefail` turns that into a failed job. The sweep went red precisely when it had nothing to do.

Confirmed by extracting the old step and running it against a local repo containing only a default branch: exit 1, no output. The fixed step in the same harness: exit 0.

## The fix

Both steps now write their list to a file under `$RUNNER_TEMP` and read the loop from it, so an empty list is a no-op and the loop body no longer shares its stdin with `gh`.

Two related bugs found alongside it:

- **Unreviewed PRs were never merged.** `reviewDecision` comes back as JSON `null` for a PR with no review, so `.reviewDecision == ""` never matched. Now compares `(.reviewDecision // "")`.
- **One bad branch aborted the sweep.** A failing `gh pr create` now logs and continues, and `GH_TOKEN`/`GIT_TOKEN` fall back to `secrets.GITHUB_TOKEN` when no `GIT_TOKEN` secret is set.

Applied to the repo's own workflow and to both shipped copies of it (`packages/template-git-repo/template/`, `starter-templates/template-git-repo/`), so generated repos don't inherit the same red sweep.

## Verification

- Simulated both steps against a local git repo with a stubbed `gh`: new branch → PR created; branch with a merged PR → skipped; ancestor of base → skipped; only-the-default-branch → clean exit; 0 and 2 eligible PRs → correct merge attempts.
- Old step reproduced the exit 1 on the only-default-branch case; new step exits 0.
- jq filter checked against sample PR JSON: unreviewed / empty / approved pass; changes-requested, draft, `BLOCKED`, failing and pending checks are excluded.
- `bash -n` and YAML parse clean on all three files; `packages/template-git-repo` vitest suite passes (107 tests), including the workflow-validity checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wuf3AVUqtC5bZkKi6qtfsF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wuf3AVUqtC5bZkKi6qtfsF)_