### PR TITLE
📝 docs(readmes): give every generated badge row an "Open in StackBlitz" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
     <a href="https://starterdocs.vtempest.workers.dev"><img src="https://img.shields.io/badge/Docs-blue?logo=ReadTheDocs&logoColor=white" alt="Documentation" /></a>
     <a href="https://www.npmjs.com/~vtempest"><img src="https://img.shields.io/badge/npm-packages-CB3837?logo=npm&logoColor=white" alt="npm packages" /></a>
     <a href="https://codespaces.new/OpenSourceAGI/dev-tools-starter-agent"><img src="https://github.com/codespaces/badge.svg" height="20" alt="Open in GitHub Codespaces" /></a>
+    <a href="https://stackblitz.com/github/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/create-starter-app"><img height="20px" src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt="Open in StackBlitz" /></a>
     <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
 <br />
     <a href="https://codecov.io/gh/OpenSourceAGI/dev-tools-starter-agent"><img src="https://codecov.io/gh/OpenSourceAGI/dev-tools-starter-agent/graph/badge.svg" alt="Coverage" /></a>

--- a/apps/Cloud-Computer-Control-Panel/README.md
+++ b/apps/Cloud-Computer-Control-Panel/README.md
@@ -1,6 +1,7 @@
 <!-- template-git-repo:badges:start -->
 <p align="center">
     <a href="https://starterdocs.vtempest.workers.dev/docs/apps/Cloud-Computer-Control-Panel"><img src="https://img.shields.io/badge/Docs-blue?logo=ReadTheDocs&logoColor=white" alt="Documentation" /></a>
+    <a href="https://stackblitz.com/github/OpenSourceAGI/dev-tools-starter-agent/tree/master/apps/Cloud-Computer-Control-Panel"><img height="20px" src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt="Open in StackBlitz" /></a>
 </p>
 <!-- template-git-repo:badges:end -->
 

--- a/apps/docs/content/docs/(index)/apps/Cloud-Computer-Control-Panel.mdx
+++ b/apps/docs/content/docs/(index)/apps/Cloud-Computer-Control-Panel.mdx
@@ -8,6 +8,7 @@ icon: Server
 
 <div align="center">
     <a href="https://starterdocs.vtempest.workers.dev/docs/apps/Cloud-Computer-Control-Panel"><img src="https://img.shields.io/badge/Docs-blue?logo=ReadTheDocs&logoColor=white" alt="Documentation" /></a>
