### PR TITLE
Add legal-terms-privacy-policy package (unblocks the rights.institute build)

### DIFF
--- a/packages/legal-terms-privacy-policy/cli.mjs
+++ b/packages/legal-terms-privacy-policy/cli.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * Print a configured Terms of Service + Privacy Policy as Markdown, HTML or
+ * plain text — for a repo's `TERMS.md`, a static page, or a diff of what a
+ * config change does to the policy text.
+ *
+ * @example
+ * ```sh
+ * npx legal-terms-privacy-policy --app-name Acme --variant full > TERMS.md
+ * npx legal-terms-privacy-policy --app-name Acme --format html --standalone \
+ *   --no-part california --exclude social-features > terms.html
+ * ```
+ */
+import { register } from 'node:module';
+
+register('./ts-loader.mjs', import.meta.url);
+
+const { renderMarkdown, renderHtml, renderText, resolveLegalDoc } = await import(
+  new URL('./src/index.ts', import.meta.url).href
+);
+
+const USAGE = `
+legal-terms-privacy-policy — print a configurable Terms of Service + Privacy Policy
+
+Usage:
+  legal-terms-privacy-policy [options]
+
+Document:
+  --variant <summary|full>    Which presentation to print (default: full)
+  --format <markdown|html|text|json>
+                              Output format (default: markdown)
+  --standalone                For --format html, emit a full page with styles
+
+Values substituted into the text:
+  --app-name <name>           Product name (default: Our Service)
+  --company-name <name>       Legal entity (default: same as --app-name)
+  --contact-email <email>     Address for legal and privacy requests
+  --home-url <url>            Target of the "Back to Home" link
+  --last-revised <date>       Revision date shown under the title
+  --effective-date <date>     Effective date (default: same as --last-revised)
+  --jurisdiction <region>     Region the Services are offered in
+  --minimum-age <n>           Minimum age to hold an account
+  --children-age <n>          COPPA age threshold
+  --deletion-days <n>         Days to purge data after account deletion
+
+Choosing what appears:
+  --no-part <id>              Drop a named part; repeatable. One of:
+                              ai, privacy, cookies, california, children,
+                              security, thirdParty
+  --part <id>                 Force a part back on; repeatable
+  --include <id>              Keep only these section ids; repeatable
+  --exclude <id>              Drop these section ids; repeatable
+  --order <id,id,...>         Put these sections first, in this order
+  --no-numbers                Do not number the full-text sections
+  --title <text>              Override the document title
+
+  --list-sections             Print the section ids of the chosen variant
+  -h, --help                  Show this help
+`.trim();
+
+const PART_IDS = new Set([
+  'ai',
+  'privacy',
+  'cookies',
+  'california',
+  'children',
+  'security',
+  'thirdParty',
+]);
+
+function parseArgs(argv) {
+  const options = { parts: {}, include: [], exclude: [] };
+  let format = 'markdown';
+  let standalone = false;
+  let listSections = false;
+
+  /** Flags that take the next argv entry as their value. */
+  const valueFlags = {
+    '--variant': 'variant',
+    '--app-name': 'appName',
+    '--company-name': 'companyName',
+    '--contact-email': 'contactEmail',
+    '--home-url': 'homeUrl',
+    '--last-revised': 'lastRevisedDate',
+    '--effective-date': 'effectiveDate',
+    '--jurisdiction': 'jurisdiction',
+    '--minimum-age': 'minimumAge',
+    '--children-age': 'childrenAge',
+    '--deletion-days': 'dataDeletionDays',
+    '--title': 'title',
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '-h' || arg === '--help') {
+      console.log(USAGE);
+      process.exit(0);
+    } else if (arg === '--list-sections') {
+      listSections = true;
+    } else if (arg === '--standalone') {
+      standalone = true;
+    } else if (arg === '--no-numbers') {
+      options.features = { ...options.features, numbered: false };
+    } else if (arg === '--format') {
+      format = argv[++i];
+    } else if (arg === '--no-part' || arg === '--part') {
+      const id = argv[++i];
+      if (!PART_IDS.has(id)) {
+        console.error(`Unknown part "${id}". Expected one of: ${[...PART_IDS].join(', ')}`);
+        process.exit(1);
+      }
+      options.parts[id] = arg === '--part';
+    } else if (arg === '--include') {
+      options.include.push(argv[++i]);
+    } else if (arg === '--exclude') {
+      options.exclude.push(argv[++i]);
+    } else if (arg === '--order') {
+      options.order = argv[++i].split(',').map((s) => s.trim()).filter(Boolean);
+    } else if (valueFlags[arg]) {
+      options[valueFlags[arg]] = argv[++i];
+    } else {
+      console.error(`Unknown option "${arg}". Run with --help for usage.`);
+      process.exit(1);
+    }
+  }
+  return { options, format, standalone, listSections };
+}
+
+const { options, format, standalone, listSections } = parseArgs(process.argv.slice(2));
+
+if (listSections) {
+  const doc = resolveLegalDoc(options);
+  for (const section of doc.sections) {
+    console.log(section.id);
+    for (const sub of section.subsections ?? []) console.log(`  ${sub.id}`);
+  }
+  process.exit(0);
+}
+
+switch (format) {
+  case 'markdown':
+  case 'md':
+    process.stdout.write(renderMarkdown(options));
+    break;
+  case 'html':
+    process.stdout.write(renderHtml(options, { standalone }) + '\n');
+    break;
+  case 'text':
+  case 'txt':
+    process.stdout.write(renderText(options));
+    break;
+  case 'json':
+    process.stdout.write(JSON.stringify(resolveLegalDoc(options), null, 2) + '\n');
+    break;
+  default:
+    console.error(`Unknown format "${format}". Expected markdown, html, text or json.`);
+    process.exit(1);
+}

