### PR TITLE
🐛 fix(docs): stop the Groq client from failing `next build`

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -39,6 +39,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-hover-card": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-tabs": "^1.1.21",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@shikijs/rehype": "^4.0.0",
     "@shikijs/transformers": "^4.0.0",

--- a/apps/docs/src/app/api/chat/route.ts
+++ b/apps/docs/src/app/api/chat/route.ts
@@ -1,6 +1,6 @@
 import { type CoreMessage } from 'ai'
 import { toUIMessageStream } from '@ai-sdk/langchain'
-import { chatModel } from '@/lib/ai/providers'
+import { MissingApiKeyError, getChatModel } from '@/lib/ai/providers'
 import { provideLinks } from '@/lib/ai/tools/provide-links'
 import { searchDocs } from '@/lib/ai/tools/search-docs'
 import { getPageContent } from '@/lib/ai/tools/get-page-content'
@@ -49,6 +49,16 @@ function stringifyContent(content: CoreMessage['content']): string {
 }
 
 export async function POST(request: Request) {
+  let chatModel: ReturnType<typeof getChatModel>
+  try {
+    chatModel = getChatModel()
+  } catch (error) {
+    if (error instanceof MissingApiKeyError) {
+      return new Response(error.message, { status: 503 })
+    }
+    throw error
+  }
+
   const { messages }: { messages: CoreMessage[] } = await request.json()
 
   const tools = [provideLinks, searchDocs, getPageContent]

--- a/apps/docs/src/lib/ai/providers.ts
+++ b/apps/docs/src/lib/ai/providers.ts
@@ -1,11 +1,43 @@
 import { ChatGroq } from '@langchain/groq'
 import { OpenAIEmbeddings } from '@langchain/openai'
 
-export const chatModel = new ChatGroq({
-  model: 'llama-3.3-70b-versatile',
-  temperature: 0,
-})
+/**
+ * Providers are created lazily, on first use.
+ *
+ * `new ChatGroq()` / `new OpenAIEmbeddings()` throw when their API key is
+ * missing, and Next.js evaluates every route module while collecting page data
+ * during `next build`. Instantiating at module scope therefore fails the build
+ * on any machine without the keys (CI, Vercel preview builds). Constructing on
+ * demand keeps the build key-free and moves the failure to the request that
+ * actually needs the model.
+ */
 
-export const embeddingModel = new OpenAIEmbeddings({
-  model: 'text-embedding-3-small',
-})
+let cachedChatModel: ChatGroq | undefined
+let cachedEmbeddingModel: OpenAIEmbeddings | undefined
+
+export class MissingApiKeyError extends Error {
+  constructor(envVar: string) {
+    super(
+      `${envVar} is not set. Add it to your environment to enable the docs assistant.`
+    )
+    this.name = 'MissingApiKeyError'
+  }
+}
+
+export function getChatModel(): ChatGroq {
+  if (!process.env.GROQ_API_KEY) throw new MissingApiKeyError('GROQ_API_KEY')
+  cachedChatModel ??= new ChatGroq({
+    model: 'llama-3.3-70b-versatile',
+    temperature: 0,
+  })
+  return cachedChatModel
+}
+
+export function getEmbeddingModel(): OpenAIEmbeddings {
+  if (!process.env.OPENAI_API_KEY)
+    throw new MissingApiKeyError('OPENAI_API_KEY')
+  cachedEmbeddingModel ??= new OpenAIEmbeddings({
+    model: 'text-embedding-3-small',
+  })
+  return cachedEmbeddingModel
+}

--- a/turbo.json
+++ b/turbo.json
@@ -7,6 +7,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
+      "env": ["GROQ_API_KEY", "OPENAI_API_KEY"],
       "outputs": ["dist/**", ".next/**", "!.next/cache/**", "build/**"]
     },
     "dev": {


### PR DESCRIPTION
## The failure

The Vercel build died during page-data collection:

```
Error: Groq API key not found. Please set the GROQ_API_KEY environment variable or provide the key into "apiKey"
> Build error occurred
Error: Failed to collect page data for /api/chat
```

`next build` evaluates every route module while collecting page data. `apps/docs/src/lib/ai/providers.ts` built its clients at module scope:

```ts
export const chatModel = new ChatGroq({ model: 'llama-3.3-70b-versatile', temperature: 0 })
```

`new ChatGroq()` throws when `GROQ_API_KEY` is absent, so importing `/api/chat` — which the build does — failed on any machine without the key. Turbo also warned it was dropping `GROQ_API_KEY`, so even a configured Vercel project would not have passed it through.

## The fix

- **Lazy providers.** `getChatModel()` / `getEmbeddingModel()` construct on first use and cache. Nothing runs at import time, so the build no longer needs a key. A missing key raises a `MissingApiKeyError` at request time.
- **`/api/chat` degrades instead of crashing** — 503 with the "set `GROQ_API_KEY`" message when the key is absent.
- **`turbo.json`** declares `GROQ_API_KEY` and `OPENAI_API_KEY` in the `build` task's `env`, clearing the platform-environment-variable warning so the keys reach the build when they are set.
- **`@radix-ui/react-tabs`** is declared in `apps/docs/package.json`. `src/components/ui/tabs.tsx` imports it directly but it was only ever resolved transitively; a cold install here failed to compile with `Module not found: Can't resolve '@radix-ui/react-tabs'`.

## Verification

- With `GROQ_API_KEY` and `OPENAI_API_KEY` unset, importing `providers.ts` now succeeds; `getChatModel()` throws only when called (`MissingApiKeyError: GROQ_API_KEY is not set…`). Before this change the import itself threw — exactly the build failure.
- `bun run build` in `apps/docs` gets past `Collecting page data` without touching `/api/chat`. (The build cannot finish in this sandbox: MDX image sizing needs `i.imgur.com`, which egress policy blocks, and `@takumi-rs/image-response` has no native binding here. Both are environment limits, not code.)
- `bun run readmes:check` passes.
- `bun run typecheck` reports the same 160 pre-existing errors before and after — no regression, and CI/Vercel skip type validation.

## Heads-up, not fixed here

A cold `bun install` today resolves `fumadocs-openapi@10.10.3` against `fumadocs-ui@16.15.9`, and that pair does not compile: `fumadocs-openapi/dist/ui/client/i18n.js` imports `useTranslations` from `fumadocs-ui/contexts/i18n`, which 16.15.9 renamed to `useI18n`. Neither is pinned (`^10.1.3`, `^16.2.5`) and no root lockfile is committed, so this is luck of the resolve — the deployment in the log compiled fine. Upgrading to `fumadocs-openapi@11` is a real migration (`fumadocs-openapi/ui/client` moves), so it is out of scope for this fix. Pinning `fumadocs-ui` to the last version that exports `useTranslations` would be the quick lid if it bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qk1775Kp6y6mLQXosPUght

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qk1775Kp6y6mLQXosPUght)_