### PR TITLE
🔧 fix(cloudflare): keep dashboard-set Worker variables across deploys

### DIFF
--- a/apps/vscode-cloud/wrangler.jsonc
+++ b/apps/vscode-cloud/wrangler.jsonc
@@ -1,6 +1,9 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "vscode-cloud",
+  // Wrangler deletes plaintext Variables set in the Cloudflare dashboard on every
+  // deploy unless keep_vars is set. Secrets are never deleted either way.
+  "keep_vars": true,
   "main": "src/index.ts",
   "compatibility_date": "2025-04-01",
   "compatibility_flags": ["nodejs_compat"],

--- a/docs/cloudflare-env-vars.md
+++ b/docs/cloudflare-env-vars.md
@@ -1,0 +1,181 @@
+# Cloudflare Workers environment variables
+
+## Symptom
+
+Variables you entered in the Cloudflare dashboard (**Workers & Pages → your
+Worker → Settings → Variables**) disappear after a rebuild or deploy, and the
+Worker starts failing on missing configuration.
+
+## Cause
+
+The rebuild runs Wrangler, and Wrangler treats its own configuration file as the
+source of truth. By default `wrangler deploy` **deletes every plaintext variable
+on the Worker before setting the ones found in `wrangler.toml` /
+`wrangler.jsonc`** — so any variable that exists only in the dashboard is wiped.
+Secrets (`wrangler secret put`) are never deleted by a deploy, with or without
+the flag.
+See [Wrangler commands](https://developers.cloudflare.com/workers/wrangler/commands/workers/)
+and [Source of truth](https://developers.cloudflare.com/workers/wrangler/configuration/#source-of-truth).
+
+## Immediate fix
+
+Deploy with `--keep-vars`:
+
+```bash
+npx wrangler deploy --keep-vars
+```
+
+For version uploads:
+
+```bash
+npx wrangler versions upload --keep-vars
+```
+
+## Permanent fix (what this repo does)
+
+`keep_vars` is set in the Wrangler config, so **every** deploy path — a local
+`wrangler deploy`, Workers Builds, a GitHub Actions job, or a framework wrapper
+such as `opennextjs-cloudflare` / `vinext-cloudflare` — preserves dashboard
+variables without anyone having to remember the flag:
+
+```jsonc
+{
+  "name": "my-worker",
+  "main": "src/index.ts",
+  "keep_vars": true
+}
+```
+
+TOML:
+
+```toml
+name = "my-worker"
+main = "src/index.ts"
+keep_vars = true
+```
+
+`keep_vars` is a **top-level-only** key: it applies to the Worker as a whole and
+cannot be set inside a named environment (`env.production`, `env.staging`).
+Wrangler ignores it there and warns about an unexpected field.
+
+## Better long-term setup
+
+Keep one source of truth instead of mixing dashboard variables with CLI
+deployments.
+
+Non-sensitive configuration belongs in the Wrangler config:
+
+```jsonc
+{
+  "vars": {
+    "API_URL": "https://api.example.com",
+    "APP_ENV": "production"
+  }
+}
+```
+
+API keys, database credentials, and tokens belong in secrets:
+
+```bash
+npx wrangler secret put DATABASE_URL
+npx wrangler secret put OPENAI_API_KEY
+```
+
+Cloudflare stores secrets encrypted and does not show their values in the
+dashboard or in Wrangler, but code reads them exactly like ordinary variables
+([Environment variables](https://developers.cloudflare.com/workers/configuration/environment-variables/)):
+
+```js
+export default {
+  async fetch(request, env) {
+    const apiKey = env.OPENAI_API_KEY;
+    const apiUrl = env.API_URL;
+
+    return new Response('ok');
+  },
+};
+```
+
+Read them off `env`, not `process.env`, unless the Worker runs with the relevant
+Node.js compatibility flag.
+
+## Wrangler environments
+
+Variables and bindings are **not inherited** between Wrangler environments —
+Cloudflare treats each one as effectively a separate Worker:
+
+```bash
+npx wrangler deploy
+npx wrangler deploy --env staging
+npx wrangler deploy --env production
+```
+
+Each environment needs its own `vars` block and its own secrets
+([Environments](https://developers.cloudflare.com/workers/wrangler/environments/)):
+
+```jsonc
+{
+  "name": "my-worker",
+  "main": "src/index.ts",
+  "keep_vars": true,
+  "env": {
+    "production": {
+      "vars": { "APP_ENV": "production", "API_URL": "https://api.example.com" }
+    },
+    "staging": {
+      "vars": { "APP_ENV": "staging", "API_URL": "https://staging-api.example.com" }
+    }
+  }
+}
+```
+
+```bash
+npx wrangler secret put OPENAI_API_KEY --env production
+npx wrangler secret put OPENAI_API_KEY --env staging
+```
+
+## Deploying from GitHub Actions
+
+A workflow step that runs bare Wrangler has the same problem:
+
+```yaml
+- name: Deploy Worker
+  run: npx wrangler deploy --keep-vars
+  env:
+    CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+```
+
+For production, prefer defining configuration in the Wrangler config and
+uploading secrets from CI rather than depending on dashboard variables:
+
+```bash
+npx wrangler deploy --secrets-file .secrets.json
+```
+
+Never commit `.secrets.json`, `.dev.vars`, or API keys.
+
+## The four things people confuse
+
+| | Where it lives | Survives a Wrangler deploy? |
+| --- | --- | --- |
+| Build variables/secrets | Workers Builds settings | Only used while the framework builds |
+| Worker runtime variables | `vars` in the Wrangler config | Yes — the config is the source of truth |
+| Dashboard variables | Cloudflare dashboard only | **Only with `keep_vars` / `--keep-vars`** |
+| Secrets | `wrangler secret put` | Yes — deploys never delete secrets |
+
+See also
+[Workers Builds configuration](https://developers.cloudflare.com/workers/ci-cd/builds/configuration/).
+
+## Wrangler configs in this repository
+
+Every one of these sets `keep_vars`:
+
+- `apps/vscode-cloud/wrangler.jsonc`
+- `packages/cloudflare-to-claude-fix/wrangler.jsonc`
+- `packages/verify-phone-sms/docs/wrangler.toml`
+- `packages/verify-phone-sms/wrangler.toml`
+- `starter-templates/template-fumadocs/wrangler.jsonc`
+- `starter-templates/template-svelte-betterauth-shadcn-drizzle/wrangler.toml`
+- `starter-templates/template-vinext-betterauth-shadcn-themes-teams-stripe/template-fumadocs/wrangler.jsonc`
+- `starter-templates/template-vinext-betterauth-shadcn-themes-teams-stripe/wrangler.jsonc`

--- a/packages/cloudflare-to-claude-fix/wrangler.jsonc
+++ b/packages/cloudflare-to-claude-fix/wrangler.jsonc
@@ -1,6 +1,9 @@
 {
   // ── Core ────────────────────────────────────────────────────────────────────
   "name": "cloudflare-to-claude-fix",
+  // Wrangler deletes plaintext Variables set in the Cloudflare dashboard on every
+  // deploy unless keep_vars is set. Secrets are never deleted either way.
+  "keep_vars": true,
   "main": "src/index.js",
   "compatibility_date": "2025-11-01",
 

--- a/packages/template-git-repo/template/.github/workflows/deploy-test-reports.yml
+++ b/packages/template-git-repo/template/.github/workflows/deploy-test-reports.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Deploy to Cloudflare Workers
         working-directory: ${{ env.REPORT_DIR }}
-        run: npx wrangler deploy
+        run: npx wrangler deploy --keep-vars
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/packages/verify-phone-sms/docs/wrangler.toml
+++ b/packages/verify-phone-sms/docs/wrangler.toml
@@ -1,4 +1,7 @@
 name = "sms-verification-docs"
+# Wrangler deletes plaintext Variables set in the Cloudflare dashboard on every
+# deploy unless keep_vars is set. Secrets are never deleted either way.
+keep_vars = true
 main = "worker.js"
 compatibility_date = "2024-01-01"
 

--- a/packages/verify-phone-sms/scripts/deploy.sh
+++ b/packages/verify-phone-sms/scripts/deploy.sh
@@ -31,11 +31,11 @@ deploy_docs() {
     bun run build:docs
     
     if [ "$ENVIRONMENT" = "production" ]; then
-        cd docs && wrangler deploy --env production && cd ..
+        cd docs && wrangler deploy --keep-vars --env production && cd ..
     elif [ "$ENVIRONMENT" = "staging" ]; then
-        cd docs && wrangler deploy --env staging && cd ..
+        cd docs && wrangler deploy --keep-vars --env staging && cd ..
     else
-        cd docs && wrangler deploy && cd ..
+        cd docs && wrangler deploy --keep-vars && cd ..
     fi
     echo "✅ Docs deployment completed!"
 }

--- a/packages/verify-phone-sms/wrangler.toml
+++ b/packages/verify-phone-sms/wrangler.toml
@@ -1,4 +1,7 @@
 name = "sms-verification-api"
+# Wrangler deletes plaintext Variables set in the Cloudflare dashboard on every
+# deploy unless keep_vars is set. Secrets are never deleted either way.
+keep_vars = true
 main = "src/index.ts"
 compatibility_date = "2024-01-01"
 compatibility_flags = ["nodejs_compat"]

--- a/starter-templates/template-fumadocs/wrangler.jsonc
+++ b/starter-templates/template-fumadocs/wrangler.jsonc
@@ -1,5 +1,8 @@
 {
   "name": "template-fumadocs",
+  // Wrangler deletes plaintext Variables set in the Cloudflare dashboard on every
+  // deploy unless keep_vars is set. Secrets are never deleted either way.
+  "keep_vars": true,
   "compatibility_date": "2025-01-01",
   "compatibility_flags": ["nodejs_compat"],
   "main": ".vinext/worker.js",

--- a/starter-templates/template-git-repo/.github/workflows/deploy-test-reports.yml
+++ b/starter-templates/template-git-repo/.github/workflows/deploy-test-reports.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Deploy to Cloudflare Workers
         working-directory: apps/test-reports
-        run: npx wrangler deploy
+        run: npx wrangler deploy --keep-vars
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/starter-templates/template-svelte-betterauth-shadcn-drizzle/wrangler.toml
+++ b/starter-templates/template-svelte-betterauth-shadcn-drizzle/wrangler.toml
@@ -1,4 +1,7 @@
 name = "starterdocs"
+# Wrangler deletes plaintext Variables set in the Cloudflare dashboard on every
+# deploy unless keep_vars is set. Secrets are never deleted either way.
+keep_vars = true
 compatibility_date = "2024-02-08"
 compatibility_flags = ["nodejs_compat"]
 main = ".svelte-kit/cloudflare/_worker.js"

--- a/starter-templates/template-vinext-betterauth-shadcn-themes-teams-stripe/template-fumadocs/wrangler.jsonc
+++ b/starter-templates/template-vinext-betterauth-shadcn-themes-teams-stripe/template-fumadocs/wrangler.jsonc
@@ -1,5 +1,8 @@
 {
   "name": "template-fumadocs",
+  // Wrangler deletes plaintext Variables set in the Cloudflare dashboard on every
+  // deploy unless keep_vars is set. Secrets are never deleted either way.
+  "keep_vars": true,
   "compatibility_date": "2025-01-01",
   "compatibility_flags": ["nodejs_compat"],
   "main": ".vinext/worker.js",

--- a/starter-templates/template-vinext-betterauth-shadcn-themes-teams-stripe/wrangler.jsonc
+++ b/starter-templates/template-vinext-betterauth-shadcn-themes-teams-stripe/wrangler.jsonc
@@ -1,6 +1,9 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "template-nextjs-stripe-teams",
+  // Wrangler deletes plaintext Variables set in the Cloudflare dashboard on every
+  // deploy unless keep_vars is set. Secrets are never deleted either way.
+  "keep_vars": true,
   "main": "worker/index.ts",
   "compatibility_date": "2026-03-10",
   "compatibility_flags": ["nodejs_compat"],
@@ -20,7 +23,6 @@
   ],
   "env": {
     "production": {
-      "keep_vars": true,
       "images": {
         "binding": "IMAGES",
       },


### PR DESCRIPTION
By default `wrangler deploy` deletes every plaintext variable on the Worker before applying the ones in the Wrangler config, so variables entered only in the Cloudflare dashboard vanish on each rebuild. Secrets are never deleted.

- Set the top-level `keep_vars` key in every Wrangler config, so the behaviour holds for all deploy paths (local CLI, Workers Builds, CI, and framework wrappers such as opennextjs-cloudflare / vinext-cloudflare) without anyone needing to remember the `--keep-vars` flag.
- Pass `--keep-vars` explicitly where CI or scripts invoke wrangler directly.
- Drop `keep_vars` from named environments: it is a top-level-only key, so those entries did nothing and made wrangler warn about an unexpected field.
- Document the failure mode, the flag, and the vars-vs-secrets split.

Claude-Session: https://claude.ai/code/session_01CvwVahdpudNPUPzWHn6N7c