--- a/packages/legal-terms-privacy-policy/package-lock.json
+++ b/packages/legal-terms-privacy-policy/package-lock.json
@@ -1,0 +1,1535 @@
+{
+  "name": "legal-terms-privacy-policy",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "legal-terms-privacy-policy",
+      "version": "0.1.0",
+      "license": "rights.institute/prosper",
+      "bin": {
+        "legal-terms-privacy-policy": "cli.mjs"
+      },
+      "devDependencies": {
+        "@types/react": "^19.2.0",
+        "@types/react-dom": "^19.2.0",
+        "@vitest/coverage-v8": "^4.1.0",
+        "lucide-react": "^1.43.0",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.0"
+      },
+      "peerDependencies": {
+        "lucide-react": ">=0.4.0",
+        "react": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "lucide-react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.149.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.149.0.tgz",
+      "integrity": "sha512-Efcc+iF0j3Bf67YjEqIqWXbX5XddXoK/Mw4K1/JuXwRCZ8N16VR7iT23nlCc9XrveFVh/E5Rqs2StT0V8v9LdA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/oxc-project"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.8.tgz",
+      "integrity": "sha512-tN5aztYkKCte4i5SIrrz5yK/HMjEuCqCSCJa418jOV8tZ1cBY3YF2otxB1ktPxzsLA1BeTqwapK0bfjxNvHJVw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.8.tgz",
+      "integrity": "sha512-dIYTWl9XprMUiQFoc55KUyk/oS8SKYH3zFl0LTR7RT0Xj4hgSVyuJcroH8JUu8RcpF8fTB6E0aOwCkZoYPcDSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.8.tgz",
+      "integrity": "sha512-PCSDQGXD2IyTEFrcgPyBM8jJuGmrbCMuoIOXdbEGVemruKACXoLQJrb+A45Z0L5t1RQkdfJprAYPkikbh7dzdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.8.tgz",
+      "integrity": "sha512-Uk7lRsGhPFHVX/sAUC6D5H9Ol30dFHd6iquokll2th3LpdJ3F5CzQB+7DHn0Ri2mG+U7k2zXiPHDrwZenXhwSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.8.tgz",
+      "integrity": "sha512-DjszaTEVogPqA5bYzsEeqDCQxbcp2fexQwKcRspYji2yzR68fCf+e4fx6kBSRDwX5/brZaHw/hWS9+A/+/w9sQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.8.tgz",
+      "integrity": "sha512-zmwa7FTmdzB6aaEEuuls18H6Ap5JmJPSoPTuXixeJZV6tG40SyLkApQtz1g8ptZtiEKqj9OM0oNLPh1AgvE31Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.8.tgz",
+      "integrity": "sha512-KdYQDPHwJVnbFwdTGMgxsI9SqblBlz6STGM+w1We/d5B8OWWidYH0MwkU/uA1wM5fIpO2MkOVxXrNzzuZhw9ew==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.8.tgz",
+      "integrity": "sha512-jFJTifHnNPY+yzOoNZQfSIysrVyXzEQPhPnOUjmD1bcQGHH6s7c8cViKWar8YplQImE5N9JRqMCLrM2CdxOrZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.8.tgz",
+      "integrity": "sha512-FhiOziBDWPBjbcmRzfLyIJnaP7AVMFXT7YCXPjXxj7wKU3vx24RjrCNN/zjvVa+N2vVoHJwCoUBvsrN/DG3zIA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.8.tgz",
+      "integrity": "sha512-WnHfADMzOV2Y55wlx1hzzQnar/wDt/VdvWSD99r18Mz9ylNieIGOkRx3UV21h7m/eJvjySYJkO26VvGNFkwsIQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.8.tgz",
+      "integrity": "sha512-H9tRr5ibfXFVLxbPOseVewewFpl28zcEdjRDt2FTUZU7odxP0gEv1ki4/kGmcGOh78oRwZuuQllGLZ9zTJp84g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.8.tgz",
+      "integrity": "sha512-UefiqfM3D6IVNlZ8tSGs9+Ejjud2T+oxO0IHADU45Y+lyEjD2dVFyZHbkfX0LUb5Zugo/oIv1eCO/KVYhgYJYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.8.tgz",
+      "integrity": "sha512-637Ke4kWSy6rp9cxQ9gMOXlxPgIw/c1beASV4M//3+9I4uwBVOOl74G+e3zyU3u19U7RkRl/HuewixZ/Z6+Rjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.8.tgz",
+      "integrity": "sha512-xWBkPOF1Q9k/Gv1nQXnVdLxKu74jXppuOM4Z3mnypVUJJJwLsMl7hNJGRAUJoG8A5MgOI1ACKM+wBFxSJzKy4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.8.tgz",
+      "integrity": "sha512-uz2ZvfgXbxqNwijjjbxrnvALwpyODDcgc1T1N8N3rf/DXKQmaFwmB4LX4yyjggpwN2obdQLb2rgirX5ffCWYng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.3.0.tgz",
+      "integrity": "sha512-N0rFCuH9YoxG9/m61l9MfpJKfmLOVU0em7ipIz6TRgSSkvReLB9vL85GB+yr8Bs5leqpvg96JSwF4ZS1s4viQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.3.0.tgz",
+      "integrity": "sha512-ZI7bU42mZXXKHn/qNLEw2IrbiINU7X5+vfgdixBHkCNpYWXjKgfQ/P+uyGb5CjOLB9UcnTeg3rylQtV2hym44Q==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.3.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.11.tgz",
+      "integrity": "sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.11",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.11",
+        "vitest": "4.1.11"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.6.tgz",
+      "integrity": "sha512-fvpl29helSO2w/z7utIbrkNXILdrLwDwAMH2I/zPKlGf5244+gf+B4cyS1sANcrPY2h+hWCGSgC8N61s/+AF9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.44.0.tgz",
+      "integrity": "sha512-2egNApH4hX4j/qdCgRublh88+9u3mEhz9iSlW5ckm4kaQEqZbXbMr0l5u5JZLy8nmWRx2dbHGQkEDYz6C9aCgw==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.5.tgz",
+      "integrity": "sha512-UicdXN8zQ3JHlxVq+28afMXPr1z7WNY6+7EJnzTdQWkTAlMLF5fNCCKxJHBQwGaNGR11581EiQmQzx73+MvszA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.19",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.19.tgz",
+      "integrity": "sha512-Y2tUNy4ouw6tq5oDSKeQYGOyhkUBhNOcGV/02KC+6kd9eDGqdZd++mjMiIDilrBYvjEnCYvVtsuHCuP+okSfug==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.2.1.tgz",
+      "integrity": "sha512-XrsrhT5sybtKI6wakr2SPOlGZWWYbUXZ7a0jT8/QOeAPau+1X/bSegNe5YR75oJmEZQbKningirmGOEJCIk61Q==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.18",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.3.0.tgz",
+      "integrity": "sha512-E8LUcbtBWt20bbl2YoHfx4ZDBdxVTfOKtCZn9cDSJ4l6/nuoApcpIBcj47t2wZoVX8g2ZHuMHbiShgCR1T5Sog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.3.0.tgz",
+      "integrity": "sha512-JDk8dgif51OjFoDE70+OT9ICyYr+69HlmihNwp1+Nsfbna3t5sIiCa9ZJktDmQ4/1b/rn26hIAR2uYXDMr5r0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.28.0"
+      },
+      "peerDependencies": {
+        "react": "^19.3.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.8.tgz",
+      "integrity": "sha512-Z67nTmhZe7anqnM/EjI392w5i/ANUinjip7QYsOyN37oayduxt3ksdX0hf5OOamkAd53BiIHfbfSzfUmzKFQqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.149.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm-eabi": "1.2.8",
+        "@rolldown/binding-android-arm64": "1.2.8",
+        "@rolldown/binding-darwin-arm64": "1.2.8",
+        "@rolldown/binding-darwin-x64": "1.2.8",
+        "@rolldown/binding-freebsd-x64": "1.2.8",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.8",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.8",
+        "@rolldown/binding-linux-arm64-musl": "1.2.8",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.8",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.8",
+        "@rolldown/binding-linux-x64-gnu": "1.2.8",
+        "@rolldown/binding-linux-x64-musl": "1.2.8",
+        "@rolldown/binding-openharmony-arm64": "1.2.8",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.8",
+        "@rolldown/binding-win32-x64-msvc": "1.2.8"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.28.0.tgz",
+      "integrity": "sha512-juorfCmIkIw8tT+p5BXSm6PJjQF/ycEYmKyzURCIt/RaZIhL+PulbQ9Yu2z1HdOJDdqDTlxA1+xKBmHXJsczAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.1.tgz",
+      "integrity": "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.3.0.tgz",
+      "integrity": "sha512-lhZBVvEHefgE+HQZC9O7EBJgCU/nVzFNl7vkS4RE0APtWLP02/8QVIkQtzBxPquh7lq5/78NHipTj7ODQ6XuyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.7",
+        "postcss": "^8.5.28",
+        "rolldown": "~1.2.6",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.7.1",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/packages/legal-terms-privacy-policy/package.json
+++ b/packages/legal-terms-privacy-policy/package.json
@@ -1,0 +1,80 @@
+{
+  "name": "legal-terms-privacy-policy",
+  "version": "0.1.0",
+  "description": "Configurable Terms of Service and Privacy Policy \u2014 a scannable summary and the full legal text, with every section addable, removable and reorderable. React page, plus Markdown/HTML/text renderers and a CLI.",
+  "type": "module",
+  "author": "vtempest",
+  "license": "rights.institute/prosper",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "module": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "require": "./src/index.ts"
+    },
+    "./react": {
+      "types": "./src/react/index.ts",
+      "import": "./src/react/index.ts"
+    },
+    "./content/full": "./src/content/full.ts",
+    "./content/summary": "./src/content/summary.ts",
+    "./package.json": "./package.json",
+    "./*": "./src/*"
+  },
+  "bin": {
+    "legal-terms-privacy-policy": "./cli.mjs"
+  },
+  "files": [
+    "src",
+    "cli.mjs",
+    "readme.md"
+  ],
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "demo": "node cli.mjs --app-name 'Example App' --variant full --format markdown",
+    "pub": "npm version patch && npm publish"
+  },
+  "keywords": [
+    "terms-of-service",
+    "privacy-policy",
+    "legal",
+    "gdpr",
+    "ccpa",
+    "coppa",
+    "compliance",
+    "react",
+    "nextjs"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OpenSourceAGI/dev-tools-starter-agent.git",
+    "directory": "packages/legal-terms-privacy-policy"
+  },
+  "homepage": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/legal-terms-privacy-policy",
+  "peerDependencies": {
+    "lucide-react": ">=0.4.0",
+    "react": ">=18"
+  },
+  "peerDependenciesMeta": {
+    "lucide-react": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.0",
+    "@vitest/coverage-v8": "^4.1.0",
+    "lucide-react": "^1.43.0",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/legal-terms-privacy-policy/package.json
+++ b/packages/legal-terms-privacy-policy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "legal-terms-privacy-policy",
   "version": "0.1.0",
-  "description": "Configurable Terms of Service and Privacy Policy \u2014 a scannable summary and the full legal text, with every section addable, removable and reorderable. React page, plus Markdown/HTML/text renderers and a CLI.",
+  "description": "Configurable Terms of Service and Privacy Policy — a scannable summary and the full legal text, with every section addable, removable and reorderable. React page, plus Markdown/HTML/text renderers and a CLI.",
   "type": "module",
   "author": "vtempest",
   "license": "rights.institute/prosper",
@@ -70,6 +70,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
     "@vitest/coverage-v8": "^4.1.0",
     "lucide-react": "^1.43.0",
     "react": "^19.2.8",

--- a/packages/legal-terms-privacy-policy/readme.md
+++ b/packages/legal-terms-privacy-policy/readme.md
@@ -1,0 +1,226 @@
+<!-- template-git-repo:badges:start -->
+<p align="center">
+    <a href="https://starterdocs.vtempest.workers.dev/docs/packages/legal-terms-privacy-policy"><img src="https://img.shields.io/badge/Docs-blue?logo=ReadTheDocs&logoColor=white" alt="Documentation" /></a>
+    <a href="https://stackblitz.com/github/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/legal-terms-privacy-policy"><img height="20px" src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt="Open in StackBlitz" /></a>
+    <br />
+    <a href="https://www.npmjs.com/package/legal-terms-privacy-policy"><img src="https://img.shields.io/npm/dm/legal-terms-privacy-policy.svg" alt="NPM Monthly Downloads" /></a>
+    <a href="https://www.npmjs.com/package/legal-terms-privacy-policy"><img src="https://img.shields.io/npm/v/legal-terms-privacy-policy.svg" alt="npm version" /></a>
+    <a href="https://www.npmjs.com/package/legal-terms-privacy-policy"><img src="https://img.shields.io/npm/dt/legal-terms-privacy-policy.svg" alt="NPM Total Downloads" /></a>
+    <a href="https://www.npmjs.com/package/legal-terms-privacy-policy"><img src="https://img.shields.io/npm/types/legal-terms-privacy-policy" alt="TypeScript types" /></a>
+    <a href="https://packagephobia.com/result?p=legal-terms-privacy-policy"><img src="https://packagephobia.com/badge?p=legal-terms-privacy-policy" alt="Install size" /></a>
+</p>
+<!-- template-git-repo:badges:end -->
+
+<!-- skills:install:start -->
+**🤖 Agent skill** — `npx skills@latest add https://github.com/OpenSourceAGI/dev-tools-starter-agent --skill legal-terms-privacy-policy` ([what it covers](../../skills/legal-terms-privacy-policy/SKILL.md))
+<!-- skills:install:end -->
+
+# legal-terms-privacy-policy
+
+One combined **Terms of Service + Privacy Policy**, in two presentations of the same policy, with every section addable, removable and reorderable from config.
+
+- **Summary** — the scannable card-and-icon layout published at [rights.institute/terms-privacy](https://rights.institute/terms-privacy).
+- **Full text** — the long-form legal document published by QwkSearch, Debate AI and AI Broker.
+
+Ship both and let readers switch between them, or pin a page to one. Nothing in the package needs editing to adopt it: the product name, contact address, dates, which clauses appear and in what order all come from props.
+
+> Not legal advice. This is boilerplate to start from — have a lawyer review the text you publish.
+
+## Install
+
+```sh
+npm install legal-terms-privacy-policy
+```
+
+The package ships TypeScript source rather than a build output, matching the other packages in this monorepo. In a Next.js app, add it to `transpilePackages`:
+
+```js
+// next.config.js
+export default { transpilePackages: ['legal-terms-privacy-policy'] };
+```
+
+`react` and `lucide-react` are optional peers — needed only for the React page, not for the Markdown/HTML/text renderers or the CLI.
+
+## React page
+
+```tsx
+import { LegalTermsPrivacyPolicy } from 'legal-terms-privacy-policy/react';
+
+export default function TermsPage() {
+  return (
+    <LegalTermsPrivacyPolicy
+      appName="QwkSearch"
+      contactEmail="legal@qwksearch.com"
+      lastRevisedDate="March 1, 2026"
+      defaultVariant="full"
+    />
+  );
+}
+```
+
+The component renders the whole page — back link, title, badges, revision date, the summary ⇄ full-text switch, section navigation and the body. It is Tailwind-styled and works in light and dark.
+
+### Controlling the variant
+
+Uncontrolled, the switch keeps its own state starting from `defaultVariant`. Pass `variant` and `onVariantChange` to drive it from the URL instead:
+
+```tsx
+'use client';
+const [variant, setVariant] = useState<Variant>('summary');
+<LegalTermsPrivacyPolicy variant={variant} onVariantChange={setVariant} appName="Acme" />;
+```
+
+To publish only one presentation, set `variant` and turn the switch off:
+
+```tsx
+<LegalTermsPrivacyPolicy appName="Acme" variant="full" features={{ variantSwitch: false }} />
+```
+
+## Configuration
+
+Every option below works the same way in the React component, the renderers and the CLI.
+
+### Values substituted into the text
+
+The legal text carries `{{token}}` placeholders. Unknown tokens are left visible rather than blanked, so a typo shows up on the page instead of silently deleting a clause.
+
+| Option | Default | Appears in |
+| --- | --- | --- |
+| `appName` | `"Our Service"` | Throughout |
+| `companyName` | same as `appName` | Liability, contact, footer |
+| `contactEmail` | `"legal@example.com"` | Accounts, retention, contact |
+| `homeUrl` | `"/"` | "Back to Home" link |
+| `lastRevisedDate` | `"January 1, 2025"` | Under the title |
+| `effectiveDate` | same as `lastRevisedDate` | Under the title |
+| `jurisdiction` | `"the United States"` | Introduction |
+| `minimumAge` | `18` | Acceptance of Terms |
+| `childrenAge` | `13` | Children's Privacy |
+| `dataDeletionDays` | `30` | Data Security and Retention |
+| `tokens` | `{}` | Extra placeholders for your own sections |
+
+### Adding and removing parts
+
+`parts` switches named groups of clauses on or off in one go:
+
+```tsx
+<LegalTermsPrivacyPolicy
+  appName="Grab URL"
+  parts={{ ai: false, california: false }}   // no model in the loop, no CA notice
+/>
+```
+
+| Part | Covers |
+| --- | --- |
+| `core` | Introduction, changes, accounts, use, materials, feedback, warranties, termination, contact. Always on — switching it off is ignored. |
+| `ai` | The Artificial Intelligence Ethical Use Policy and AI-specific clauses |
+| `privacy` | Collection, use, disclosure and retention of personal data |
+| `cookies` | Cookies, tracking technologies and Do Not Track |
+| `california` | The CCPA/CPRA resident notice |
+| `children` | The COPPA under-13 notice |
+| `security` | Security measures and data retention |
+| `thirdParty` | Third-party links and social features |
+
+For finer control, work by section id — `include` keeps only what you name, `exclude` drops it, and both reach subsections:
+
+```tsx
+exclude={['social-features', 'california-selling']}
+include={['introduction', 'privacy-policy', 'contact']}
+```
+
+Naming a parent in `include` keeps its whole subtree (`['ai-ethics']` is the section and its four sub-policies); naming only a child keeps the parent as its heading (`['california-rights']` renders under "California Residents"). `exclude` still applies inside an included parent.
+
+Run `npx legal-terms-privacy-policy --list-sections` (add `--variant summary`) to see every id.
+
+### Rewriting and adding sections
+
+`replace` patches a section by id, merging over the built-in one — pass only the fields you are changing:
+
+```tsx
+replace={{
+  contact: { blocks: [{ type: 'p', text: 'Write to {{companyName}}, 1 Main St.' }] },
+  'california-selling': { title: 'We Do Not Sell Your Data' },
+}}
+```
+
+`add` inserts your own sections, anchored to an existing one:
+
+```tsx
+add={[{
+  after: 'termination',
+  section: {
+    id: 'arbitration',
+    title: 'Arbitration and Governing Law',
+    icon: 'Scale',
+    accent: 'slate',
+    blocks: [
+      { type: 'p', text: 'Disputes with {{companyName}} are resolved by binding arbitration.' },
+      { type: 'ul', lead: 'Exceptions:', items: ['Small claims court', 'Injunctive relief'] },
+    ],
+  },
+}]}
+```
+
+Anchors are `after`, `before` or `at` (an index); with none of them, the section is appended. `order` puts named sections first, in the order given, and leaves the rest in place.
+
+### Block types
+
+Sections hold `blocks`, so caller-authored content renders in every format:
+
+| Block | Shape |
+| --- | --- |
+| `p` | `{ type: 'p', text, strong? }` |
+| `ol` / `ul` | `{ type: 'ol', lead?, items }` — items are strings or `{ text, items }` for one nested level |
+| `cards` | `{ type: 'cards', columns?: 1-4, center?, items: [{ title, text?, items?, icon? }] }` |
+| `note` | `{ type: 'note', title?, text?, items?, icon? }` |
+
+Card and note blocks render as tinted tiles in the summary variant and flatten to headings and lists in the full-text variant, so you only write them once. `icon` names a [lucide](https://lucide.dev) icon; unknown names fall back to a document glyph, or pass your own components through the `icons` prop.
+
+### Chrome
+
+`features` toggles the page furniture: `backLink`, `sidebar`, `tableOfContents`, `copyButtons`, `badges`, `variantSwitch`, `footer`, `numbered`. `badges` (the array) sets the compliance pills — `['GDPR Compliant', 'CCPA Compliant', 'Cookie Policy']` by default; pass `[]` to drop them.
+
+## Rendering without React
+
+```ts
+import { renderMarkdown, renderHtml, renderText, resolveLegalDoc } from 'legal-terms-privacy-policy';
+
+const config = { appName: 'Acme', contactEmail: 'legal@acme.com', parts: { ai: false } };
+
+renderMarkdown(config);                      // TERMS.md, MDX docs page
+renderHtml(config, { standalone: true });    // complete styled page
+renderText(config);                          // email, CLI, in-app agreement dialog
+resolveLegalDoc(config).sections;            // the resolved tree, to render yourself
+```
+
+`LEGAL_CSS` is exported for pairing with the HTML fragment. Interpolated values are HTML-escaped, and emails and URLs in the text become links.
+
+## CLI
+
+```sh
+npx legal-terms-privacy-policy --app-name Acme --variant full > TERMS.md
+
+npx legal-terms-privacy-policy \
+  --app-name Acme --contact-email legal@acme.com \
+  --format html --standalone \
+  --no-part california --exclude social-features > terms.html
+
+npx legal-terms-privacy-policy --list-sections --variant summary
+```
+
+`--format` takes `markdown`, `html`, `text` or `json`. Run `--help` for the full list.
+
+## Keeping the two variants honest
+
+The summary is a plain-language restatement; the full text is what binds. If you edit one, edit the other — `src/content/summary.ts` and `src/content/full.ts` are the two files to keep in step. Publishing a summary whose claims the full text does not support is the failure mode this package is shaped to avoid, which is why the switch is on by default.
+
+## Tests
+
+```sh
+npm test
+```
+
+Covers token substitution, part and id filtering, patching, insertion, ordering, and each renderer — including that neither variant ships an unsubstituted `{{token}}` and that interpolated values cannot inject markup.
+
+## License
+
+[PROSPER 1.0.0](https://rights.institute/prosper)

--- a/packages/legal-terms-privacy-policy/src/content/full.ts
+++ b/packages/legal-terms-privacy-policy/src/content/full.ts
@@ -1,0 +1,516 @@
+import type { Section } from '../types';
+
+/**
+ * The long-form combined Terms of Service and Privacy Policy — the text
+ * currently published by QwkSearch, Debate AI and AI Broker, lifted verbatim
+ * and tokenized.
+ *
+ * Section ids are stable and double as anchors; the `part` field groups them
+ * so callers can drop, say, every AI clause with `parts: { ai: false }`.
+ */
+export const FULL_SECTIONS: Section[] = [
+  {
+    id: 'introduction',
+    title: 'Introduction',
+    icon: 'BookOpen',
+    accent: 'emerald',
+    part: 'core',
+    blocks: [
+      {
+        type: 'p',
+        text: 'These Terms of Service ("Terms") govern your use of {{appName}}\'s products and services, along with any associated apps, software, and websites (together, our "Services"). These Terms are a contract between you and {{appName}}, and they include our Acceptable Use Policy. By accessing our Services, you agree to these Terms.',
+      },
+      {
+        type: 'p',
+        text: 'This document also describes how {{appName}} ("we", "us," "our") collects, uses and discloses information about individuals who use our websites, applications, services, tools and features, purchase our products or otherwise interact with us (collectively, the "Services"). For the purposes of this document, "you" and "your" means you as the user of the Services, whether you are a customer, website visitor, job applicant, representative of a company with whom we do business, or another individual whose information we have collected pursuant to this Privacy Policy. Please note that the Services are designed for users in {{jurisdiction}} only and are not intended for users located outside {{jurisdiction}}.',
+      },
+      {
+        type: 'p',
+        text: 'Please read this document carefully. By using any of the Services, you agree to the collection, use, and disclosure of your information as described in this document. If you do not agree to these terms, please do not use or access the Services.',
+      },
+    ],
+  },
+  {
+    id: 'changes',
+    title: 'Changes to These Terms',
+    icon: 'FileText',
+    accent: 'blue',
+    part: 'core',
+    blocks: [
+      {
+        type: 'p',
+        text: 'We may revise and update these Terms at our discretion. We may modify this document from time to time, in which case we will update the "Last Updated" date at the top of this document. If we make material changes to the way in which we use or disclose information we collect, we will use reasonable efforts to notify you (such as by emailing you at the last email address you provided us, by posting notice of such changes on the Services, or by other means consistent with applicable law) and will take additional steps as required by applicable law. If you continue to access the Services after we post the updated Terms, you agree to the updated Terms. If you do not agree to any updates to this document, please do not continue using or accessing the Services.',
+      },
+    ],
+  },
+  {
+    id: 'ai-ethics',
+    title: 'Artificial Intelligence Ethical Use Policy',
+    icon: 'Sparkles',
+    accent: 'purple',
+    part: 'ai',
+    subsections: [
+      {
+        id: 'ai-trust-but-verify',
+        title: 'Trust, But Verify Outputs',
+        icon: 'AlertTriangle',
+        part: 'ai',
+        blocks: [
+          {
+            type: 'ol',
+            lead: 'Artificial intelligence and large language models (LLMs) are frontier technologies that are still improving in accuracy, reliability and safety. When you use our Services, you acknowledge and agree:',
+            items: [
+              'Outputs may not always be accurate and may contain material inaccuracies even if they appear accurate because of their level of detail or specificity.',
+              'You should not rely on any Outputs without independently confirming their accuracy.',
+              'The Services and any Outputs may not reflect correct, current, or complete information.',
+            ],
+          },
+        ],
+      },
+      {
+        id: 'ai-privacy-protection',
+        title: 'Privacy Protection',
+        icon: 'Lock',
+        part: 'ai',
+        blocks: [
+          {
+            type: 'ol',
+            lead: "Don't compromise the privacy of others, including:",
+            items: [
+              'Collecting, processing, disclosing, inferring or generating personal data without complying with applicable legal requirements',
+              'Using biometric systems for identification or assessment, including facial recognition',
+              'Facilitating spyware, communications surveillance, or unauthorized monitoring of individuals',
+            ],
+          },
+        ],
+      },
+      {
+        id: 'ai-safety-rights',
+        title: 'Safety and Rights Protection',
+        icon: 'Shield',
+        part: 'ai',
+        blocks: [
+          {
+            type: 'ol',
+            lead: "Don't perform or facilitate activities that may significantly impair the safety, wellbeing, or rights of others, including:",
+            items: [
+              'Providing tailored legal, medical/health, or financial advice without review by a qualified professional and disclosure of the use of AI assistance and its potential limitations',
+              "Making high-stakes automated decisions in domains that affect an individual's safety, rights or well-being",
+              'Facilitating real money gambling or payday lending',
+              'Engaging in political campaigning or lobbying, including generating campaign materials personalized to or targeted at specific demographics',
+              'Deterring people from participation in democratic processes',
+            ],
+          },
+        ],
+      },
+      {
+        id: 'ai-truthfulness',
+        title: 'Truthfulness and Transparency',
+        icon: 'Eye',
+        part: 'ai',
+        blocks: [
+          {
+            type: 'ol',
+            lead: "Don't misuse our platform to cause harm by intentionally deceiving or misleading others, including:",
+            items: [
+              'Generating or promoting disinformation, misinformation, or false online engagement',
+              'Impersonating another individual or organization without consent or legal right',
+              'Engaging in or promoting academic dishonesty',
+              "Failing to ensure that automated systems disclose to people that they are interacting with AI, unless it's obvious from the context",
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'accounts',
+    title: 'Account Creation and Access',
+    icon: 'User',
+    accent: 'amber',
+    part: 'core',
+    blocks: [
+      {
+        type: 'p',
+        text: 'Your {{appName}} Account: To access our Services, we may ask you to create an Account. You agree to provide correct, current, and complete Account information. You may not share your Account login information with anyone else. You are responsible for all activity occurring under your Account.',
+      },
+      {
+        type: 'p',
+        text: 'You may close your Account at any time by contacting us at {{contactEmail}}.',
+      },
+    ],
+  },
+  {
+    id: 'use-of-services',
+    title: 'Use of Our Services',
+    icon: 'Globe',
+    accent: 'blue',
+    part: 'core',
+    blocks: [
+      {
+        type: 'p',
+        text: 'You may access and use our Services only in compliance with our Terms, our Acceptable Use Policy, and any guidelines or supplemental terms we may post on the Services (the "Permitted Use").',
+      },
+      {
+        type: 'p',
+        text: 'You may not access or use, or help another person to access or use, our Services in any manner that violates these Terms or applicable laws.',
+      },
+    ],
+  },
+  {
+    id: 'materials',
+    title: 'Prompts, Outputs, and Materials',
+    icon: 'FileText',
+    accent: 'indigo',
+    part: 'core',
+    blocks: [
+      {
+        type: 'p',
+        text: 'You may be allowed to submit text or other materials to our Services for processing (we call these "Prompts"). Our Services may generate responses based on your Prompts (we call these "Outputs"). Prompts and Outputs collectively are "Materials."',
+      },
+      {
+        type: 'p',
+        text: 'You are responsible for all Prompts you submit to our Services. By submitting Prompts, you represent and warrant that you have all necessary rights and permissions.',
+      },
+    ],
+  },
+  {
+    id: 'privacy-policy',
+    title: 'Privacy Policy',
+    icon: 'Shield',
+    accent: 'rose',
+    part: 'privacy',
+    blocks: [
+      {
+        type: 'p',
+        text: 'When you use or access the Services, we collect certain categories of information about you from a variety of sources.',
+      },
+    ],
+    subsections: [
+      {
+        id: 'information-you-provide',
+        title: 'Information You Provide to Us',
+        icon: 'User',
+        part: 'privacy',
+        blocks: [
+          {
+            type: 'ol',
+            lead: 'Some features of the Services may require you to directly provide us with certain information about yourself. You may elect not to provide this information, but doing so may prevent you from using or accessing these features. Information that you directly submit through our Services includes:',
+            items: [
+              'Basic contact details, such as name, address, phone number, and email. We use this information to provide the Services, and to communicate with you (including to tell you about certain promotions or products or services that may be of interest to you).',
+              'Account information, such as name, username (email) and password. We use this information to provide the Services and to maintain and secure your account with us. If you choose to register an account, you are responsible for keeping your account credentials safe. We recommend you do not share your access details with anyone else. If you believe your account has been compromised, please contact us immediately.',
+              'Your Input and Output, such as questions, prompts and other content that you input, upload or submit to the Services, and the output that you create. This content may constitute or contain personal information, depending on the substance and how it is associated with your account. We use this information to generate and output new content as part of the Services.',
+              'Any other information you choose to include in communications with us, for example, when sending a message through the Services or provide your size when purchasing certain products.',
+            ],
+          },
+        ],
+      },
+      {
+        id: 'information-collected-automatically',
+        title: 'Information We Collect Automatically',
+        icon: 'Settings',
+        part: 'privacy',
+        blocks: [
+          {
+            type: 'ol',
+            lead: 'We also automatically collect certain information about your interaction with the Services ("Usage Data"). To do this, we may use cookies and other tracking technologies ("Tracking Technologies"). Usage Data includes:',
+            items: [
+              'Device information, such as device type, operating system, unique device identifier, and internet protocol (IP) address.',
+              'Location information, such as approximate location.',
+              'Other information regarding your interaction with the Services, such as browser type, log data, date and time stamps, clickstream data, interactions with marketing emails, and ad impressions.',
+            ],
+          },
+          {
+            type: 'p',
+            text: 'We use Usage Data to tailor features and content to you, run analytics and better understand user interaction with the Services. For more information on how we use Tracking Technologies and your choices, see the Cookies and Other Tracking Technologies section.',
+          },
+        ],
+      },
+      {
+        id: 'information-from-other-sources',
+        title: 'Information Collected From Other Sources',
+        icon: 'Building2',
+        part: 'privacy',
+        blocks: [
+          {
+            type: 'ol',
+            lead: 'We may obtain information about you from outside sources, including information that we collect directly from third parties and information from third parties that you choose to share with us. Such information includes:',
+            items: [
+              'Analytics data we receive from analytics providers such as Google Analytics.',
+              'Information we receive from consumer marketing databases or other data enrichment companies, which we use to better customize advertising and marketing to you.',
+            ],
+          },
+          {
+            type: 'p',
+            text: "Any information we receive from outside sources will be treated in accordance with this document. We are not responsible for the accuracy of the information provided to us by third parties and are not responsible for any third party's policies or practices. For more information, see the Third Party Websites and Links section.",
+          },
+          {
+            type: 'p',
+            text: 'In addition to the specific uses described above, we may use any of the above information to provide you with and improve the Services and to maintain our business relationship, including by enhancing the safety and security of our Services (e.g., troubleshooting, data analysis, testing, system maintenance, and reporting), providing customer support, sending service and other non-marketing communications, monitoring and analyzing trends, conducting internal research and development, complying with applicable legal obligations, enforcing any applicable terms of service, and protecting the Services, our rights, and the rights of our employees, users or other individuals.',
+          },
+          {
+            type: 'p',
+            text: 'Finally, we may deidentify or anonymize your information such that it cannot reasonably be used to infer information about you or otherwise be linked to you ("deidentified information") (or we may collect information that has already been deidentified/anonymized), and we may use such deidentified information for any purpose. To the extent we possess or process any deidentified information, we will maintain and use such information in deidentified/anonymized form and not attempt to re-identify the information, except solely for the purpose of determining whether our deidentification/anonymization process satisfies legal requirements.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'cookies',
+    title: 'Cookies and Other Tracking Technologies',
+    icon: 'Star',
+    accent: 'yellow',
+    part: 'cookies',
+    blocks: [
+      {
+        type: 'p',
+        text: 'Most browsers accept cookies automatically, but you may be able to control the way in which your devices permit the use of Tracking Technologies. If you so choose, you may block or delete our cookies from your browser; however, blocking or deleting cookies may cause some of the Services, including certain features and general functionality, to work incorrectly. If you have questions regarding the specific information about you that we process or retain, as well as your choices regarding our collection and use practices, please contact us using the information listed below.',
+      },
+      {
+        type: 'p',
+        text: 'To opt out of tracking by Google Analytics, click here: https://tools.google.com/dlpage/gaoptout',
+      },
+      {
+        type: 'p',
+        text: 'Your browser settings may allow you to transmit a "do not track" signal, "opt-out preference" signal, or other mechanism for exercising your choice regarding the collection of your information when you visit various websites. Like many websites, our website is not designed to respond to such signals, and we do not use or disclose your information in any way that would legally require us to recognize opt-out preference signals. To learn more about "do not track" signals, you can visit http://www.allaboutdnt.com/.',
+      },
+    ],
+  },
+  {
+    id: 'disclosure',
+    title: 'Disclosure of Your Information',
+    icon: 'Users',
+    accent: 'purple',
+    part: 'privacy',
+    blocks: [
+      {
+        type: 'ol',
+        lead: 'We may disclose your information to third parties for legitimate purposes subject to this document, including the following categories of third parties:',
+        items: [
+          'Company Group: Our affiliates or others within our corporate group.',
+          'Service Providers: Vendors or other service providers who help us provide the Services, including for system administration, cloud storage, security, customer relationship management, marketing communications, web analytics, payment networks, and payment processing.',
+          'Other Third Parties: Third parties to whom you request or direct us to disclose information, such as through your use of social media widgets or login integration.',
+          'Professional advisors: such as auditors, law firms, or accounting firms.',
+          'Business Transactions: Third parties in connection with or anticipation of an asset sale, merger, or other business transaction, including in the context of a bankruptcy.',
+        ],
+      },
+      {
+        type: 'p',
+        text: 'We may also disclose your information as needed to comply with applicable law or any obligations thereunder or to cooperate with law enforcement, judicial orders, and regulatory inquiries, to enforce any applicable terms of service, and to ensure the safety and security of our business, employees, and users.',
+      },
+    ],
+  },
+  {
+    id: 'social-features',
+    title: 'Social Features',
+    icon: 'Users',
+    accent: 'cyan',
+    part: 'thirdParty',
+    blocks: [
+      {
+        type: 'p',
+        text: 'Certain features of the Services may allow you to initiate interactions between the Services and third-party services or platforms, such as social networks ("Social Features"). Social Features include features that allow you to access our pages on third-party platforms, and from there "like" or "share" our content. Use of Social Features may allow a third party to collect and/or use your information. If you use Social Features, information you post or make accessible may be publicly displayed by the third-party service. Both we and the third party may have access to information about you and your use of both the Services and the third-party service. For more information, see the Third Party Websites and Links section.',
+      },
+    ],
+  },
+  {
+    id: 'third-party',
+    title: 'Third Party Websites and Links',
+    icon: 'Building2',
+    accent: 'purple',
+    part: 'thirdParty',
+    blocks: [
+      {
+        type: 'p',
+        text: 'We may provide links to third-party websites or platforms. If you follow links to sites or platforms that we do not control and are not affiliated with us, you should review the applicable privacy notice, policies and other terms. We are not responsible for the privacy or security of, or information found on, these sites or platforms. Information you provide on public or semi-public venues, such as third-party social networking platforms, may also be viewable by other users of the Services and/or users of those third-party platforms without limitation as to its use. Our inclusion of such links does not, by itself, imply any endorsement of the content on such platforms or of their owners or operators.',
+      },
+    ],
+  },
+  {
+    id: 'children',
+    title: "Children's Privacy",
+    icon: 'Users',
+    accent: 'emerald',
+    part: 'children',
+    blocks: [
+      {
+        type: 'p',
+        text: 'Children under the age of {{childrenAge}} are not permitted to use the Services, and we do not seek or knowingly collect any personal information about children under {{childrenAge}} years of age. If we become aware that we have unknowingly collected information about a child under {{childrenAge}} years of age, we will make commercially reasonable efforts to delete such information. If you are the parent or guardian of a child under {{childrenAge}} years of age who has provided us with their personal information, you may contact us using the below information to request that it be deleted.',
+      },
+    ],
+  },
+  {
+    id: 'security',
+    title: 'Data Security and Retention',
+    icon: 'Lock',
+    accent: 'green',
+    part: 'security',
+    blocks: [
+      {
+        type: 'p',
+        text: 'Despite our reasonable efforts to protect your information, no security measures are impenetrable, and we cannot guarantee "perfect security." Any information you send to us electronically, while using the Services or otherwise interacting with us, may not be secure while in transit. We recommend that you do not use unsecure channels to send us sensitive or confidential information.',
+      },
+      {
+        type: 'p',
+        text: 'We retain your information for as long as is reasonably necessary for the purposes specified in this document. When determining the length of time to retain your information, we consider various criteria, including whether we need the information to continue to provide you the Services, resolve a dispute, enforce our contractual agreements, prevent harm, promote safety, security and integrity, or protect ourselves, including our rights, property or products.',
+      },
+      {
+        type: 'p',
+        text: 'You may opt out of information collection for AI, which would prohibit us from using your search information to improve our AI models in your settings page if you are logged into the Services. If you delete your account, we will delete your personal information from our servers within {{dataDeletionDays}} days. Please contact us at {{contactEmail}} to request deletion.',
+      },
+    ],
+  },
+  {
+    id: 'california',
+    title: 'California Residents',
+    icon: 'Scale',
+    accent: 'indigo',
+    part: 'california',
+    blocks: [
+      {
+        type: 'p',
+        text: 'This section applies to you only if you are a California resident ("resident" or "residents"). For purposes of this section, references to "personal information" shall include "sensitive personal information," as these terms are defined under the California Consumer Privacy Act ("CCPA").',
+      },
+    ],
+    subsections: [
+      {
+        id: 'california-processing',
+        title: 'Processing of Personal Information',
+        icon: 'Eye',
+        part: 'california',
+        blocks: [
+          {
+            type: 'ol',
+            lead: 'In the preceding 12 months, we collected and disclosed for a business purpose the following categories of personal information and sensitive personal information (denoted by *) about residents:',
+            items: [
+              'Identifiers such as name, e-mail address, IP address',
+              'Personal information categories listed in the California Customer Records statute such as name, address and telephone number',
+              'Commercial information such as records of products or services purchased',
+              'Internet or other similar network activity such as information regarding your interaction with the Platform',
+              'Geolocation data such as IP address',
+              'Professional or employment-related information such as title of profession, employer, professional background and other information provided by you when you apply for a job with us',
+              'Non-public education information collected by certain federally funded institutions such as education records',
+              'Account access credentials* such as account log-in',
+            ],
+          },
+          {
+            type: 'p',
+            text: 'The specific business or commercial purposes for which we collect your personal information and the categories of sources from which we collect your personal information are described in the Privacy Policy section. We only use and disclose sensitive personal information for the purposes specified in the CCPA. The criteria we use to determine how long to retain your personal information is described in the Data Security and Retention section.',
+          },
+          {
+            type: 'ol',
+            lead: 'We disclosed personal information over the preceding 12 months for the following business or commercial purposes:',
+            items: [
+              'to communicate with you, provide you with products and services, to market to you, etc.',
+              'to maintain and secure your account with us',
+              'to process your payment, to provide you with products or services you have requested',
+              'to evaluate your candidacy and process your application for employment.',
+            ],
+          },
+        ],
+      },
+      {
+        id: 'california-selling',
+        title: 'Selling and/or Sharing of Personal Information',
+        icon: 'Building2',
+        part: 'california',
+        blocks: [
+          {
+            type: 'p',
+            text: 'We do not "sell" or "share" (as those terms are defined under the CCPA) personal information, nor have we done so in the preceding 12 months. Further, we do not have actual knowledge that we "sell" or "share" personal information of residents under 16 years of age.',
+          },
+        ],
+      },
+      {
+        id: 'california-rights',
+        title: 'Your California Privacy Rights',
+        icon: 'Scale',
+        part: 'california',
+        blocks: [
+          {
+            type: 'p',
+            text: 'As a California resident, you may have the rights listed below in relation to personal information that we have collected about you. However, these rights are not absolute, and in certain cases, we may decline your request as permitted by law.',
+          },
+          {
+            type: 'ol',
+            items: [
+              {
+                text: 'Right to Know. You have a right to request the following information about our collection, use and disclosure of your personal information:',
+                items: [
+                  'categories of personal information we have collected, disclosed for a business purpose;',
+                  'categories of sources from which we collected personal information;',
+                  'the business or commercial purposes for collecting personal information;',
+                  'categories of third parties to whom the personal information was disclosed for a business purpose; and',
+                  'specific pieces of personal information we have collected.',
+                ],
+              },
+              'Right to Delete. You have a right to request that we delete personal information we maintain about you.',
+              'Right to Correct. You have a right to request that we correct inaccurate personal information we maintain about you.',
+            ],
+          },
+          {
+            type: 'p',
+            text: 'You may exercise any of these rights by contacting us using the information provided below. We will not discriminate against you for exercising any of these rights. We may need to collect information from you to verify your identity, such as your email address and government issued ID, before providing a substantive response to the request. You may designate, in writing or through a power of attorney document, an authorized agent to make requests on your behalf to exercise your rights. Before accepting such a request from an agent, we will require that the agent provide proof you have authorized them to act on your behalf, and we may need you to verify your identity directly with us.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'feedback',
+    title: 'Feedback',
+    icon: 'Star',
+    accent: 'amber',
+    part: 'core',
+    blocks: [
+      {
+        type: 'p',
+        text: 'If you provide Feedback to us, you agree that we may use the Feedback however we choose without any obligation or payment to you.',
+      },
+    ],
+  },
+  {
+    id: 'liability',
+    title: 'Disclaimer of Warranties and Limitations of Liability',
+    icon: 'AlertTriangle',
+    accent: 'red',
+    part: 'core',
+    blocks: [
+      {
+        type: 'p',
+        text: 'The services are provided "as is" and "as available" without warranties of any kind. {{companyName}} disclaims all warranties, express or implied.',
+      },
+      {
+        type: 'p',
+        text: 'To the fullest extent permissible under applicable law, {{companyName}} shall not be liable for any indirect, incidental, special, consequential, or punitive damages, or any loss of profits or revenues.',
+      },
+    ],
+  },
+  {
+    id: 'termination',
+    title: 'Termination',
+    icon: 'X',
+    accent: 'slate',
+    part: 'core',
+    blocks: [
+      {
+        type: 'p',
+        text: 'We may suspend or terminate your access to the Services at any time if we believe that you have breached these Terms, or if we must do so to comply with law.',
+      },
+    ],
+  },
+  {
+    id: 'contact',
+    title: 'How to Contact Us',
+    icon: 'Mail',
+    accent: 'blue',
+    part: 'core',
+    blocks: [
+      {
+        type: 'p',
+        text: 'Should you have any questions about our privacy practices, these Terms of Service, or this document, please email us at {{contactEmail}}',
+      },
+    ],
+  },
+];

--- a/packages/legal-terms-privacy-policy/src/content/summary.ts
+++ b/packages/legal-terms-privacy-policy/src/content/summary.ts
@@ -1,0 +1,431 @@
+import type { Section } from '../types';
+
+/**
+ * The short, scannable presentation — the card-and-icon layout published at
+ * rights.institute/terms-privacy, lifted verbatim and tokenized.
+ *
+ * This is a plain-language summary, not a substitute for {@link FULL_SECTIONS}:
+ * ship both and let readers switch between them.
+ */
+export const SUMMARY_SECTIONS: Section[] = [
+  {
+    id: 'introduction',
+    title: 'Introduction',
+    icon: 'BookOpen',
+    accent: 'emerald',
+    part: 'core',
+    blocks: [
+      {
+        type: 'p',
+        text: 'Welcome to {{appName}}, operated by {{companyName}}. These Terms of Service ("Terms") and Privacy Policy govern your use of our website, applications, and services (collectively, the "Services").',
+      },
+      {
+        type: 'p',
+        text: 'By accessing or using our Services, you agree to be bound by these Terms and our Privacy Policy. If you disagree with any part of these terms, then you may not access the Services.',
+      },
+      {
+        type: 'p',
+        text: 'We are committed to protecting your privacy and ensuring transparency in how we collect, use, and protect your personal information. This document combines our Terms of Service and Privacy Policy to provide you with a comprehensive understanding of your rights and our responsibilities.',
+      },
+    ],
+  },
+  {
+    id: 'acceptance',
+    title: 'Acceptance of Terms',
+    icon: 'FileText',
+    accent: 'blue',
+    part: 'core',
+    blocks: [
+      {
+        type: 'p',
+        text: "By accessing and using {{appName}}, you accept and agree to be bound by the terms and provision of this agreement. Additionally, when using this website's particular services, you shall be subject to any posted guidelines or rules applicable to such services.",
+      },
+      {
+        type: 'note',
+        title: 'Legal Agreement',
+        icon: 'Scale',
+        items: [
+          'You must be at least {{minimumAge}} years old to use our Services',
+          'You agree to provide accurate and complete information',
+          'You are responsible for maintaining the security of your account',
+          'You agree to use our Services in compliance with all applicable laws',
+        ],
+      },
+    ],
+  },
+  {
+    id: 'ai-ethics',
+    title: 'AI Ethical Use',
+    icon: 'Sparkles',
+    accent: 'purple',
+    part: 'ai',
+    blocks: [
+      {
+        type: 'p',
+        text: 'Artificial intelligence and large language models are frontier technologies that are still improving in accuracy, reliability and safety. Outputs may look authoritative and still be wrong — confirm anything you intend to rely on.',
+      },
+      {
+        type: 'cards',
+        columns: 2,
+        items: [
+          {
+            title: 'Trust, But Verify',
+            icon: 'AlertTriangle',
+            items: [
+              'Outputs may contain material inaccuracies',
+              'Confirm accuracy independently before relying on them',
+              'Outputs may not be correct, current, or complete',
+            ],
+          },
+          {
+            title: 'Respect Privacy',
+            icon: 'Lock',
+            items: [
+              'No personal data processing that breaks applicable law',
+              'No biometric identification, including facial recognition',
+              'No spyware, surveillance, or unauthorized monitoring',
+            ],
+          },
+          {
+            title: 'Protect Safety & Rights',
+            icon: 'Shield',
+            items: [
+              'No unreviewed legal, medical, or financial advice',
+              'No high-stakes automated decisions about people',
+              'No gambling, payday lending, or political campaigning',
+            ],
+          },
+          {
+            title: 'Be Truthful',
+            icon: 'Eye',
+            items: [
+              'No disinformation or false online engagement',
+              'No impersonation without consent or legal right',
+              'Disclose to people when they are talking to AI',
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'user-accounts',
+    title: 'User Accounts',
+    icon: 'User',
+    accent: 'amber',
+    part: 'core',
+    blocks: [
+      {
+        type: 'p',
+        text: 'When you create an account with us, you must provide information that is accurate, complete, and current at all times.',
+      },
+      {
+        type: 'note',
+        title: 'Account Security',
+        icon: 'Lock',
+        items: [
+          'Use a strong, unique password for your account',
+          'Enable two-factor authentication when available',
+          'Do not share your account credentials with others',
+          'Notify us immediately of any unauthorized access',
+        ],
+      },
+      {
+        type: 'note',
+        title: 'Account Responsibility',
+        icon: 'AlertTriangle',
+        text: 'You are responsible for safeguarding the password and for any activities that occur under your account. We cannot and will not be liable for any loss or damage arising from your failure to comply with this security obligation.',
+      },
+    ],
+  },
+  {
+    id: 'privacy-policy',
+    title: 'Privacy Policy',
+    icon: 'Shield',
+    accent: 'rose',
+    part: 'privacy',
+    blocks: [
+      {
+        type: 'p',
+        text: 'Your privacy is critically important to us. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you use our Services.',
+      },
+      {
+        type: 'cards',
+        columns: 3,
+        items: [
+          {
+            title: 'Transparency',
+            icon: 'Eye',
+            text: "We're clear about what data we collect and why we collect it.",
+          },
+          {
+            title: 'Security',
+            icon: 'Lock',
+            text: 'Your data is protected with industry-standard security measures.',
+          },
+          {
+            title: 'Control',
+            icon: 'Users',
+            text: 'You have control over your personal information and privacy settings.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'data-collection',
+    title: 'Data Collection',
+    icon: 'Eye',
+    accent: 'cyan',
+    part: 'privacy',
+    blocks: [
+      {
+        type: 'p',
+        text: 'We collect information you provide directly to us, information we obtain automatically when you use our Services, and information from other sources.',
+      },
+      {
+        type: 'note',
+        title: 'Information You Provide',
+        icon: 'User',
+        items: [
+          'Account information (name, email, profile details)',
+          'Content you create, upload, or share',
+          'Communications with us and other users',
+          'Payment and billing information',
+        ],
+      },
+      {
+        type: 'note',
+        title: 'Automatically Collected Information',
+        icon: 'Settings',
+        items: [
+          'Device and browser information',
+          'IP address and location data',
+          'Usage patterns and preferences',
+          'Cookies and similar tracking technologies',
+        ],
+      },
+    ],
+  },
+  {
+    id: 'data-usage',
+    title: 'How We Use Your Data',
+    icon: 'Settings',
+    accent: 'teal',
+    part: 'privacy',
+    blocks: [
+      {
+        type: 'p',
+        text: 'We use the information we collect to provide, maintain, and improve our Services, process transactions, and communicate with you.',
+      },
+      {
+        type: 'cards',
+        columns: 2,
+        items: [
+          {
+            title: 'Service Operations',
+            icon: 'Globe',
+            items: [
+              'Provide and maintain our Services',
+              'Process transactions and payments',
+              'Provide customer support',
+            ],
+          },
+          {
+            title: 'Communications',
+            icon: 'Mail',
+            items: [
+              'Send service notifications',
+              'Respond to inquiries',
+              'Marketing (with consent)',
+            ],
+          },
+          {
+            title: 'Improvements',
+            icon: 'Star',
+            items: [
+              'Analyze usage patterns',
+              'Develop new features',
+              'Enhance user experience',
+            ],
+          },
+          {
+            title: 'Security & Legal',
+            icon: 'Shield',
+            items: [
+              'Prevent fraud and abuse',
+              'Enforce our Terms',
+              'Comply with legal requirements',
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'user-rights',
+    title: 'Your Rights & Choices',
+    icon: 'Scale',
+    accent: 'indigo',
+    part: 'privacy',
+    blocks: [
+      {
+        type: 'p',
+        text: 'You have certain rights regarding your personal information. We provide you with the ability to access, update, and delete your information.',
+      },
+      {
+        type: 'cards',
+        columns: 4,
+        center: true,
+        items: [
+          { title: 'Access', icon: 'Eye', text: 'View the personal data we have about you' },
+          { title: 'Update', icon: 'Settings', text: 'Correct or update your information' },
+          { title: 'Delete', icon: 'X', text: 'Request deletion of your data' },
+          { title: 'Control', icon: 'Lock', text: 'Manage privacy settings' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'security',
+    title: 'Security Measures',
+    icon: 'Lock',
+    accent: 'green',
+    part: 'security',
+    blocks: [
+      {
+        type: 'p',
+        text: 'We implement appropriate technical and organizational security measures to protect your personal information against unauthorized access, alteration, disclosure, or destruction.',
+      },
+      {
+        type: 'cards',
+        columns: 3,
+        items: [
+          {
+            title: 'Encryption',
+            icon: 'Shield',
+            text: 'Data is encrypted in transit and at rest using industry-standard protocols.',
+          },
+          {
+            title: 'Access Controls',
+            icon: 'Eye',
+            text: 'Strict access controls ensure only authorized personnel can access your data.',
+          },
+          {
+            title: 'Monitoring',
+            icon: 'AlertTriangle',
+            text: 'Continuous monitoring and regular security audits protect against threats.',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'cookies',
+    title: 'Cookies & Tracking Technologies',
+    icon: 'Star',
+    accent: 'yellow',
+    part: 'cookies',
+    blocks: [
+      {
+        type: 'p',
+        text: 'We use cookies and similar tracking technologies to track activity on our Service and hold certain information to improve your experience.',
+      },
+      {
+        type: 'cards',
+        columns: 2,
+        items: [
+          { title: 'Essential Cookies', text: 'Required for basic site functionality' },
+          { title: 'Analytics Cookies', text: 'Help us understand how you use our site' },
+          { title: 'Preference Cookies', text: 'Remember your settings and preferences' },
+          { title: 'Marketing Cookies', text: 'Provide relevant ads and content' },
+        ],
+      },
+      {
+        type: 'note',
+        title: 'Your Cookie Choices',
+        icon: 'User',
+        text: 'You can control cookies through your browser settings. Note that disabling certain cookies may affect the functionality of our Services.',
+      },
+    ],
+  },
+  {
+    id: 'third-party',
+    title: 'Third Party Services',
+    icon: 'Building2',
+    accent: 'purple',
+    part: 'thirdParty',
+    blocks: [
+      {
+        type: 'p',
+        text: 'Our Services may contain links to third-party websites or integrate with third-party services. We are not responsible for the privacy practices of these third parties.',
+      },
+      {
+        type: 'note',
+        title: 'Important Notice',
+        icon: 'AlertTriangle',
+        items: [
+          'Third-party sites have their own privacy policies',
+          'We encourage you to review these policies',
+          'We are not responsible for third-party practices',
+          'Integration services may share data according to their terms',
+        ],
+      },
+    ],
+  },
+  {
+    id: 'liability',
+    title: 'Liability & Disclaimers',
+    icon: 'AlertTriangle',
+    accent: 'red',
+    part: 'core',
+    blocks: [
+      {
+        type: 'note',
+        title: 'Service Disclaimer',
+        icon: 'Shield',
+        text: 'Our Services are provided "as is" and "as available" without warranties of any kind, either express or implied.',
+        items: [
+          'We do not guarantee uninterrupted access',
+          'Services may be modified or discontinued',
+          'Content accuracy is not guaranteed',
+        ],
+      },
+      {
+        type: 'note',
+        title: 'Limitation of Liability',
+        icon: 'Scale',
+        text: 'To the maximum extent permitted by law, {{companyName}} shall not be liable for any indirect, incidental, special, consequential, or punitive damages arising from your use of our Services.',
+      },
+    ],
+  },
+  {
+    id: 'contact',
+    title: 'Contact Information',
+    icon: 'Mail',
+    accent: 'blue',
+    part: 'core',
+    blocks: [
+      {
+        type: 'p',
+        text: 'If you have any questions about these Terms of Service and Privacy Policy, please contact us:',
+      },
+      {
+        type: 'cards',
+        columns: 2,
+        items: [
+          {
+            title: 'Company Information',
+            icon: 'Building2',
+            items: ['Company: {{companyName}}', 'Service: {{appName}}'],
+          },
+          {
+            title: 'Contact Details',
+            icon: 'Mail',
+            items: ['Email: {{contactEmail}}'],
+          },
+        ],
+      },
+    ],
+  },
+];

--- a/packages/legal-terms-privacy-policy/src/index.ts
+++ b/packages/legal-terms-privacy-policy/src/index.ts
@@ -1,0 +1,44 @@
+/**
+ * legal-terms-privacy-policy — one configurable Terms of Service + Privacy
+ * Policy document, in two presentations.
+ *
+ * This entry point is framework-free: content, config and the Markdown / HTML /
+ * plain-text renderers. Import `legal-terms-privacy-policy/react` for the
+ * React page component.
+ */
+export type {
+  Accent,
+  Block,
+  Card,
+  CardsBlock,
+  IconName,
+  LegalDoc,
+  LegalDocOptions,
+  LegalFeatures,
+  BaseTokens,
+  LegalTokens,
+  ListBlock,
+  ListItem,
+  NoteBlock,
+  ParagraphBlock,
+  PartId,
+  Section,
+  SectionInsertion,
+  Variant,
+} from './types';
+
+export {
+  DEFAULT_BADGES,
+  DEFAULT_FEATURES,
+  DEFAULT_TOKENS,
+  VARIANTS,
+  interpolate,
+  resolveLegalDoc,
+} from './resolve';
+
+export { FULL_SECTIONS } from './content/full';
+export { SUMMARY_SECTIONS } from './content/summary';
+
+export { renderMarkdown, toMarkdown } from './render/markdown';
+export { LEGAL_CSS, escapeHtml, renderHtml, toHtml } from './render/html';
+export { renderText, toPlainText } from './render/text';

--- a/packages/legal-terms-privacy-policy/src/react/LegalTermsPrivacyPolicy.tsx
+++ b/packages/legal-terms-privacy-policy/src/react/LegalTermsPrivacyPolicy.tsx
@@ -1,0 +1,381 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import type { LegalDoc, LegalDocOptions, Section, Variant } from '../types';
+import { resolveLegalDoc } from '../resolve';
+import { BlockView } from './blocks';
+import { accentOf, resolveIcon, type IconMap } from './icons';
+
+export interface LegalTermsPrivacyPolicyProps extends LegalDocOptions {
+  /**
+   * Controlled variant. When set, the switch calls `onVariantChange` instead
+   * of holding its own state — use it to drive the variant from the URL.
+   */
+  variant?: Variant;
+  /** Initial variant for the uncontrolled case. Defaults to `'summary'`. */
+  defaultVariant?: Variant;
+  onVariantChange?: (variant: Variant) => void;
+  /** Extra icons for caller-authored sections, keyed by the name used in `icon`. */
+  icons?: IconMap;
+  /** Extra classes on the outermost element. */
+  className?: string;
+}
+
+/** Numbered heading label for a section at `index`, or '' when unnumbered. */
+function label(doc: LegalDoc, index: number, parent?: string) {
+  if (!doc.features.numbered || doc.variant !== 'full') return '';
+  return parent ? `${parent.replace(/\.$/, '')}.${index + 1}` : `${index + 1}.`;
+}
+
+function SectionBody({
+  doc,
+  section,
+  index,
+  parentLabel,
+  icons,
+}: {
+  doc: LegalDoc;
+  section: Section;
+  index: number;
+  parentLabel?: string;
+  icons?: IconMap;
+}) {
+  const isSummary = doc.variant === 'summary';
+  const tint = accentOf(section.accent);
+  const Icon = resolveIcon(section.icon, icons);
+  const heading = label(doc, index, parentLabel);
+  const depth = parentLabel === undefined ? 0 : 1;
+  const Heading = depth === 0 ? 'h2' : 'h3';
+
+  const body = (
+    <>
+      {section.blocks?.map((block, i) => (
+        <BlockView
+          key={i}
+          block={block}
+          accent={section.accent}
+          icons={icons}
+          style={isSummary ? 'cards' : 'prose'}
+        />
+      ))}
+      {section.subsections?.map((sub, i) => (
+        <SectionBody
+          key={sub.id}
+          doc={doc}
+          section={sub}
+          index={i}
+          parentLabel={heading || ''}
+          icons={icons}
+        />
+      ))}
+    </>
+  );
+
+  return (
+    <section id={section.id} className={depth === 0 ? 'mb-12 scroll-mt-24' : 'mt-8 scroll-mt-24'}>
+      <Heading
+        className={
+          depth === 0
+            ? 'mb-4 flex items-center text-2xl font-bold'
+            : 'mb-2 flex items-center text-lg font-semibold'
+        }
+      >
+        {isSummary && section.icon ? (
+          <Icon className={`mr-3 h-6 w-6 shrink-0 ${tint.icon}`} />
+        ) : null}
+        {heading ? <span className="mr-2 tabular-nums opacity-60">{heading}</span> : null}
+        {section.title}
+      </Heading>
+      {isSummary && depth === 0 ? (
+        <div className={`rounded-xl border bg-gradient-to-br p-6 shadow-sm ${tint.card}`}>
+          {body}
+        </div>
+      ) : (
+        body
+      )}
+    </section>
+  );
+}
+
+/**
+ * A combined Terms of Service and Privacy Policy page with two presentations
+ * of the same policy — a scannable card summary and the full legal text — and
+ * a switch between them.
+ *
+ * Content, tokens, which sections appear and in what order all come from
+ * {@link LegalDocOptions}; nothing here needs editing to adopt it.
+ *
+ * @example
+ * ```tsx
+ * <LegalTermsPrivacyPolicy
+ *   appName="QwkSearch"
+ *   contactEmail="legal@qwksearch.com"
+ *   lastRevisedDate="March 1, 2026"
+ *   defaultVariant="full"
+ *   parts={{ california: false }}
+ * />
+ * ```
+ */
+export default function LegalTermsPrivacyPolicy({
+  variant: controlledVariant,
+  defaultVariant = 'summary',
+  onVariantChange,
+  icons,
+  className = '',
+  ...options
+}: LegalTermsPrivacyPolicyProps) {
+  const [uncontrolled, setUncontrolled] = useState<Variant>(defaultVariant);
+  const variant = controlledVariant ?? uncontrolled;
+
+  const setVariant = useCallback(
+    (next: Variant) => {
+      if (controlledVariant === undefined) setUncontrolled(next);
+      onVariantChange?.(next);
+    },
+    [controlledVariant, onVariantChange],
+  );
+
+  // `options` is a fresh object on every render (it's a rest spread), so the
+  // memo is keyed on its serialized value instead — the option tree is plain
+  // data, and this keeps `doc` stable enough for the scroll effect below.
+  const optionsKey = JSON.stringify(options);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const doc = useMemo(() => resolveLegalDoc({ ...options, variant }), [optionsKey, variant]);
+
+  const [activeSection, setActiveSection] = useState(doc.sections[0]?.id ?? '');
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [copied, setCopied] = useState<string | null>(null);
+
+  // Highlight whichever section currently crosses the top of the viewport.
+  useEffect(() => {
+    if (!doc.features.sidebar && !doc.features.tableOfContents) return;
+    const onScroll = () => {
+      let current = doc.sections[0]?.id ?? '';
+      for (const el of document.querySelectorAll<HTMLElement>('section[id]')) {
+        const rect = el.getBoundingClientRect();
+        if (rect.top <= 120 && rect.bottom >= 120) current = el.id;
+      }
+      setActiveSection(current);
+    };
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, [doc]);
+
+  const scrollTo = useCallback((id: string) => {
+    setActiveSection(id);
+    setMenuOpen(false);
+    document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' });
+  }, []);
+
+  const copy = useCallback(async (text: string, key: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(key);
+      setTimeout(() => setCopied(null), 2000);
+    } catch {
+      // Clipboard access is denied in some embeds; the email is still selectable.
+    }
+  }, []);
+
+  const CopyIcon = resolveIcon('Copy', icons);
+  const CheckIcon = resolveIcon('Check', icons);
+  const MenuIcon = resolveIcon('Menu', icons);
+  const CloseIcon = resolveIcon('X', icons);
+  const BackIcon = resolveIcon('ArrowLeft', icons);
+  const CalendarIcon = resolveIcon('Calendar', icons);
+  const isSummary = variant === 'summary';
+  const showRail = isSummary && doc.features.sidebar;
+
+  return (
+    <div className={`min-h-screen bg-white text-gray-800 dark:bg-slate-950 dark:text-slate-200 ${className}`}>
+      <div className="mx-auto flex max-w-6xl gap-6 px-4 py-8 sm:px-6">
+        {showRail ? (
+          <aside className="sticky top-24 hidden h-fit w-14 shrink-0 flex-col items-center gap-3 rounded-xl border bg-white/70 py-4 backdrop-blur-md lg:flex dark:border-slate-800 dark:bg-slate-900/70">
+            {doc.sections.map((section) => {
+              const Icon = resolveIcon(section.icon, icons);
+              const active = activeSection === section.id;
+              return (
+                <button
+                  key={section.id}
+                  type="button"
+                  title={section.title}
+                  aria-label={section.title}
+                  aria-current={active ? 'true' : undefined}
+                  onClick={() => scrollTo(section.id)}
+                  className={`flex h-10 w-10 items-center justify-center rounded-lg transition-all ${
+                    active
+                      ? 'scale-110 bg-indigo-600 text-white shadow'
+                      : 'text-gray-500 hover:bg-indigo-50 hover:text-indigo-600 dark:hover:bg-slate-800'
+                  }`}
+                >
+                  <Icon className="h-4 w-4" />
+                </button>
+              );
+            })}
+          </aside>
+        ) : null}
+
+        <main className="min-w-0 flex-1">
+          <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+            {doc.features.backLink ? (
+              <a
+                href={String(doc.tokens.homeUrl)}
+                className="inline-flex items-center gap-2 rounded-md border border-gray-200 bg-gray-50 px-4 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800"
+              >
+                <BackIcon className="h-4 w-4" />
+                Back to Home
+              </a>
+            ) : (
+              <span />
+            )}
+
+            <div className="flex items-center gap-2">
+              {showRail ? (
+                <button
+                  type="button"
+                  onClick={() => setMenuOpen((open) => !open)}
+                  aria-label="Table of contents"
+                  className="rounded-lg p-2 text-gray-600 hover:bg-indigo-50 hover:text-indigo-600 lg:hidden dark:text-slate-300 dark:hover:bg-slate-800"
+                >
+                  {menuOpen ? <CloseIcon className="h-5 w-5" /> : <MenuIcon className="h-5 w-5" />}
+                </button>
+              ) : null}
+
+              {doc.features.variantSwitch ? (
+                <div
+                  role="tablist"
+                  aria-label="Policy detail level"
+                  className="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1 text-sm dark:border-slate-700 dark:bg-slate-900"
+                >
+                  {(
+                    [
+                      ['summary', 'Summary'],
+                      ['full', 'Full Text'],
+                    ] as const
+                  ).map(([value, text]) => (
+                    <button
+                      key={value}
+                      type="button"
+                      role="tab"
+                      aria-selected={variant === value}
+                      onClick={() => setVariant(value)}
+                      className={`rounded-md px-3 py-1.5 font-medium transition-colors ${
+                        variant === value
+                          ? 'bg-indigo-600 text-white shadow'
+                          : 'text-gray-600 hover:text-indigo-600 dark:text-slate-300'
+                      }`}
+                    >
+                      {text}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          </div>
+
+          {menuOpen && showRail ? (
+            <nav className="mb-6 rounded-xl border p-3 lg:hidden dark:border-slate-800">
+              {doc.sections.map((section) => (
+                <button
+                  key={section.id}
+                  type="button"
+                  onClick={() => scrollTo(section.id)}
+                  className="block w-full rounded-md px-3 py-2 text-left text-sm hover:bg-indigo-50 dark:hover:bg-slate-800"
+                >
+                  {section.title}
+                </button>
+              ))}
+            </nav>
+          ) : null}
+
+          <header className={isSummary ? 'mb-8 text-center' : 'mb-8'}>
+            <h1
+              className={
+                isSummary
+                  ? 'bg-gradient-to-r from-indigo-600 via-purple-600 to-pink-600 bg-clip-text text-4xl font-black text-transparent'
+                  : 'text-3xl font-bold'
+              }
+            >
+              {doc.title}
+            </h1>
+            {doc.features.badges && doc.badges.length ? (
+              <div
+                className={`mt-4 flex flex-wrap gap-2 ${isSummary ? 'justify-center' : ''}`}
+              >
+                {doc.badges.map((badge) => (
+                  <span
+                    key={badge}
+                    className="rounded-full bg-gradient-to-r from-indigo-500 to-purple-600 px-3 py-1 text-xs font-medium text-white shadow"
+                  >
+                    {badge}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+          </header>
+
+          <div className="mb-8 flex items-center justify-between gap-4 rounded-xl border border-blue-200 bg-blue-50/60 p-4 dark:border-blue-900 dark:bg-blue-950/30">
+            <div className="flex items-center gap-3">
+              <CalendarIcon className="h-5 w-5 shrink-0 text-blue-600 dark:text-blue-400" />
+              <div className="text-sm">
+                <p className="font-medium">Last Updated: {doc.tokens.lastRevisedDate}</p>
+                {doc.tokens.effectiveDate !== doc.tokens.lastRevisedDate ? (
+                  <p className="opacity-75">Effective Date: {doc.tokens.effectiveDate}</p>
+                ) : null}
+              </div>
+            </div>
+            {doc.features.copyButtons ? (
+              <button
+                type="button"
+                aria-label="Copy contact email"
+                title={`Copy ${doc.tokens.contactEmail}`}
+                onClick={() => copy(String(doc.tokens.contactEmail), 'email')}
+                className="rounded-lg p-2 text-blue-600 hover:bg-blue-100 dark:text-blue-400 dark:hover:bg-blue-900/40"
+              >
+                {copied === 'email' ? (
+                  <CheckIcon className="h-4 w-4 text-green-600" />
+                ) : (
+                  <CopyIcon className="h-4 w-4" />
+                )}
+              </button>
+            ) : null}
+          </div>
+
+          {!isSummary && doc.features.tableOfContents ? (
+            <nav className="mb-10 rounded-xl border p-4 dark:border-slate-800">
+              <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide opacity-70">
+                Contents
+              </h2>
+              <ol className="grid gap-1 sm:grid-cols-2">
+                {doc.sections.map((section, i) => (
+                  <li key={section.id}>
+                    <button
+                      type="button"
+                      onClick={() => scrollTo(section.id)}
+                      className="text-left text-sm text-blue-600 hover:underline dark:text-blue-400"
+                    >
+                      {doc.features.numbered ? `${i + 1}. ` : ''}
+                      {section.title}
+                    </button>
+                  </li>
+                ))}
+              </ol>
+            </nav>
+          ) : null}
+
+          {doc.sections.map((section, i) => (
+            <SectionBody key={section.id} doc={doc} section={section} index={i} icons={icons} />
+          ))}
+
+          {doc.features.footer ? (
+            <footer className="mt-12 border-t pt-8 text-center text-sm opacity-70 dark:border-slate-800">
+              © {new Date().getFullYear()} {doc.tokens.companyName}. All rights reserved. | Last
+              updated: {doc.tokens.lastRevisedDate}
+            </footer>
+          ) : null}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/packages/legal-terms-privacy-policy/src/react/blocks.tsx
+++ b/packages/legal-terms-privacy-policy/src/react/blocks.tsx
@@ -1,0 +1,178 @@
+import React from 'react';
+import type { Block, ListItem } from '../types';
+import { accentOf, resolveIcon, type IconMap } from './icons';
+import type { Accent } from '../types';
+
+const URL_OR_EMAIL = /(https?:\/\/[^\s<)]+|[\w.+-]+@[\w-]+\.[\w.-]+)/g;
+
+/**
+ * Turn bare URLs and email addresses inside the legal text into links.
+ *
+ * The content model stores plain strings so it can render to Markdown and
+ * text too; this is where the React view earns its links back.
+ */
+export function linkify(text: string): React.ReactNode[] {
+  return text.split(URL_OR_EMAIL).map((part, i) => {
+    if (i % 2 === 0) return <React.Fragment key={i}>{part}</React.Fragment>;
+    const href = part.includes('@') && !part.startsWith('http') ? `mailto:${part}` : part;
+    return (
+      <a
+        key={i}
+        href={href}
+        className="text-blue-600 underline underline-offset-2 hover:text-blue-800 dark:text-blue-400"
+        {...(href.startsWith('http') ? { target: '_blank', rel: 'noreferrer noopener' } : {})}
+      >
+        {part}
+      </a>
+    );
+  });
+}
+
+function ListItems({ items, ordered }: { items: ListItem[]; ordered: boolean }) {
+  const Tag = ordered ? 'ol' : 'ul';
+  return (
+    <Tag
+      className={
+        ordered
+          ? 'my-3 list-decimal space-y-2 pl-6 [&_ol]:list-[lower-alpha]'
+          : 'my-3 list-disc space-y-2 pl-6'
+      }
+    >
+      {items.map((item, i) =>
+        typeof item === 'string' ? (
+          <li key={i}>{linkify(item)}</li>
+        ) : (
+          <li key={i}>
+            {linkify(item.text)}
+            {item.items ? <ListItems items={item.items} ordered={ordered} /> : null}
+          </li>
+        ),
+      )}
+    </Tag>
+  );
+}
+
+export interface BlockProps {
+  block: Block;
+  accent?: Accent;
+  icons?: IconMap;
+  /** `'cards'` keeps the tinted tile layout; `'prose'` flattens to headings and lists. */
+  style?: 'cards' | 'prose';
+}
+
+/**
+ * Render one content block.
+ *
+ * The same block data drives both views — `style: 'prose'` is what lets the
+ * full-text variant show a summary-only block (or a caller's card block)
+ * without a second copy of the content.
+ */
+export function BlockView({ block, accent, icons, style = 'cards' }: BlockProps) {
+  const tint = accentOf(accent);
+
+  switch (block.type) {
+    case 'p':
+      return (
+        <p className="my-4 leading-relaxed">
+          {block.strong ? <strong>{linkify(block.text)}</strong> : linkify(block.text)}
+        </p>
+      );
+
+    case 'ol':
+    case 'ul':
+      return (
+        <>
+          {block.lead ? <p className="my-4 leading-relaxed">{linkify(block.lead)}</p> : null}
+          <ListItems items={block.items} ordered={block.type === 'ol'} />
+        </>
+      );
+
+    case 'cards': {
+      const columns = block.columns ?? 3;
+      const grid =
+        columns === 1
+          ? 'grid-cols-1'
+          : columns === 2
+            ? 'sm:grid-cols-2'
+            : columns === 3
+              ? 'sm:grid-cols-2 lg:grid-cols-3'
+              : 'sm:grid-cols-2 lg:grid-cols-4';
+      if (style === 'prose') {
+        return (
+          <div className="my-4 space-y-4">
+            {block.items.map((card, i) => (
+              <div key={i}>
+                <h4 className="font-semibold">{card.title}</h4>
+                {card.text ? <p className="my-2 leading-relaxed">{linkify(card.text)}</p> : null}
+                {card.items ? <ListItems items={card.items} ordered={false} /> : null}
+              </div>
+            ))}
+          </div>
+        );
+      }
+      return (
+        <div className={`my-4 grid gap-4 ${grid}`}>
+          {block.items.map((card, i) => {
+            const Icon = resolveIcon(card.icon, icons);
+            return (
+              <div
+                key={i}
+                className={`rounded-lg border bg-white/80 p-4 backdrop-blur-sm transition-transform duration-300 hover:scale-[1.02] dark:bg-slate-900/60 ${tint.chip} ${
+                  block.center ? 'text-center' : ''
+                }`}
+              >
+                {card.icon ? (
+                  <Icon
+                    className={`mb-3 h-7 w-7 ${tint.icon} ${block.center ? 'mx-auto' : ''}`}
+                  />
+                ) : null}
+                <h4 className="mb-2 text-base font-semibold">{card.title}</h4>
+                {card.text ? <p className="text-sm leading-relaxed">{linkify(card.text)}</p> : null}
+                {card.items ? (
+                  <ul className="mt-2 space-y-1 text-sm">
+                    {card.items.map((item, j) => (
+                      <li key={j}>• {linkify(item)}</li>
+                    ))}
+                  </ul>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      );
+    }
+
+    case 'note': {
+      const Icon = resolveIcon(block.icon, icons);
+      if (style === 'prose') {
+        return (
+          <div className="my-4">
+            {block.title ? <h4 className="font-semibold">{block.title}</h4> : null}
+            {block.text ? <p className="my-2 leading-relaxed">{linkify(block.text)}</p> : null}
+            {block.items ? <ListItems items={block.items} ordered={false} /> : null}
+          </div>
+        );
+      }
+      return (
+        <div
+          className={`my-4 rounded-lg border bg-white/80 p-4 backdrop-blur-sm dark:bg-slate-900/60 ${tint.chip}`}
+        >
+          {block.title ? (
+            <h4 className="mb-3 flex items-center text-base font-semibold">
+              {block.icon ? <Icon className={`mr-2 h-5 w-5 ${tint.icon}`} /> : null}
+              {block.title}
+            </h4>
+          ) : null}
+          {block.text ? <p className="text-sm leading-relaxed">{linkify(block.text)}</p> : null}
+          {block.items ? (
+            <ul className="mt-2 space-y-2 text-sm">
+              {block.items.map((item, i) => (
+                <li key={i}>• {linkify(typeof item === 'string' ? item : item.text)}</li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      );
+    }
+  }
+}

--- a/packages/legal-terms-privacy-policy/src/react/icons.tsx
+++ b/packages/legal-terms-privacy-policy/src/react/icons.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import {
+  AlertTriangle,
+  ArrowLeft,
+  BookOpen,
+  Building2,
+  Calendar,
+  Check,
+  ChevronRight,
+  Copy,
+  Eye,
+  FileText,
+  Globe,
+  List,
+  Lock,
+  Mail,
+  Menu,
+  Scale,
+  Settings,
+  Shield,
+  Sparkles,
+  Star,
+  User,
+  Users,
+  X,
+} from 'lucide-react';
+import type { Accent, IconName } from '../types';
+
+/**
+ * Icons referenced by the built-in content, imported by name so bundlers can
+ * drop the rest of `lucide-react`.
+ *
+ * Callers adding their own sections can pass extra entries through the
+ * `icons` prop; anything still unresolved falls back to a document glyph
+ * rather than throwing.
+ */
+export const ICONS = {
+  AlertTriangle,
+  ArrowLeft,
+  BookOpen,
+  Building2,
+  Calendar,
+  Check,
+  ChevronRight,
+  Copy,
+  Eye,
+  FileText,
+  Globe,
+  List,
+  Lock,
+  Mail,
+  Menu,
+  Scale,
+  Settings,
+  Shield,
+  Sparkles,
+  Star,
+  User,
+  Users,
+  X,
+} as const;
+
+export type IconComponent = React.ComponentType<{ className?: string }>;
+export type IconMap = Record<string, IconComponent>;
+
+/** Look up an icon by name, falling back to `FileText` for unknown names. */
+export function resolveIcon(name: IconName | undefined, extra?: IconMap): IconComponent {
+  if (!name) return FileText;
+  return extra?.[name] ?? (ICONS as unknown as IconMap)[name] ?? FileText;
+}
+
+/** Tailwind classes per accent, so sections tint consistently across views. */
+export const ACCENTS: Record<Accent, { card: string; icon: string; chip: string }> = {
+  indigo: {
+    card: 'from-indigo-50 to-purple-50 border-indigo-200 dark:from-indigo-950/40 dark:to-purple-950/40 dark:border-indigo-900',
+    icon: 'text-indigo-600 dark:text-indigo-400',
+    chip: 'border-indigo-200 dark:border-indigo-900',
+  },
+  emerald: {
+    card: 'from-emerald-50 to-teal-50 border-emerald-200 dark:from-emerald-950/40 dark:to-teal-950/40 dark:border-emerald-900',
+    icon: 'text-emerald-600 dark:text-emerald-400',
+    chip: 'border-emerald-200 dark:border-emerald-900',
+  },
+  blue: {
+    card: 'from-blue-50 to-indigo-50 border-blue-200 dark:from-blue-950/40 dark:to-indigo-950/40 dark:border-blue-900',
+    icon: 'text-blue-600 dark:text-blue-400',
+    chip: 'border-blue-200 dark:border-blue-900',
+  },
+  amber: {
+    card: 'from-amber-50 to-orange-50 border-amber-200 dark:from-amber-950/40 dark:to-orange-950/40 dark:border-amber-900',
+    icon: 'text-amber-600 dark:text-amber-400',
+    chip: 'border-amber-200 dark:border-amber-900',
+  },
+  rose: {
+    card: 'from-rose-50 to-pink-50 border-rose-200 dark:from-rose-950/40 dark:to-pink-950/40 dark:border-rose-900',
+    icon: 'text-rose-600 dark:text-rose-400',
+    chip: 'border-rose-200 dark:border-rose-900',
+  },
+  cyan: {
+    card: 'from-cyan-50 to-blue-50 border-cyan-200 dark:from-cyan-950/40 dark:to-blue-950/40 dark:border-cyan-900',
+    icon: 'text-cyan-600 dark:text-cyan-400',
+    chip: 'border-cyan-200 dark:border-cyan-900',
+  },
+  teal: {
+    card: 'from-teal-50 to-cyan-50 border-teal-200 dark:from-teal-950/40 dark:to-cyan-950/40 dark:border-teal-900',
+    icon: 'text-teal-600 dark:text-teal-400',
+    chip: 'border-teal-200 dark:border-teal-900',
+  },
+  green: {
+    card: 'from-green-50 to-emerald-50 border-green-200 dark:from-green-950/40 dark:to-emerald-950/40 dark:border-green-900',
+    icon: 'text-green-600 dark:text-green-400',
+    chip: 'border-green-200 dark:border-green-900',
+  },
+  yellow: {
+    card: 'from-yellow-50 to-amber-50 border-yellow-200 dark:from-yellow-950/40 dark:to-amber-950/40 dark:border-yellow-900',
+    icon: 'text-yellow-600 dark:text-yellow-400',
+    chip: 'border-yellow-200 dark:border-yellow-900',
+  },
+  purple: {
+    card: 'from-purple-50 to-violet-50 border-purple-200 dark:from-purple-950/40 dark:to-violet-950/40 dark:border-purple-900',
+    icon: 'text-purple-600 dark:text-purple-400',
+    chip: 'border-purple-200 dark:border-purple-900',
+  },
+  red: {
+    card: 'from-red-50 to-rose-50 border-red-200 dark:from-red-950/40 dark:to-rose-950/40 dark:border-red-900',
+    icon: 'text-red-600 dark:text-red-400',
+    chip: 'border-red-200 dark:border-red-900',
+  },
+  slate: {
+    card: 'from-slate-50 to-gray-50 border-slate-200 dark:from-slate-900/60 dark:to-gray-900/60 dark:border-slate-700',
+    icon: 'text-slate-600 dark:text-slate-400',
+    chip: 'border-slate-200 dark:border-slate-700',
+  },
+};
+
+/** Accent classes for a section, defaulting to `slate` for untinted sections. */
+export function accentOf(accent: Accent | undefined) {
+  return ACCENTS[accent ?? 'slate'];
+}

--- a/packages/legal-terms-privacy-policy/src/react/index.ts
+++ b/packages/legal-terms-privacy-policy/src/react/index.ts
@@ -1,0 +1,10 @@
+/**
+ * React entry point. Pulls in `react` and `lucide-react`; keep imports of the
+ * package root free of both by importing from here only where you render.
+ */
+export { default as LegalTermsPrivacyPolicy } from './LegalTermsPrivacyPolicy';
+export { default } from './LegalTermsPrivacyPolicy';
+export type { LegalTermsPrivacyPolicyProps } from './LegalTermsPrivacyPolicy';
+export { BlockView, linkify } from './blocks';
+export { ACCENTS, ICONS, accentOf, resolveIcon } from './icons';
+export type { IconComponent, IconMap } from './icons';

--- a/packages/legal-terms-privacy-policy/src/render/html.ts
+++ b/packages/legal-terms-privacy-policy/src/render/html.ts
@@ -1,0 +1,155 @@
+import type { Block, LegalDoc, LegalDocOptions, ListItem, Section } from '../types';
+import { resolveLegalDoc } from '../resolve';
+
+/** Escape the five characters that can break out of HTML text or an attribute. */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/** Linkify bare URLs and email addresses left in the legal text. */
+function autoLink(text: string): string {
+  return escapeHtml(text)
+    .replace(/\bhttps?:\/\/[^\s<)]+/g, (url) => `<a href="${url}">${url}</a>`)
+    .replace(
+      /\b[\w.+-]+@[\w-]+\.[\w.-]+\b/g,
+      (email) => `<a href="mailto:${email}">${email}</a>`,
+    );
+}
+
+function renderListItems(items: ListItem[], tag: 'ol' | 'ul'): string {
+  const body = items
+    .map((item) => {
+      if (typeof item === 'string') return `<li>${autoLink(item)}</li>`;
+      const nested = item.items ? renderListItems(item.items, tag) : '';
+      return `<li>${autoLink(item.text)}${nested}</li>`;
+    })
+    .join('');
+  return `<${tag}>${body}</${tag}>`;
+}
+
+function renderBlock(block: Block): string {
+  switch (block.type) {
+    case 'p':
+      return block.strong
+        ? `<p><strong>${autoLink(block.text)}</strong></p>`
+        : `<p>${autoLink(block.text)}</p>`;
+    case 'ol':
+    case 'ul':
+      return (
+        (block.lead ? `<p>${autoLink(block.lead)}</p>` : '') +
+        renderListItems(block.items, block.type)
+      );
+    case 'cards':
+      return (
+        `<div class="legal-cards legal-cards-${block.columns ?? 3}">` +
+        block.items
+          .map(
+            (card) =>
+              `<div class="legal-card">` +
+              `<h4>${escapeHtml(card.title)}</h4>` +
+              (card.text ? `<p>${autoLink(card.text)}</p>` : '') +
+              (card.items
+                ? `<ul>${card.items.map((i) => `<li>${autoLink(i)}</li>`).join('')}</ul>`
+                : '') +
+              `</div>`,
+          )
+          .join('') +
+        `</div>`
+      );
+    case 'note':
+      return (
+        `<div class="legal-note">` +
+        (block.title ? `<h4>${escapeHtml(block.title)}</h4>` : '') +
+        (block.text ? `<p>${autoLink(block.text)}</p>` : '') +
+        (block.items ? renderListItems(block.items, 'ul') : '') +
+        `</div>`
+      );
+  }
+}
+
+function renderSection(section: Section, label: string, depth: number): string {
+  const tag = depth === 0 ? 'h2' : 'h3';
+  return (
+    `<section id="${escapeHtml(section.id)}">` +
+    `<${tag}>${label ? `${escapeHtml(label)} ` : ''}${escapeHtml(section.title)}</${tag}>` +
+    (section.blocks?.map(renderBlock).join('') ?? '') +
+    (section.subsections
+      ?.map((sub, i) =>
+        renderSection(sub, label ? `${label.replace(/\.$/, '')}.${i + 1}` : '', depth + 1),
+      )
+      .join('') ?? '') +
+    `</section>`
+  );
+}
+
+/**
+ * Stylesheet for {@link toHtml}'s markup — the `.privacy-page` rules the
+ * QwkSearch and Debate AI pages already ship, plus card and note styles.
+ * Exported so a host page can inline it rather than take the full document.
+ */
+export const LEGAL_CSS = `
+.legal-page { font-family: Lato, system-ui, -apple-system, Arial, sans-serif; line-height: 1.6; margin: 0 auto; max-width: 800px; padding: 20px 20px 50px; color: #333; }
+.legal-page h1 { margin: 1rem 0; font-size: 2rem; color: #2c3e50; font-variant: small-caps; }
+.legal-page h2 { margin: 1.5rem 0 1rem; font-size: 1.5rem; color: #34495e; font-variant: small-caps; }
+.legal-page h3 { margin: 1rem 0; font-size: 1.2rem; color: #7f8c8d; font-variant: small-caps; }
+.legal-page h4 { margin: .75rem 0 .25rem; font-size: 1rem; color: #34495e; }
+.legal-page p { margin: 1rem 0; }
+.legal-page ol { list-style-type: decimal; padding-left: 20px; margin: 1rem 0; }
+.legal-page ul { list-style-type: disc; padding-left: 20px; margin: 1rem 0; }
+.legal-page ol ol { list-style-type: lower-alpha; }
+.legal-page a { color: #2563eb; }
+.legal-note { border: 1px solid #e2e8f0; border-radius: .5rem; padding: .75rem 1rem; margin: 1rem 0; background: #f8fafc; }
+.legal-cards { display: grid; gap: 1rem; margin: 1rem 0; grid-template-columns: 1fr; }
+.legal-card { border: 1px solid #e2e8f0; border-radius: .5rem; padding: 1rem; background: #fff; }
+@media (min-width: 640px) {
+  .legal-cards-2, .legal-cards-4 { grid-template-columns: repeat(2, 1fr); }
+  .legal-cards-3 { grid-template-columns: repeat(3, 1fr); }
+}
+@media (min-width: 1024px) { .legal-cards-4 { grid-template-columns: repeat(4, 1fr); } }
+@media (prefers-color-scheme: dark) {
+  .legal-page { color: #e2e8f0; }
+  .legal-page h1, .legal-page h2, .legal-page h3, .legal-page h4 { color: #cbd5e1; }
+  .legal-note { background: #1e293b; border-color: #334155; }
+  .legal-card { background: #0f172a; border-color: #334155; }
+}
+`.trim();
+
+/**
+ * Render a resolved document as an HTML fragment (no `<html>` wrapper).
+ *
+ * Pair it with {@link LEGAL_CSS}, or pass `{ standalone: true }` for a
+ * complete page with the stylesheet inlined.
+ */
+export function toHtml(doc: LegalDoc, opts: { standalone?: boolean } = {}): string {
+  const body =
+    `<main class="legal-page">` +
+    `<h1>${escapeHtml(doc.title)}</h1>` +
+    `<p><strong>Revised Date: ${escapeHtml(String(doc.tokens.lastRevisedDate))}</strong></p>` +
+    doc.sections
+      .map((section, index) =>
+        renderSection(section, doc.features.numbered ? `${index + 1}.` : '', 0),
+      )
+      .join('') +
+    `</main>`;
+
+  if (!opts.standalone) return body;
+  return (
+    `<!doctype html><html lang="en"><head><meta charset="utf-8">` +
+    `<meta name="viewport" content="width=device-width, initial-scale=1">` +
+    `<title>${escapeHtml(doc.title)}</title><style>${LEGAL_CSS}</style></head>` +
+    `<body>${body}</body></html>`
+  );
+}
+
+/** Resolve options and render HTML in one call. */
+export function renderHtml(
+  options: LegalDocOptions = {},
+  opts: { standalone?: boolean } = {},
+): string {
+  return toHtml(resolveLegalDoc(options), opts);
+}

--- a/packages/legal-terms-privacy-policy/src/render/markdown.ts
+++ b/packages/legal-terms-privacy-policy/src/render/markdown.ts
@@ -1,0 +1,81 @@
+import type { Block, LegalDoc, LegalDocOptions, ListItem, Section } from '../types';
+import { resolveLegalDoc } from '../resolve';
+
+function listItems(items: ListItem[], ordered: boolean, depth: number): string[] {
+  const indent = '  '.repeat(depth);
+  return items.flatMap((item, index) => {
+    const marker = ordered ? `${index + 1}.` : '-';
+    if (typeof item === 'string') return [`${indent}${marker} ${item}`];
+    return [
+      `${indent}${marker} ${item.text}`,
+      ...(item.items ? listItems(item.items, ordered, depth + 1) : []),
+    ];
+  });
+}
+
+function renderBlock(block: Block): string[] {
+  switch (block.type) {
+    case 'p':
+      return [block.strong ? `**${block.text}**` : block.text, ''];
+    case 'ol':
+    case 'ul':
+      return [
+        ...(block.lead ? [block.lead, ''] : []),
+        ...listItems(block.items, block.type === 'ol', 0),
+        '',
+      ];
+    case 'cards':
+      return block.items.flatMap((card) => [
+        `**${card.title}**`,
+        '',
+        ...(card.text ? [card.text, ''] : []),
+        ...(card.items ? [...card.items.map((i) => `- ${i}`), ''] : []),
+      ]);
+    case 'note':
+      return [
+        ...(block.title ? [`**${block.title}**`, ''] : []),
+        ...(block.text ? [block.text, ''] : []),
+        ...(block.items ? [...listItems(block.items, false, 0), ''] : []),
+      ];
+  }
+}
+
+function renderSection(section: Section, label: string, depth: number): string[] {
+  const hashes = '#'.repeat(Math.min(depth + 2, 6));
+  return [
+    `${hashes} ${label ? `${label} ` : ''}${section.title}`,
+    '',
+    ...(section.blocks?.flatMap(renderBlock) ?? []),
+    ...(section.subsections?.flatMap((sub, i) =>
+      renderSection(sub, label ? `${label.replace(/\.$/, '')}.${i + 1}` : '', depth + 1),
+    ) ?? []),
+  ];
+}
+
+/**
+ * Render a resolved document as GitHub-flavored Markdown.
+ *
+ * Useful for a `TERMS.md` in a repo, an MDX docs page, or a diffable snapshot
+ * of the policy text in review.
+ */
+export function toMarkdown(doc: LegalDoc): string {
+  const lines = [
+    `# ${doc.title}`,
+    '',
+    `**Revised Date: ${doc.tokens.lastRevisedDate}**`,
+    ...(doc.tokens.effectiveDate !== doc.tokens.lastRevisedDate
+      ? [`**Effective Date: ${doc.tokens.effectiveDate}**`]
+      : []),
+    '',
+    ...doc.sections.flatMap((section, index) =>
+      renderSection(section, doc.features.numbered ? `${index + 1}.` : '', 0),
+    ),
+  ];
+  // Collapse the blank lines each block appends into at most one.
+  return lines.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd() + '\n';
+}
+
+/** Resolve options and render Markdown in one call. */
+export function renderMarkdown(options: LegalDocOptions = {}): string {
+  return toMarkdown(resolveLegalDoc(options));
+}

--- a/packages/legal-terms-privacy-policy/src/render/text.ts
+++ b/packages/legal-terms-privacy-policy/src/render/text.ts
@@ -1,0 +1,74 @@
+import type { Block, LegalDoc, LegalDocOptions, ListItem, Section } from '../types';
+import { resolveLegalDoc } from '../resolve';
+
+function listLines(items: ListItem[], ordered: boolean, depth: number): string[] {
+  const indent = '    '.repeat(depth);
+  return items.flatMap((item, index) => {
+    const marker = ordered ? `${index + 1}.` : '-';
+    if (typeof item === 'string') return [`${indent}${marker} ${item}`];
+    return [
+      `${indent}${marker} ${item.text}`,
+      ...(item.items ? listLines(item.items, ordered, depth + 1) : []),
+    ];
+  });
+}
+
+function blockLines(block: Block): string[] {
+  switch (block.type) {
+    case 'p':
+      return [block.text, ''];
+    case 'ol':
+    case 'ul':
+      return [
+        ...(block.lead ? [block.lead, ''] : []),
+        ...listLines(block.items, block.type === 'ol', 0),
+        '',
+      ];
+    case 'cards':
+      return block.items.flatMap((card) => [
+        card.title,
+        ...(card.text ? [card.text] : []),
+        ...(card.items ?? []).map((i) => `- ${i}`),
+        '',
+      ]);
+    case 'note':
+      return [
+        ...(block.title ? [block.title] : []),
+        ...(block.text ? [block.text] : []),
+        ...(block.items ? listLines(block.items, false, 0) : []),
+        '',
+      ];
+  }
+}
+
+function sectionLines(section: Section, label: string): string[] {
+  return [
+    `${label ? `${label} ` : ''}${section.title}`.toUpperCase(),
+    '',
+    ...(section.blocks?.flatMap(blockLines) ?? []),
+    ...(section.subsections?.flatMap((sub, i) =>
+      sectionLines(sub, label ? `${label.replace(/\.$/, '')}.${i + 1}` : ''),
+    ) ?? []),
+  ];
+}
+
+/**
+ * Render a resolved document as plain text — for an email, a CLI `--print`,
+ * or an in-app agreement dialog with no markup engine.
+ */
+export function toPlainText(doc: LegalDoc): string {
+  const lines = [
+    doc.title.toUpperCase(),
+    `Revised Date: ${doc.tokens.lastRevisedDate}`,
+    '',
+    ...doc.sections.flatMap((section, index) =>
+      sectionLines(section, doc.features.numbered ? `${index + 1}.` : ''),
+    ),
+  ];
+  return lines.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd() + '\n';
+}
+
+/** Resolve options and render plain text in one call. */
+export function renderText(options: LegalDocOptions = {}): string {
+  return toPlainText(resolveLegalDoc(options));
+}

--- a/packages/legal-terms-privacy-policy/src/resolve.ts
+++ b/packages/legal-terms-privacy-policy/src/resolve.ts
@@ -1,0 +1,264 @@
+import type {
+  Block,
+  Card,
+  LegalDoc,
+  LegalDocOptions,
+  LegalFeatures,
+  LegalTokens,
+  ListItem,
+  PartId,
+  Section,
+  Variant,
+} from './types';
+import { FULL_SECTIONS } from './content/full';
+import { SUMMARY_SECTIONS } from './content/summary';
+
+/**
+ * Placeholder values. Every one is overridable; `appName` is the only field
+ * most callers need to set, and `companyName`/`effectiveDate` fall back to
+ * `appName`/`lastRevisedDate` when left out.
+ */
+export const DEFAULT_TOKENS: LegalTokens = {
+  appName: 'Our Service',
+  companyName: '',
+  contactEmail: 'legal@example.com',
+  homeUrl: '/',
+  lastRevisedDate: 'January 1, 2025',
+  effectiveDate: '',
+  jurisdiction: 'the United States',
+  minimumAge: 18,
+  childrenAge: 13,
+  dataDeletionDays: 30,
+};
+
+/** Chrome shown unless a caller turns it off. */
+export const DEFAULT_FEATURES: LegalFeatures = {
+  backLink: true,
+  sidebar: true,
+  tableOfContents: true,
+  copyButtons: true,
+  badges: true,
+  variantSwitch: true,
+  footer: true,
+  numbered: true,
+};
+
+/** Compliance pills shown under the title when `features.badges` is on. */
+export const DEFAULT_BADGES = ['GDPR Compliant', 'CCPA Compliant', 'Cookie Policy'];
+
+/** The built-in section trees, keyed by variant. */
+export const VARIANTS: Record<Variant, Section[]> = {
+  summary: SUMMARY_SECTIONS,
+  full: FULL_SECTIONS,
+};
+
+/**
+ * Replace every `{{token}}` in `text` with its value.
+ *
+ * Unknown tokens are left as-is rather than blanked, so a typo shows up in the
+ * rendered page instead of silently deleting a clause.
+ */
+export function interpolate(text: string, tokens: LegalTokens): string {
+  return text.replace(/\{\{\s*(\w+)\s*\}\}/g, (match, key: string) => {
+    const value = tokens[key];
+    return value === undefined || value === '' ? match : String(value);
+  });
+}
+
+function interpolateListItem(item: ListItem, tokens: LegalTokens): ListItem {
+  if (typeof item === 'string') return interpolate(item, tokens);
+  return {
+    text: interpolate(item.text, tokens),
+    ...(item.items ? { items: item.items.map((sub) => interpolateListItem(sub, tokens)) } : {}),
+  };
+}
+
+function interpolateCard(card: Card, tokens: LegalTokens): Card {
+  return {
+    ...card,
+    title: interpolate(card.title, tokens),
+    ...(card.text ? { text: interpolate(card.text, tokens) } : {}),
+    ...(card.items ? { items: card.items.map((i) => interpolate(i, tokens)) } : {}),
+  };
+}
+
+function interpolateBlock(block: Block, tokens: LegalTokens): Block {
+  switch (block.type) {
+    case 'p':
+      return { ...block, text: interpolate(block.text, tokens) };
+    case 'ol':
+    case 'ul':
+      return {
+        ...block,
+        ...(block.lead ? { lead: interpolate(block.lead, tokens) } : {}),
+        items: block.items.map((i) => interpolateListItem(i, tokens)),
+      };
+    case 'cards':
+      return { ...block, items: block.items.map((c) => interpolateCard(c, tokens)) };
+    case 'note':
+      return {
+        ...block,
+        ...(block.title ? { title: interpolate(block.title, tokens) } : {}),
+        ...(block.text ? { text: interpolate(block.text, tokens) } : {}),
+        ...(block.items ? { items: block.items.map((i) => interpolateListItem(i, tokens)) } : {}),
+      };
+  }
+}
+
+function interpolateSection(section: Section, tokens: LegalTokens): Section {
+  return {
+    ...section,
+    title: interpolate(section.title, tokens),
+    ...(section.blocks ? { blocks: section.blocks.map((b) => interpolateBlock(b, tokens)) } : {}),
+    ...(section.subsections
+      ? { subsections: section.subsections.map((s) => interpolateSection(s, tokens)) }
+      : {}),
+  };
+}
+
+/**
+ * Drop sections whose `part` is switched off, that are excluded by id, or that
+ * fall outside an `include` whitelist. Runs over subsections too, so a caller
+ * can remove `california-selling` without losing the rest of the CCPA notice.
+ *
+ * A parent kept only because a child survived keeps that child; a parent whose
+ * own id is excluded takes its children with it. Naming a parent in `include`
+ * keeps its whole subtree, so `include: ['ai-ethics']` is the section and its
+ * four sub-policies rather than an empty heading.
+ */
+function filterSections(
+  sections: Section[],
+  parts: Partial<Record<PartId, boolean>>,
+  include: Set<string> | null,
+  exclude: Set<string>,
+): Section[] {
+  const kept: Section[] = [];
+  for (const section of sections) {
+    if (exclude.has(section.id)) continue;
+    // `core` is structural — turning it off would leave an empty document.
+    if (section.part && section.part !== 'core' && parts[section.part] === false) continue;
+
+    // An explicitly included parent takes its children with it: past this
+    // point the whitelist has done its job and only `exclude` and `parts` apply.
+    const childInclude = include?.has(section.id) ? null : include;
+    const subsections = section.subsections
+      ? filterSections(section.subsections, parts, childInclude, exclude)
+      : undefined;
+
+    // An `include` list keeps a parent if the parent itself or any of its
+    // surviving children was named, so `include: ['california-rights']` still
+    // renders under its "California Residents" heading.
+    if (include && !include.has(section.id) && !subsections?.length) continue;
+
+    kept.push({
+      ...section,
+      ...(subsections ? { subsections } : {}),
+    });
+  }
+  return kept;
+}
+
+/** Apply `replace` patches to a section and its subsections, by id. */
+function patchSections(sections: Section[], patches: Record<string, Partial<Section>>): Section[] {
+  return sections.map((section) => {
+    const patched = patches[section.id] ? { ...section, ...patches[section.id] } : section;
+    return patched.subsections
+      ? { ...patched, subsections: patchSections(patched.subsections, patches) }
+      : patched;
+  });
+}
+
+/** Insert caller-authored sections at their requested positions. */
+function insertSections(sections: Section[], insertions: LegalDocOptions['add']): Section[] {
+  if (!insertions?.length) return sections;
+  const result = [...sections];
+  for (const { section, after, before, at } of insertions) {
+    const afterIndex = after ? result.findIndex((s) => s.id === after) : -1;
+    const beforeIndex = before ? result.findIndex((s) => s.id === before) : -1;
+    let index: number;
+    if (afterIndex >= 0) index = afterIndex + 1;
+    else if (beforeIndex >= 0) index = beforeIndex;
+    else if (typeof at === 'number') index = Math.max(0, Math.min(at, result.length));
+    else index = result.length;
+    result.splice(index, 0, section);
+  }
+  return result;
+}
+
+/**
+ * Reorder by the given ids. Sections named in `order` come first in that
+ * order; anything unnamed keeps its relative position after them.
+ */
+function reorderSections(sections: Section[], order: string[]): Section[] {
+  const byId = new Map(sections.map((s) => [s.id, s]));
+  const named = order.map((id) => byId.get(id)).filter((s): s is Section => Boolean(s));
+  const namedIds = new Set(named.map((s) => s.id));
+  return [...named, ...sections.filter((s) => !namedIds.has(s.id))];
+}
+
+/**
+ * Build a ready-to-render document from a caller's options.
+ *
+ * Order of operations: pick the variant's sections → drop parts and ids →
+ * patch surviving sections → insert new ones → reorder → interpolate tokens.
+ * Inserted sections are interpolated too, so caller-authored text can use the
+ * same `{{appName}}` placeholders as the built-ins.
+ *
+ * @example
+ * ```ts
+ * const doc = resolveLegalDoc({
+ *   appName: 'QwkSearch',
+ *   contactEmail: 'legal@qwksearch.com',
+ *   lastRevisedDate: 'March 1, 2026',
+ *   variant: 'full',
+ *   parts: { california: false },   // drop the CCPA notice
+ *   exclude: ['social-features'],   // drop one section by id
+ * });
+ * ```
+ */
+export function resolveLegalDoc(options: LegalDocOptions = {}): LegalDoc {
+  const {
+    variant = 'full',
+    parts = {},
+    include,
+    exclude = [],
+    add,
+    replace,
+    order,
+    features,
+    badges,
+    title,
+    tokens: extraTokens,
+    ...tokenOverrides
+  } = options;
+
+  // Drop `undefined` overrides rather than letting them shadow a default — a
+  // caller passing `contactEmail={process.env.APP_EMAIL}` on a machine without
+  // that variable should get the default, not a `{{contactEmail}}` on the page.
+  const defined = Object.fromEntries(
+    Object.entries(tokenOverrides).filter(([, value]) => value !== undefined),
+  );
+  const tokens: LegalTokens = { ...DEFAULT_TOKENS, ...extraTokens, ...defined };
+  if (!tokens.companyName) tokens.companyName = tokens.appName;
+  if (!tokens.effectiveDate) tokens.effectiveDate = tokens.lastRevisedDate;
+
+  let sections = filterSections(
+    VARIANTS[variant] ?? VARIANTS.full,
+    parts,
+    include?.length ? new Set(include) : null,
+    new Set(exclude),
+  );
+  if (replace) sections = patchSections(sections, replace);
+  sections = insertSections(sections, add);
+  if (order?.length) sections = reorderSections(sections, order);
+  sections = sections.map((s) => interpolateSection(s, tokens));
+
+  return {
+    variant,
+    title: interpolate(title ?? '{{appName}} Terms of Service & Privacy Policy', tokens),
+    tokens,
+    features: { ...DEFAULT_FEATURES, ...features },
+    badges: badges ?? DEFAULT_BADGES,
+    sections,
+  };
+}

--- a/packages/legal-terms-privacy-policy/src/types.ts
+++ b/packages/legal-terms-privacy-policy/src/types.ts
@@ -1,0 +1,247 @@
+/**
+ * Content model for a combined Terms of Service + Privacy Policy document.
+ *
+ * The document is plain data — a tree of sections and blocks — so the same
+ * source text can be rendered as React, HTML, Markdown or plain text, and so
+ * callers can add, remove, reorder or rewrite any part of it without forking
+ * a JSX file.
+ */
+
+/**
+ * Name of a `lucide-react` icon, used by the card renderer for section and
+ * card glyphs. Unknown names fall back to a neutral document icon, so a doc
+ * stays renderable even when it names an icon the installed lucide version
+ * does not have.
+ */
+export type IconName = string;
+
+/**
+ * Tailwind color family used to tint a section's card. The card renderer maps
+ * each accent onto a fixed background/border/text triple so sections stay
+ * visually distinct without callers writing class strings.
+ */
+export type Accent =
+  | 'indigo'
+  | 'emerald'
+  | 'blue'
+  | 'amber'
+  | 'rose'
+  | 'cyan'
+  | 'teal'
+  | 'green'
+  | 'yellow'
+  | 'purple'
+  | 'red'
+  | 'slate';
+
+/** A list entry, optionally with its own nested list (for `a.`/`b.` sub-items). */
+export type ListItem = string | { text: string; items?: ListItem[] };
+
+/** A single tile inside a {@link CardsBlock}. */
+export interface Card {
+  title: string;
+  /** Body copy. Omit when the tile is a bullet list. */
+  text?: string;
+  /** Bullets shown under the title. Combine with `text` or use alone. */
+  items?: string[];
+  icon?: IconName;
+}
+
+/** A paragraph of body copy. */
+export interface ParagraphBlock {
+  type: 'p';
+  text: string;
+  /** Render the whole paragraph bold (used for lead-ins like "Your Account:"). */
+  strong?: boolean;
+}
+
+/** An ordered (`1.`) or unordered (`•`) list. */
+export interface ListBlock {
+  type: 'ol' | 'ul';
+  items: ListItem[];
+  /** Optional lead-in line rendered above the list. */
+  lead?: string;
+}
+
+/** A grid of tiles. Rendered as a bullet list by the text-first renderers. */
+export interface CardsBlock {
+  type: 'cards';
+  /** Columns at desktop width. Defaults to 3. */
+  columns?: 1 | 2 | 3 | 4;
+  /** Center the title/text inside each tile. */
+  center?: boolean;
+  items: Card[];
+}
+
+/** A callout box — a sub-heading plus body copy and/or bullets. */
+export interface NoteBlock {
+  type: 'note';
+  title?: string;
+  text?: string;
+  items?: ListItem[];
+  icon?: IconName;
+}
+
+export type Block = ParagraphBlock | ListBlock | CardsBlock | NoteBlock;
+
+/**
+ * One section of the document. Sections may nest one level (7 → 7.1, 7.2),
+ * which the full-text renderer numbers automatically.
+ */
+export interface Section {
+  /** Stable slug — the anchor id, and the handle used by `include`/`exclude`. */
+  id: string;
+  title: string;
+  icon?: IconName;
+  accent?: Accent;
+  blocks?: Block[];
+  subsections?: Section[];
+  /**
+   * Marks the section as belonging to an optional part of the document (for
+   * example `'ai'` or `'california'`) so it can be switched off wholesale via
+   * {@link LegalDocOptions.parts} without listing every section id.
+   */
+  part?: PartId;
+}
+
+/**
+ * Named groups of sections that are commonly kept or dropped as a unit.
+ *
+ * - `core` — introduction, changes, accounts, use, materials, feedback,
+ *   warranties, termination, contact. Always on; listing it in `parts` is a
+ *   no-op, because a document without it is not a document.
+ * - `ai` — the Artificial Intelligence Ethical Use Policy and the AI-specific
+ *   opt-out language. Drop it for a product with no model in the loop.
+ * - `privacy` — collection, use, disclosure and retention of personal data.
+ * - `cookies` — cookies, tracking technologies and Do Not Track.
+ * - `california` — the CCPA/CPRA resident notice.
+ * - `children` — the COPPA under-13 notice.
+ * - `security` — security measures and data retention.
+ * - `thirdParty` — third-party links and social features.
+ */
+export type PartId =
+  | 'core'
+  | 'ai'
+  | 'privacy'
+  | 'cookies'
+  | 'california'
+  | 'children'
+  | 'security'
+  | 'thirdParty';
+
+/** The two presentations of the same policy. */
+export type Variant = 'summary' | 'full';
+
+/**
+ * The substitution values the built-in text refers to.
+ *
+ * Kept free of an index signature so {@link LegalDocOptions} can extend it —
+ * see {@link LegalTokens} for the open-ended form used at render time.
+ */
+export interface BaseTokens {
+  /** Product name, e.g. `"QwkSearch"`. */
+  appName: string;
+  /** Legal entity behind the product. Defaults to `appName`. */
+  companyName: string;
+  /** Address for legal and privacy requests. */
+  contactEmail: string;
+  /** Marketing site URL, used by the "back to home" link. */
+  homeUrl: string;
+  /** Date the text was last revised, already formatted for display. */
+  lastRevisedDate: string;
+  /** Date the current version took effect. Defaults to `lastRevisedDate`. */
+  effectiveDate: string;
+  /** Region the Services are offered in, named in the introduction. */
+  jurisdiction: string;
+  /** Minimum age to hold an account, named in the acceptance section. */
+  minimumAge: number | string;
+  /** Age below which no data is knowingly collected (COPPA). */
+  childrenAge: number | string;
+  /** Days after account deletion within which personal data is purged. */
+  dataDeletionDays: number | string;
+}
+
+/**
+ * Substitution values interpolated into `{{token}}` placeholders, including
+ * any extra ones a caller passed for their own sections.
+ */
+export type LegalTokens = BaseTokens & Record<string, string | number | undefined>;
+
+/** Which chrome the React views render around the document body. */
+export interface LegalFeatures {
+  /** "Back to Home" link above the title. */
+  backLink: boolean;
+  /** Sticky icon rail / mobile table of contents (summary variant). */
+  sidebar: boolean;
+  /** Inline table of contents above the body (full variant). */
+  tableOfContents: boolean;
+  /** Copy-to-clipboard buttons on the header and contact email. */
+  copyButtons: boolean;
+  /** Compliance pills under the title ("GDPR Compliant", …). */
+  badges: boolean;
+  /** The summary ⇄ full-text switch. */
+  variantSwitch: boolean;
+  /** Copyright line at the foot of the document. */
+  footer: boolean;
+  /** Number full-variant sections `1.`, `1.1`, … */
+  numbered: boolean;
+}
+
+/** An insertion of a caller-authored section into the document. */
+export interface SectionInsertion {
+  section: Section;
+  /** Insert immediately after the section with this id. */
+  after?: string;
+  /** Insert immediately before the section with this id. */
+  before?: string;
+  /** Insert at this index. Applied when neither `after` nor `before` matches. */
+  at?: number;
+}
+
+/**
+ * Everything a caller can change about the document.
+ *
+ * Every field is optional; {@link resolveLegalDoc} fills the gaps from
+ * {@link DEFAULT_TOKENS} and {@link DEFAULT_FEATURES}.
+ */
+export interface LegalDocOptions extends Partial<BaseTokens> {
+  /**
+   * Extra `{{token}}` values, for placeholders used by caller-authored
+   * sections. Named tokens above win over entries here.
+   */
+  tokens?: Record<string, string | number>;
+  /** Which presentation to render. Defaults to `'full'`. */
+  variant?: Variant;
+  /** Turn named parts of the document on or off. */
+  parts?: Partial<Record<PartId, boolean>>;
+  /** Keep only these section ids (applied before `exclude`). */
+  include?: string[];
+  /** Drop these section ids. */
+  exclude?: string[];
+  /** Add caller-authored sections at chosen positions. */
+  add?: SectionInsertion[];
+  /**
+   * Replace or patch sections by id. A partial section is merged over the
+   * built-in one, so `{ contact: { blocks: [...] } }` swaps the body while
+   * keeping the title and icon.
+   */
+  replace?: Record<string, Partial<Section>>;
+  /** Final section order, by id. Ids not listed keep their relative order. */
+  order?: string[];
+  /** Chrome toggles. */
+  features?: Partial<LegalFeatures>;
+  /** Compliance pills to show when `features.badges` is on. */
+  badges?: string[];
+  /** Document title. Defaults to `"{{appName}} Terms of Service & Privacy Policy"`. */
+  title?: string;
+}
+
+/** A fully-resolved document, ready to render. */
+export interface LegalDoc {
+  variant: Variant;
+  title: string;
+  tokens: LegalTokens;
+  features: LegalFeatures;
+  badges: string[];
+  sections: Section[];
+}

--- a/packages/legal-terms-privacy-policy/test/legal-terms-privacy-policy.test.ts
+++ b/packages/legal-terms-privacy-policy/test/legal-terms-privacy-policy.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_TOKENS,
+  FULL_SECTIONS,
+  SUMMARY_SECTIONS,
+  interpolate,
+  renderHtml,
+  renderMarkdown,
+  renderText,
+  resolveLegalDoc,
+} from '../src/index';
+import type { Section } from '../src/types';
+
+/** Flatten a section tree to ids so assertions can look for nested sections. */
+function allIds(sections: Section[]): string[] {
+  return sections.flatMap((s) => [s.id, ...allIds(s.subsections ?? [])]);
+}
+
+/** Every string in the tree, for leak checks on tokens. */
+function allText(sections: Section[]): string {
+  return JSON.stringify(sections);
+}
+
+describe('interpolate', () => {
+  it('substitutes known tokens', () => {
+    expect(interpolate('Hello {{appName}}', { ...DEFAULT_TOKENS, appName: 'Acme' })).toBe(
+      'Hello Acme',
+    );
+  });
+
+  it('leaves unknown tokens visible rather than blanking the clause', () => {
+    expect(interpolate('Contact {{nope}}', DEFAULT_TOKENS)).toBe('Contact {{nope}}');
+  });
+
+  it('tolerates whitespace inside the braces', () => {
+    expect(interpolate('{{ appName }}', { ...DEFAULT_TOKENS, appName: 'Acme' })).toBe('Acme');
+  });
+});
+
+describe('resolveLegalDoc', () => {
+  it('defaults to the full variant', () => {
+    expect(resolveLegalDoc().variant).toBe('full');
+    expect(resolveLegalDoc().sections).toHaveLength(FULL_SECTIONS.length);
+  });
+
+  it('renders the summary variant when asked', () => {
+    const doc = resolveLegalDoc({ variant: 'summary' });
+    expect(doc.sections).toHaveLength(SUMMARY_SECTIONS.length);
+    expect(doc.sections.map((s) => s.id)).toContain('data-collection');
+  });
+
+  it('fills companyName and effectiveDate from their fallbacks', () => {
+    const doc = resolveLegalDoc({ appName: 'Acme', lastRevisedDate: 'May 5, 2026' });
+    expect(doc.tokens.companyName).toBe('Acme');
+    expect(doc.tokens.effectiveDate).toBe('May 5, 2026');
+  });
+
+  it('keeps an explicit companyName distinct from appName', () => {
+    const doc = resolveLegalDoc({ appName: 'Acme', companyName: 'Acme Holdings, Inc.' });
+    expect(doc.tokens.companyName).toBe('Acme Holdings, Inc.');
+  });
+
+  it('ignores undefined token overrides instead of blanking the default', () => {
+    const doc = resolveLegalDoc({ appName: 'Acme', contactEmail: undefined });
+    expect(doc.tokens.contactEmail).toBe(DEFAULT_TOKENS.contactEmail);
+    expect(JSON.stringify(doc.sections)).not.toContain('{{contactEmail}}');
+  });
+
+  it('leaves no unsubstituted tokens in either variant', () => {
+    for (const variant of ['summary', 'full'] as const) {
+      const doc = resolveLegalDoc({ variant, appName: 'Acme' });
+      expect(allText(doc.sections)).not.toMatch(/\{\{/);
+    }
+  });
+
+  it('drops a named part and everything under it', () => {
+    const doc = resolveLegalDoc({ parts: { ai: false } });
+    const ids = allIds(doc.sections);
+    expect(ids).not.toContain('ai-ethics');
+    expect(ids).not.toContain('ai-trust-but-verify');
+    expect(ids).toContain('introduction');
+  });
+
+  it('ignores an attempt to drop the core part', () => {
+    const doc = resolveLegalDoc({ parts: { core: false } });
+    expect(allIds(doc.sections)).toContain('introduction');
+  });
+
+  it('drops a single section by id', () => {
+    const doc = resolveLegalDoc({ exclude: ['social-features'] });
+    expect(allIds(doc.sections)).not.toContain('social-features');
+  });
+
+  it('drops a subsection without losing its parent', () => {
+    const doc = resolveLegalDoc({ exclude: ['california-selling'] });
+    const ids = allIds(doc.sections);
+    expect(ids).toContain('california');
+    expect(ids).toContain('california-rights');
+    expect(ids).not.toContain('california-selling');
+  });
+
+  it('keeps only whitelisted sections', () => {
+    const doc = resolveLegalDoc({ include: ['introduction', 'contact'] });
+    expect(doc.sections.map((s) => s.id)).toEqual(['introduction', 'contact']);
+  });
+
+  it('keeps the whole subtree of an explicitly included parent', () => {
+    const doc = resolveLegalDoc({ include: ['ai-ethics'] });
+    expect(doc.sections.map((s) => s.id)).toEqual(['ai-ethics']);
+    expect(doc.sections[0].subsections).toHaveLength(4);
+  });
+
+  it('still honours exclude inside an included parent', () => {
+    const doc = resolveLegalDoc({ include: ['ai-ethics'], exclude: ['ai-truthfulness'] });
+    expect(doc.sections[0].subsections?.map((s) => s.id)).not.toContain('ai-truthfulness');
+    expect(doc.sections[0].subsections).toHaveLength(3);
+  });
+
+  it('keeps a parent when only one of its children is whitelisted', () => {
+    const doc = resolveLegalDoc({ include: ['california-rights'] });
+    expect(doc.sections.map((s) => s.id)).toEqual(['california']);
+    expect(doc.sections[0].subsections?.map((s) => s.id)).toEqual(['california-rights']);
+  });
+
+  it('applies exclude on top of include', () => {
+    const doc = resolveLegalDoc({ include: ['introduction', 'contact'], exclude: ['contact'] });
+    expect(doc.sections.map((s) => s.id)).toEqual(['introduction']);
+  });
+
+  it('patches a section in place, keeping unspecified fields', () => {
+    const doc = resolveLegalDoc({
+      replace: { contact: { blocks: [{ type: 'p', text: 'Write to {{appName}} legal.' }] } },
+      appName: 'Acme',
+    });
+    const contact = doc.sections.find((s) => s.id === 'contact');
+    expect(contact?.title).toBe('How to Contact Us');
+    expect(contact?.blocks).toEqual([{ type: 'p', text: 'Write to Acme legal.' }]);
+  });
+
+  it('patches a subsection by id', () => {
+    const doc = resolveLegalDoc({
+      replace: { 'california-selling': { title: 'We Do Not Sell Your Data' } },
+    });
+    const california = doc.sections.find((s) => s.id === 'california');
+    expect(california?.subsections?.map((s) => s.title)).toContain('We Do Not Sell Your Data');
+  });
+
+  it('inserts a section after a named one', () => {
+    const doc = resolveLegalDoc({
+      add: [
+        {
+          after: 'introduction',
+          section: {
+            id: 'arbitration',
+            title: 'Arbitration',
+            blocks: [{ type: 'p', text: '{{appName}} disputes go to arbitration.' }],
+          },
+        },
+      ],
+      appName: 'Acme',
+    });
+    const ids = doc.sections.map((s) => s.id);
+    expect(ids[ids.indexOf('introduction') + 1]).toBe('arbitration');
+    expect(JSON.stringify(doc.sections)).toContain('Acme disputes go to arbitration.');
+  });
+
+  it('inserts a section before a named one, and appends when the anchor is missing', () => {
+    const section = { id: 'extra', title: 'Extra' };
+    expect(
+      resolveLegalDoc({ add: [{ before: 'contact', section }] }).sections.map((s) => s.id).at(-2),
+    ).toBe('extra');
+    expect(
+      resolveLegalDoc({ add: [{ after: 'nope', section }] }).sections.map((s) => s.id).at(-1),
+    ).toBe('extra');
+  });
+
+  it('reorders named sections to the front and keeps the rest in order', () => {
+    const doc = resolveLegalDoc({ order: ['contact', 'introduction'] });
+    const ids = doc.sections.map((s) => s.id);
+    expect(ids.slice(0, 2)).toEqual(['contact', 'introduction']);
+    expect(ids[2]).toBe('changes');
+  });
+
+  it('merges feature overrides over the defaults', () => {
+    const doc = resolveLegalDoc({ features: { badges: false } });
+    expect(doc.features.badges).toBe(false);
+    expect(doc.features.backLink).toBe(true);
+  });
+
+  it('does not mutate the shared built-in content', () => {
+    const before = JSON.stringify(FULL_SECTIONS);
+    resolveLegalDoc({ appName: 'Acme', replace: { contact: { title: 'Reach Us' } } });
+    expect(JSON.stringify(FULL_SECTIONS)).toBe(before);
+  });
+});
+
+describe('renderMarkdown', () => {
+  it('numbers sections and subsections', () => {
+    const md = renderMarkdown({ appName: 'Acme' });
+    expect(md).toContain('## 1. Introduction');
+    expect(md).toContain('### 3.1 Trust, But Verify Outputs');
+  });
+
+  it('drops numbering when the feature is off', () => {
+    const md = renderMarkdown({ features: { numbered: false } });
+    expect(md).toContain('## Introduction');
+    expect(md).not.toContain('## 1. Introduction');
+  });
+
+  it('renders nested list items with indentation', () => {
+    const md = renderMarkdown({ include: ['california-rights'] });
+    expect(md).toMatch(/\n {2}1\. categories of personal information/);
+  });
+
+  it('ends with exactly one trailing newline and no blank-line runs', () => {
+    const md = renderMarkdown();
+    expect(md.endsWith('\n')).toBe(true);
+    expect(md).not.toMatch(/\n{3}/);
+  });
+});
+
+describe('renderHtml', () => {
+  it('escapes markup in interpolated values', () => {
+    const html = renderHtml({ appName: '<script>alert(1)</script>' });
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('links emails and URLs found in the text', () => {
+    const html = renderHtml({ contactEmail: 'legal@acme.com', include: ['contact'] });
+    expect(html).toContain('<a href="mailto:legal@acme.com">legal@acme.com</a>');
+    expect(renderHtml({ include: ['cookies'] })).toContain(
+      '<a href="https://tools.google.com/dlpage/gaoptout">',
+    );
+  });
+
+  it('emits section anchors matching the section ids', () => {
+    expect(renderHtml({ include: ['introduction'] })).toContain('<section id="introduction">');
+  });
+
+  it('wraps a full page only when standalone is requested', () => {
+    expect(renderHtml({}, { standalone: true })).toMatch(/^<!doctype html>/);
+    expect(renderHtml({})).toMatch(/^<main/);
+  });
+});
+
+describe('renderText', () => {
+  it('upper-cases headings and keeps the body readable', () => {
+    const text = renderText({ appName: 'Acme' });
+    expect(text).toContain('1. INTRODUCTION');
+    expect(text).toContain('These Terms of Service');
+    expect(text).not.toContain('<');
+  });
+});

--- a/packages/legal-terms-privacy-policy/test/react.test.tsx
+++ b/packages/legal-terms-privacy-policy/test/react.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import LegalTermsPrivacyPolicy from '../src/react/LegalTermsPrivacyPolicy';
+
+/**
+ * Server-renders the page the way a Next.js route does. Catches what the data
+ * tests cannot: a bad hook order, an icon name the component can't resolve, a
+ * block type the view forgot to handle.
+ */
+function render(props: React.ComponentProps<typeof LegalTermsPrivacyPolicy>) {
+  return renderToStaticMarkup(<LegalTermsPrivacyPolicy {...props} />);
+}
+
+describe('<LegalTermsPrivacyPolicy />', () => {
+  it('renders the summary variant with its cards and section anchors', () => {
+    const html = render({ appName: 'Acme', defaultVariant: 'summary' });
+    expect(html).toContain('Acme Terms of Service &amp; Privacy Policy');
+    expect(html).toContain('id="data-collection"');
+    expect(html).toContain('Legal Agreement');
+    expect(html).toContain('<svg'); // lucide icons resolved
+  });
+
+  it('renders the full variant with numbered sections', () => {
+    const html = render({ appName: 'Acme', defaultVariant: 'full' });
+    expect(html).toContain('id="california"');
+    expect(html).toContain('3.1');
+    expect(html).toContain('Artificial Intelligence Ethical Use Policy');
+  });
+
+  it('shows the variant switch by default and hides it on request', () => {
+    expect(render({ appName: 'Acme' })).toContain('Full Text');
+    expect(render({ appName: 'Acme', features: { variantSwitch: false } })).not.toContain(
+      'Full Text',
+    );
+  });
+
+  it('honours a controlled variant over defaultVariant', () => {
+    const html = render({ appName: 'Acme', variant: 'full', defaultVariant: 'summary' });
+    expect(html).toContain('id="social-features"');
+  });
+
+  it('renders caller-authored sections, including unknown icon names', () => {
+    const html = render({
+      appName: 'Acme',
+      defaultVariant: 'summary',
+      add: [
+        {
+          after: 'introduction',
+          section: {
+            id: 'arbitration',
+            title: 'Arbitration',
+            icon: 'NoSuchIcon',
+            blocks: [
+              { type: 'p', text: 'Disputes with {{companyName}} go to arbitration.' },
+              { type: 'ul', lead: 'Exceptions:', items: ['Small claims'] },
+              { type: 'cards', items: [{ title: 'Venue', text: 'Delaware', icon: 'Scale' }] },
+              { type: 'note', title: 'Note', items: ['Opt out within 30 days'] },
+            ],
+          },
+        },
+      ],
+    });
+    expect(html).toContain('id="arbitration"');
+    expect(html).toContain('Disputes with Acme go to arbitration.');
+    expect(html).toContain('Small claims');
+    expect(html).toContain('Delaware');
+    expect(html).toContain('Opt out within 30 days');
+  });
+
+  it('links the contact email', () => {
+    const html = render({ appName: 'Acme', contactEmail: 'legal@acme.com', variant: 'full' });
+    expect(html).toContain('href="mailto:legal@acme.com"');
+  });
+
+  it('drops a part without leaving an empty heading', () => {
+    const html = render({ appName: 'Acme', variant: 'full', parts: { ai: false } });
+    expect(html).not.toContain('id="ai-ethics"');
+    expect(html).toContain('id="introduction"');
+  });
+});

--- a/packages/legal-terms-privacy-policy/ts-loader.mjs
+++ b/packages/legal-terms-privacy-policy/ts-loader.mjs
@@ -1,0 +1,31 @@
+/**
+ * Minimal ESM resolve hook so `node cli.mjs` can load the package's
+ * TypeScript sources directly.
+ *
+ * The sources use extensionless relative imports (`./resolve`) because that is
+ * what Next, Vite and Vitest expect from a package that ships TS rather than a
+ * build output. Node's own resolver requires an extension, so this hook retries
+ * failed relative specifiers with `.ts`, `.tsx` and `/index.ts`.
+ *
+ * Node still does the type stripping — this only fixes resolution — so it needs
+ * Node 22.6+ (type stripping on by default from 22.18).
+ */
+const CANDIDATES = ['.ts', '.tsx', '/index.ts', '/index.tsx'];
+
+export async function resolve(specifier, context, nextResolve) {
+  if (!specifier.startsWith('.') && !specifier.startsWith('file:')) {
+    return nextResolve(specifier, context);
+  }
+  try {
+    return await nextResolve(specifier, context);
+  } catch (error) {
+    for (const extension of CANDIDATES) {
+      try {
+        return await nextResolve(specifier + extension, context);
+      } catch {
+        // Try the next candidate; rethrow the original error if none resolve.
+      }
+    }
+    throw error;
+  }
+}

--- a/packages/legal-terms-privacy-policy/tsconfig.json
+++ b/packages/legal-terms-privacy-policy/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src", "test"]
+}

--- a/packages/legal-terms-privacy-policy/vitest.config.mjs
+++ b/packages/legal-terms-privacy-policy/vitest.config.mjs
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.{ts,tsx}'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.{ts,tsx}'],
+    },
+  },
+});

--- a/scripts/sync-package-readmes.mjs
+++ b/scripts/sync-package-readmes.mjs
@@ -120,6 +120,7 @@ const SKILLS_BY_PACKAGE = {
   'create-starter-app': ['create-starter-app'],
   'export-svg-icons-typescript': ['export-svg-typescript'],
   'git0-repo-downloader': ['git0'],
+  'legal-terms-privacy-policy': ['legal-terms-privacy-policy'],
   'manage-storage': ['manage-storage'],
   'native-app-wrapper': ['native-app-wrapper'],
   'open-when-ready': ['open-ready'],

--- a/skills/README.md
+++ b/skills/README.md
@@ -37,6 +37,7 @@ the package.
 | [git-badges](./git-badges/SKILL.md) | `setup-git-repo` | The README badge block: Shields grammar, per-badge setup, why a badge renders `invalid` |
 | [git0](./git0/SKILL.md) | `git0-repo-downloader` | Search, download, auto-install, IDE launch, rate limits |
 | [github-actions-setup](./github-actions-setup/SKILL.md) | `setup-git-repo` | The five CI workflows: what each needs, the secrets, and the failure modes worth knowing |
+| [legal-terms-privacy-policy](./legal-terms-privacy-policy/SKILL.md) | `legal-terms-privacy-policy` | The two-variant terms/privacy page: tokens, parts, adding and removing sections, the CLI |
 | [manage-storage](./manage-storage/SKILL.md) | `manage-storage` | S3 / R2 / B2 through one `StorageManager`, provider detection, edge credentials |
 | [native-app-wrapper](./native-app-wrapper/SKILL.md) | `native-app-wrapper` | Website or CLI → native Tauri app: profiles, the sidecar bridge, icons, per-OS builds |
 | [open-ready](./open-ready/SKILL.md) | `open-when-ready` | Dev-server wrapper: ready/error detection, flags, log locations |

--- a/skills/legal-terms-privacy-policy/SKILL.md
+++ b/skills/legal-terms-privacy-policy/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: legal-terms-privacy-policy
+description: Guide to packages/legal-terms-privacy-policy — the configurable Terms of Service + Privacy Policy page with two presentations of the same policy (a scannable card summary and the full legal text) and a switch between them. Covers the token substitutions, turning named parts on and off (AI clauses, CCPA, COPPA, cookies), adding/removing/reordering/rewriting sections, the block types, the React props, the Markdown/HTML/text renderers, the CLI, and wiring it into a Next.js app. Use when adding or editing a terms or privacy page, replacing a hand-written legal page, changing which clauses a product publishes, or troubleshooting one — a `{{token}}` showing through, a section that won't disappear, cards rendering as plain text, or a Next build that can't parse the package.
+---
+
+# Working With legal-terms-privacy-policy
+
+One legal document, two presentations, everything configurable. `packages/legal-terms-privacy-policy` replaces the hand-written terms pages that used to be copy-pasted between apps — QwkSearch, Debate AI, AI Broker, Grab URL and Rights Institute all render from it now.
+
+**The two variants are the same policy at different depths:**
+
+- `summary` — the card-and-icon layout from [rights.institute/terms-privacy](https://rights.institute/terms-privacy). Plain language, scannable, 13 sections.
+- `full` — the long-form legal text from the QwkSearch and Debate AI pages. 18 sections with numbered subsections, the CCPA notice, the AI Ethical Use Policy.
+
+Default is `full` in the renderers and `summary` in the React component (the switch is right there, so readers who want the binding text are one click away).
+
+## Setup
+
+```tsx
+import { LegalTermsPrivacyPolicy } from 'legal-terms-privacy-policy/react';
+
+export default function TermsPage() {
+  return (
+    <LegalTermsPrivacyPolicy
+      appName="QwkSearch"
+      contactEmail="legal@qwksearch.com"
+      lastRevisedDate="March 1, 2026"
+      homeUrl="/"
+      defaultVariant="full"
+    />
+  );
+}
+```
+
+Two things that bite on first install:
+
+1. **The package ships TypeScript source**, like the rest of this monorepo. A Next.js app needs it in `transpilePackages` or the build fails parsing JSX in `node_modules`:
+   ```js
+   // next.config.js
+   export default { transpilePackages: ['legal-terms-privacy-policy'] };
+   ```
+2. **Import the React page from `/react`**, not the package root. The root export is deliberately free of `react` and `lucide-react` so a worker, a build script or the CLI can render the policy without pulling in a UI framework.
+
+`react` and `lucide-react` are optional peers. The component is Tailwind-styled and already handles dark mode; it needs no wrapper, provider or stylesheet.
+
+## Picking the right knob
+
+| You want | Use |
+| --- | --- |
+| The product's name, email, dates in the text | Token props: `appName`, `contactEmail`, `lastRevisedDate`, … |
+| No AI clauses at all (product has no model) | `parts={{ ai: false }}` |
+| No California / COPPA / cookie notice | `parts={{ california: false, children: false, cookies: false }}` |
+| Drop one specific clause | `exclude={['social-features']}` |
+| Publish a cut-down page with only a few clauses | `include={['introduction', 'privacy-policy', 'contact']}` |
+| Rewrite one section's body, keep its title and icon | `replace={{ contact: { blocks: [...] } }}` |
+| Add your own clause (arbitration, broker disclosures) | `add={[{ after: 'termination', section: {...} }]}` |
+| A different section order | `order={['introduction', 'privacy-policy', ...]}` |
+| Only one presentation, no switch | `variant="full"` + `features={{ variantSwitch: false }}` |
+| The variant in the URL | `variant` + `onVariantChange` (controlled) |
+| No React at all | `renderMarkdown` / `renderHtml` / `renderText` from the root |
+
+## Tokens
+
+The legal text carries `{{token}}` placeholders, filled by props of the same name.
+
+| Token | Default | Where it shows |
+| --- | --- | --- |
+| `appName` | `"Our Service"` | Throughout |
+| `companyName` | falls back to `appName` | Liability, contact, footer |
+| `contactEmail` | `"legal@example.com"` | Accounts, retention, contact |
+| `homeUrl` | `"/"` | The "Back to Home" link |
+| `lastRevisedDate` | `"January 1, 2025"` | Under the title |
+| `effectiveDate` | falls back to `lastRevisedDate` | Under the title, when it differs |
+| `jurisdiction` | `"the United States"` | Introduction |
+| `minimumAge` | `18` | Acceptance of Terms (summary) |
+| `childrenAge` | `13` | Children's Privacy |
+| `dataDeletionDays` | `30` | Data Security and Retention |
+
+Custom placeholders for your own sections go in `tokens={{ brokerName: 'Alpaca' }}`.
+
+**An unknown token is left visible** — `{{appNmae}}` renders as `{{appNmae}}` rather than an empty string. That is deliberate: a typo in a token should be obvious on the page, not silently delete a clause. If you see braces on a published page, a token name is wrong.
+
+## Parts vs. section ids
+
+Two levels of granularity, and they compose — `parts` first, then `include`, then `exclude`.
+
+`parts` switches a named group of clauses:
+
+| Part | Covers |
+| --- | --- |
+| `core` | Introduction, changes, accounts, use, materials, feedback, warranties, termination, contact |
+| `ai` | The Artificial Intelligence Ethical Use Policy and its four sub-policies |
+| `privacy` | Collection, use and disclosure of personal data |
+| `cookies` | Cookies, tracking technologies, Do Not Track |
+| `california` | The CCPA/CPRA resident notice and its three subsections |
+| `children` | The COPPA under-13 notice |
+| `security` | Security measures and data retention |
+| `thirdParty` | Third-party links and social features |
+
+**`core` cannot be switched off.** `parts={{ core: false }}` is ignored rather than erroring — a document without it is not a document.
+
+`include` and `exclude` work by section id and reach subsections:
+
+- Naming a **parent** keeps its whole subtree — `include={['ai-ethics']}` is the section *and* its four sub-policies, not an empty heading.
+- Naming only a **child** keeps the parent as its heading — `include={['california-rights']}` renders that subsection under "California Residents" rather than orphaning it.
+- `exclude` still applies inside an included parent, so the two compose.
+
+To see the ids for either variant:
+
+```sh
+npx legal-terms-privacy-policy --list-sections --variant full
+```
+
+## Writing your own sections
+
+A section is data, not JSX, so it renders in every format:
+
+```tsx
+add={[{
+  after: 'termination',
+  section: {
+    id: 'arbitration',
+    title: 'Arbitration and Governing Law',
+    icon: 'Scale',            // any lucide name
+    accent: 'slate',          // tints the summary card
+    blocks: [
+      { type: 'p', text: 'Disputes with {{companyName}} are resolved by binding arbitration.' },
+      { type: 'ul', lead: 'Exceptions:', items: ['Small claims court', 'Injunctive relief'] },
+    ],
+  },
+}]}
+```
+
+| Block | Shape | Summary variant | Full variant |
+| --- | --- | --- | --- |
+| `p` | `{ type: 'p', text, strong? }` | paragraph | paragraph |
+| `ol` / `ul` | `{ type, lead?, items }` | list | list |
+| `cards` | `{ type: 'cards', columns?: 1-4, center?, items: [{ title, text?, items?, icon? }] }` | tinted tile grid | headings + lists |
+| `note` | `{ type: 'note', title?, text?, items?, icon? }` | callout box | heading + body |
+
+List items are strings, or `{ text, items }` for one nested level (the `a. b. c.` sub-lists in the CCPA "Right to Know" clause).
+
+Caller text is interpolated too, so `{{appName}}` works in your own sections. Anchors: `after`, `before`, or `at` (an index); with none of them the section is appended.
+
+## Rendering without React
+
+```ts
+import { renderMarkdown, renderHtml, renderText, resolveLegalDoc, LEGAL_CSS }
+  from 'legal-terms-privacy-policy';
+
+renderMarkdown({ appName: 'Acme' });                   // TERMS.md, an MDX docs page
+renderHtml({ appName: 'Acme' }, { standalone: true }); // complete styled page
+renderText({ appName: 'Acme' });                       // email, in-app agreement dialog
+resolveLegalDoc({ appName: 'Acme' }).sections;         // the resolved tree, render it yourself
+```
+
+The HTML renderer escapes interpolated values and links bare emails and URLs. `LEGAL_CSS` is exported for pairing with the non-standalone fragment.
+
+## CLI
+
+```sh
+# Generate a repo's TERMS.md
+npx legal-terms-privacy-policy --app-name Acme --variant full > TERMS.md
+
+# A static page with the AI and California clauses dropped
+npx legal-terms-privacy-policy --app-name Acme --contact-email legal@acme.com \
+  --format html --standalone --no-part ai --no-part california > terms.html
+
+# What changed when I flipped a config?
+npx legal-terms-privacy-policy --app-name Acme --format json | jq '.sections[].id'
+```
+
+`--format` takes `markdown`, `html`, `text`, `json`. `--no-part`/`--part`, `--include`, `--exclude` are repeatable. `--help` lists everything.
+
+The bin runs under plain `node` (22.6+) — `cli.mjs` registers `ts-loader.mjs`, a resolve hook that retries extensionless relative imports as `.ts`, and Node strips the types itself.
+
+## Keeping the two variants honest
+
+The summary restates; the full text binds. **Edit one, edit the other** — `src/content/summary.ts` and `src/content/full.ts`. A summary claiming something the full text does not support is the specific failure this package is shaped to avoid, which is why `variantSwitch` defaults on and both variants ship together.
+
+When a product's policy genuinely differs from the boilerplate (a broker's disclosures, a data processor's subprocessor list), put it in `add`/`replace` in that app rather than editing the shared content — the shared files are what every other app renders.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Next build fails parsing JSX inside `node_modules` | Package ships TS source | Add `transpilePackages: ['legal-terms-privacy-policy']` to `next.config.js` |
+| `{{someToken}}` visible on the page | Token name doesn't match a prop | Check spelling against the token table; custom ones go in `tokens={{ … }}` |
+| A section won't disappear | Its `part` is `core`, or you named a `part` where an id was needed | `core` is unremovable; use `exclude={['id']}` for a single section |
+| `include` drops a subsection's parent heading | Only the child was named — this is intended | Nothing to fix; name the parent too if you want its intro blocks |
+| Cards render as plain headings and lists | Full-text variant flattens card blocks by design | Use `variant="summary"`, or write the content as `p`/`ol` blocks |
+| Icon missing or wrong glyph | Unknown lucide name — falls back to a document icon | Check the name at lucide.dev, or pass a component via `icons={{ MyIcon }}` |
+| `useState`/`useEffect` error in a Server Component | The page is interactive | The component already carries `'use client'`; make sure your route isn't re-exporting it through a server-only boundary |
+| Clipboard button does nothing | Clipboard API blocked in an iframe or insecure origin | Expected; the email is still selectable. `features={{ copyButtons: false }}` to hide it |
+| Dates disagree between apps | Each app passes its own `lastRevisedDate` | Update the prop where the page lives, not the package |
+
+## Where it's wired
+
+| Repo | Page |
+| --- | --- |
+| `rights-institute` | `app/terms-privacy/page.tsx` — both variants, switch on |
+| `qwksearch-research-agent` | `apps/qwksearch-web/app/legal/privacy/page.tsx` |
+| `debate-ai.com` | `apps/debate-ai.com/app/legal/privacy/page.tsx`, and the practice-vs-AI frontend's `TermsOfService`/`PrivacyPolicy` pages |
+| `ai-broker-investing-agent` | `apps/ai-broker-web/app/legal/{terms,privacy}/page.tsx` |
+| `GRAB-URL` | `grab-help-docs/app/(home)/legal/terms-privacy/page.tsx` — AI clauses off |
+
+Change the shared text and every one of them moves. That is the point — and the reason to think twice before editing `src/content/*`.


### PR DESCRIPTION
## Why

`rights.institute`'s Cloudflare build is failing at install:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with <ROOT>/packages/terms-privacy/package.json
* 1 dependencies were added: legal-terms-privacy-policy@^0.1.0
```

The lockfile is a symptom, not the cause: `legal-terms-privacy-policy` has never
been published to npm, so that dependency cannot resolve at all
(`ERR_PNPM_FETCH_404`) and no lockfile update can fix it. The package was written
on `claude/youthful-bardeen-clem3n` here and never merged.

`apps/qwksearch-web` in the qwksearch repo already imports it too, so the same
404 is waiting there.

## What

- Brings that branch's commit onto master unchanged — the package, its CLI, its
  skill under `skills/`, and its rows in the skills index and README sync map.
- Adds `@types/react-dom` as a dev dependency: `npm run typecheck` failed on
  `test/react.test.tsx`, where `react-dom/server` was implicitly `any` without
  it. Adds the package-lock the other packages here carry.

Merging publishes `legal-terms-privacy-policy@0.1.0` via `npm-publish.yml` (the
package is not `private`, and `resolve-publish-version.mjs` takes the tree's
version on a first publish). That is what unblocks rights.institute.

## Verification

- `npx vitest run` — 41 tests pass across 2 files
- `npx tsc --noEmit` — clean (was 1 error before the `@types/react-dom` fix)
- `node cli.mjs --app-name 'Example App' --variant full --format markdown` — renders
- `.github/scripts/check-package-entrypoints.mjs` — clean

Neither `test.yml` nor `tests.yml` uses a glob, so the new package is not in
either matrix and no existing job changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpcM6XAWsS3GtxQaJD6yY8

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpcM6XAWsS3GtxQaJD6yY8)_