+    <a href="https://stackblitz.com/github/OpenSourceAGI/dev-tools-starter-agent/tree/master/apps/Cloud-Computer-Control-Panel"><img height="20px" src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt="Open in StackBlitz" /></a>
 </div>
 
 ![code2cloud](https://i.imgur.com/t6WlnCI.png)

--- a/packages/legal-terms-privacy-policy/readme.md
+++ b/packages/legal-terms-privacy-policy/readme.md
@@ -3,11 +3,12 @@
     <a href="https://starterdocs.vtempest.workers.dev/docs/packages/legal-terms-privacy-policy"><img src="https://img.shields.io/badge/Docs-blue?logo=ReadTheDocs&logoColor=white" alt="Documentation" /></a>
     <a href="https://stackblitz.com/github/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/legal-terms-privacy-policy"><img height="20px" src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt="Open in StackBlitz" /></a>
     <br />
-    <a href="https://www.npmjs.com/package/legal-terms-privacy-policy"><img src="https://img.shields.io/npm/dm/legal-terms-privacy-policy.svg" alt="NPM Monthly Downloads" /></a>
-    <a href="https://www.npmjs.com/package/legal-terms-privacy-policy"><img src="https://img.shields.io/npm/v/legal-terms-privacy-policy.svg" alt="npm version" /></a>
-    <a href="https://www.npmjs.com/package/legal-terms-privacy-policy"><img src="https://img.shields.io/npm/dt/legal-terms-privacy-policy.svg" alt="NPM Total Downloads" /></a>
-    <a href="https://www.npmjs.com/package/legal-terms-privacy-policy"><img src="https://img.shields.io/npm/types/legal-terms-privacy-policy" alt="TypeScript types" /></a>
-    <a href="https://packagephobia.com/result?p=legal-terms-privacy-policy"><img src="https://packagephobia.com/badge?p=legal-terms-privacy-policy" alt="Install size" /></a>
+    <a href="https://www.npmjs.com/package/legal-terms"><img src="https://img.shields.io/npm/dm/legal-terms.svg" alt="NPM Monthly Downloads" /></a>
+    <a href="https://www.npmjs.com/package/legal-terms"><img src="https://img.shields.io/npm/v/legal-terms.svg" alt="npm version" /></a>
+    <a href="https://www.npmjs.com/package/legal-terms"><img src="https://img.shields.io/npm/dt/legal-terms.svg" alt="NPM Total Downloads" /></a>
+    <a href="https://www.npmjs.com/package/legal-terms"><img src="https://img.shields.io/npm/types/legal-terms" alt="TypeScript types" /></a>
+    <a href="https://packagephobia.com/result?p=legal-terms"><img src="https://packagephobia.com/badge?p=legal-terms" alt="Install size" /></a>
+    <a href="https://app.codecov.io/gh/OpenSourceAGI/dev-tools-starter-agent/flags"><img src="https://img.shields.io/codecov/c/github/OpenSourceAGI/dev-tools-starter-agent?flag=legal-terms-privacy-policy&label=legal-terms-privacy-policy%20coverage&logo=codecov&logoColor=white" alt="Coverage" /></a>
 </p>
 <!-- template-git-repo:badges:end -->
 

--- a/scripts/sync-package-readmes.mjs
+++ b/scripts/sync-package-readmes.mjs
@@ -238,8 +238,13 @@ export function collectEntries(repoContext) {
           npmPackage: published,
           codecovFlag: codecovFlags.get(`${relative}/`),
           docsUrl: `${DOCS_SITE}/docs/${docsSlug}/${child.name}`,
+          // Not gated on `published`: StackBlitz boots from the manifest at the
+          // path, not from the registry, so a private package or an app runs
+          // there just as well as a published one. What it needs is a
+          // package.json at that path and a runtime it can host — hence the
+          // manifest check and the NO_STACKBLITZ list.
           stackblitzUrl:
-            published && !NO_STACKBLITZ.has(child.name)
+            manifest && !NO_STACKBLITZ.has(child.name)
               ? `https://stackblitz.com/github/${repoContext.repoSlug}/tree/${repoContext.defaultBranch}/${relative}`
               : undefined,
         },


### PR DESCRIPTION
Package READMEs here already carried an **Open in StackBlitz** badge, but two kinds of badge row did not: the root README's, and any generated row for something that does not publish to npm.

**`scripts/sync-package-readmes.mjs`** — the badge was gated on the package being published (`published && !NO_STACKBLITZ.has(...)`). StackBlitz boots from the `package.json` at the path it is handed, not from the registry, so a private package or an app runs there just as well. The gate is now "has a manifest", with `NO_STACKBLITZ` still keeping out the Worker, Tauri and VS Code targets StackBlitz genuinely cannot run.

**Regenerated** with `bun run readmes` + `bun run docs:sync`:
- `apps/Cloud-Computer-Control-Panel/README.md` (and its docs page) gains the badge.
- `packages/legal-terms-privacy-policy/readme.md` also picks up a fix the generator was already owed: its npm badges pointed at `legal-terms-privacy-policy`, but the package publishes as `legal-terms`, and its Codecov flag badge was missing.
- `packages/server-shell-setup` still gets no badge — it has no `package.json` for StackBlitz to install from.

**`README.md`** — the root row gains a badge next to the Codespaces one, opening `packages/create-starter-app`, the CLI you would actually run from a fresh editor. The repo root itself is a bun workspace that will not install in a WebContainer.

`node scripts/sync-package-readmes.mjs --check` (what CI runs) is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kkb27RSQgLWvRWv1vcdJef

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kkb27RSQgLWvRWv1vcdJef)_