### PR TITLE
Run the legal-terms-privacy-policy suite in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
           - package: create-starter-app
           - package: export-svg-icons-typescript
           - package: git0-repo-downloader
+          - package: legal-terms-privacy-policy
           - package: manage-storage
           - package: native-app-wrapper
           - package: open-when-ready

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,6 +65,12 @@ jobs:
             install: npm install --ignore-scripts --legacy-peer-deps
             coverage: true
 
+          - name: legal-terms-privacy-policy
+            dir: packages/legal-terms-privacy-policy
+            runtime: node
+            install: npm install --ignore-scripts --legacy-peer-deps
+            coverage: true
+
           - name: verify-phone-sms
             dir: packages/verify-phone-sms
             runtime: node

--- a/codecov.yml
+++ b/codecov.yml
@@ -34,6 +34,9 @@ flag_management:
     - name: git0-repo-downloader
       paths:
         - packages/git0-repo-downloader/
+    - name: legal-terms-privacy-policy
+      paths:
+        - packages/legal-terms-privacy-policy/
     - name: manage-storage
       paths:
         - packages/manage-storage/

--- a/packages/legal-terms-privacy-policy/package.json
+++ b/packages/legal-terms-privacy-policy/package.json
@@ -35,6 +35,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",
+    "test:ci": "vitest run --reporter=default --reporter=junit --outputFile=./junit.xml --coverage",
     "typecheck": "tsc --noEmit",
     "demo": "node cli.mjs --app-name 'Example App' --variant full --format markdown",
     "pub": "npm version patch && npm publish"

--- a/packages/legal-terms-privacy-policy/vitest.config.mjs
+++ b/packages/legal-terms-privacy-policy/vitest.config.mjs
@@ -1,11 +1,16 @@
 import { defineConfig } from 'vitest/config';
 
+// Coverage is written to this package's own ./coverage/lcov.info so Codecov
+// can flag it under "legal-terms-privacy-policy".
 export default defineConfig({
   test: {
     environment: 'node',
     include: ['test/**/*.test.{ts,tsx}'],
     coverage: {
       provider: 'v8',
+      reporter: ['text', 'lcov'],
+      reportsDirectory: './coverage',
+      reportOnFailure: true,
       include: ['src/**/*.{ts,tsx}'],
     },
   },


### PR DESCRIPTION
The package landed on master without an entry in either test matrix, so its 41 tests were not running anywhere and its coverage was not reported.

Adds it to both workflows and gives it the test:ci script they invoke, plus a Codecov flag so its coverage carries forward like every other package's. Verified from a clean checkout: `npm install --ignore-scripts --legacy-peer-deps` then `npm run test:ci` passes and writes junit.xml and coverage/lcov.info.


Claude-Session: https://claude.ai/code/session_01G9u1uDQ4mVF6L3gyarMk7M