### PR TITLE
✨ feat(template-git-repo): four-row badge block with GitHub activity counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,46 @@
 <p align="center">
     <img width="350px" src="https://i.imgur.com/OKnr9ns.png" />
+</p>
+
 <h3 align="center">
      <a href="https://starterdocs.vtempest.workers.dev">🎮 Demo</a>
     <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/apps/docs/content/docs">📑 Docs</a>
     <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/blob/master/apps/docs/content/docs/(index)/guides/starter-docs.mdx#%EF%B8%8F-installation">⬇️ Install </a>
     <a href="https://v0.app/templates/dashboard-landing-auth-billing-teams-docs-themes-ExDfusFzX6P"> 🎨 v0 Template </a>
 </h3>
+
+<!-- template-git-repo:badges:start -->
 <p align="center">
     <a href="https://deepwiki.com/OpenSourceAGI/dev-tools-starter-agent"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
+    <a href="https://starterdocs.vtempest.workers.dev"><img height="20px" src="https://img.shields.io/badge/App-blueviolet?style=for-the-badge&logo=googlechrome&logoColor=white" alt="Website" /></a>
     <a href="https://starterdocs.vtempest.workers.dev"><img src="https://img.shields.io/badge/Docs-blue?logo=ReadTheDocs&logoColor=white" alt="Documentation" /></a>
-    <a href="https://www.npmjs.com/~vtempest"><img src="https://img.shields.io/badge/npm-packages-CB3837?logo=npm&logoColor=white" alt="npm packages" /></a>
-    <a href="https://codespaces.new/OpenSourceAGI/dev-tools-starter-agent"><img src="https://github.com/codespaces/badge.svg" height="20" alt="Open in GitHub Codespaces" /></a>
     <a href="https://stackblitz.com/github/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/create-starter-app"><img height="20px" src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt="Open in StackBlitz" /></a>
-    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
-<br />
+    <a href="https://codespaces.new/OpenSourceAGI/dev-tools-starter-agent"><img height="20px" src="https://github.com/codespaces/badge.svg" alt="Open in GitHub Codespaces" /></a>
+    <br />
+    <a href="https://www.npmjs.com/package/create-starter-app"><img src="https://img.shields.io/npm/dm/create-starter-app.svg" alt="NPM Monthly Downloads" /></a>
+    <a href="https://www.npmjs.com/package/create-starter-app"><img src="https://img.shields.io/npm/v/create-starter-app.svg" alt="npm version" /></a>
+    <a href="https://www.npmjs.com/package/create-starter-app"><img src="https://img.shields.io/npm/dt/create-starter-app.svg" alt="NPM Total Downloads" /></a>
+    <a href="https://www.npmjs.com/package/create-starter-app"><img src="https://img.shields.io/npm/types/create-starter-app" alt="TypeScript types" /></a>
+    <a href="https://packagephobia.com/result?p=create-starter-app"><img src="https://packagephobia.com/badge?p=create-starter-app" alt="Install size" /></a>
     <a href="https://codecov.io/gh/OpenSourceAGI/dev-tools-starter-agent"><img src="https://codecov.io/gh/OpenSourceAGI/dev-tools-starter-agent/graph/badge.svg" alt="Coverage" /></a>
-    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/actions/workflows/tests.yml"><img src="https://github.com/OpenSourceAGI/dev-tools-starter-agent/actions/workflows/tests.yml/badge.svg?branch=master" alt="Tests" /></a>
-    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/actions/workflows/npm-publish.yml"><img src="https://github.com/OpenSourceAGI/dev-tools-starter-agent/actions/workflows/npm-publish.yml/badge.svg?branch=master" alt="Publish to npm" /></a>
-    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/graphs/contributors"><img src="https://img.shields.io/github/commit-activity/m/OpenSourceAGI/dev-tools-starter-agent" alt="Commit Activity" /></a>
-    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="Last Commit" /></a>
-<br />
-    <a href="https://discord.gg/SJdBqBz3tV"><img src="https://img.shields.io/discord/1110227955554209923.svg?label=Chat&logo=Discord&colorB=7289da&style=flat" alt="Join Discord" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/actions/workflows/tests.yml"><img src="https://github.com/OpenSourceAGI/dev-tools-starter-agent/actions/workflows/tests.yml/badge.svg?branch=master" alt="CI status" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/forks"><img src="https://img.shields.io/github/forks/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Forks" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/graphs/contributors"><img src="https://img.shields.io/github/contributors/OpenSourceAGI/dev-tools-starter-agent" alt="Contributors" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
     <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
-    <a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" /></a>
-    <a href="./LICENSE.md"><img src="https://img.shields.io/badge/License-PROSPER%201.0-blue.svg" alt="License: PROSPER 1.0" /></a>
-<br />
-    <img src="https://img.shields.io/badge/Claude-D97757?logo=claude&logoColor=fff" alt="Claude AI" />
-    <img src="https://img.shields.io/badge/Cloudflare-F38020?logo=Cloudflare&logoColor=white" alt="Cloudflare" />
-    <img src="https://img.shields.io/badge/Turborepo-EF4444?logo=turborepo&logoColor=white" alt="Turborepo" />
-    <img src="https://img.shields.io/badge/Bun-000000?logo=bun&logoColor=white" alt="Bun" />
-    <img src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white" alt="TypeScript" />
-    <img src="https://img.shields.io/badge/Next.js-black?logo=nextdotjs&logoColor=white" alt="Next.js" />
-    <img src="https://img.shields.io/badge/shadcn%2Fui-000?logo=shadcnui&logoColor=fff" alt="shadcn/ui" />
-    <a href="https://better-auth.com/docs/introduction" target="_blank"><img src="https://i.imgur.com/eaGdjBq.png" alt="better-auth" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/graphs/contributors"><img src="https://img.shields.io/github/commit-activity/m/OpenSourceAGI/dev-tools-starter-agent" alt="Commit activity" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <a href="https://discord.gg/SJdBqBz3tV"><img src="https://img.shields.io/discord/1110227955554209923.svg?label=Chat&logo=Discord&colorB=7289da&style=flat" alt="Join Discord" /></a>
+    <a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request"><img src="https://img.shields.io/badge/PRs--welcome-brightgreen" alt="PRs Welcome" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/blob/master/LICENSE.md"><img src="https://img.shields.io/github/license/OpenSourceAGI/dev-tools-starter-agent" alt="License" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Claude-D97757?logo=claude&logoColor=white" alt="Claude" /> <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" /> <img src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white" alt="TypeScript" /> <img src="https://img.shields.io/badge/Next.js-black?logo=nextdotjs&logoColor=white" alt="Next.js" /> <img src="https://img.shields.io/badge/React-20232A?logo=react&logoColor=white" alt="React" /> <img src="https://img.shields.io/badge/Tauri-24C8D8?logo=tauri&logoColor=white" alt="Tauri" /> <img src="https://img.shields.io/badge/Cloudflare%20Workers-F38020?logo=cloudflareworkers&logoColor=white" alt="Cloudflare Workers" /> <img src="https://img.shields.io/badge/Hono-E36002?logo=hono&logoColor=white" alt="Hono" /> <img src="https://img.shields.io/badge/Tailwind%20CSS-06B6D4?logo=tailwindcss&logoColor=white" alt="Tailwind CSS" /> <img src="https://img.shields.io/badge/shadcn%2Fui-000000?logo=shadcnui&logoColor=white" alt="shadcn/ui" /> <img src="https://img.shields.io/badge/Drizzle%20ORM-C5F74F?logo=drizzle&logoColor=white" alt="Drizzle ORM" /> <img src="https://img.shields.io/badge/better--auth-000000" alt="better-auth" /> <img src="https://img.shields.io/badge/Stripe-635BFF?logo=stripe&logoColor=white" alt="Stripe" /> <img src="https://img.shields.io/badge/Vercel%20AI%20SDK-black?logo=vercel&logoColor=white" alt="Vercel AI SDK" /> <img src="https://img.shields.io/badge/Zod-3E67B1?logo=zod&logoColor=white" alt="Zod" /> <img src="https://img.shields.io/badge/Fumadocs-000000" alt="Fumadocs" /> <img src="https://img.shields.io/badge/Vite-646CFF?logo=vite&logoColor=white" alt="Vite" /> <img src="https://img.shields.io/badge/Turborepo-EF4444?logo=turborepo&logoColor=white" alt="Turborepo" /> <img src="https://img.shields.io/badge/Vitest-6E9F18?logo=vitest&logoColor=white" alt="Vitest" /> <img src="https://img.shields.io/badge/Jest-C21325?logo=jest&logoColor=white" alt="Jest" />
 </p>
+<!-- template-git-repo:badges:end -->
 
 ### 📦 Packages & Apps
 

--- a/apps/Cloud-Computer-Control-Panel/README.md
+++ b/apps/Cloud-Computer-Control-Panel/README.md
@@ -2,6 +2,15 @@
 <p align="center">
     <a href="https://starterdocs.vtempest.workers.dev/docs/apps/Cloud-Computer-Control-Panel"><img src="https://img.shields.io/badge/Docs-blue?logo=ReadTheDocs&logoColor=white" alt="Documentation" /></a>
     <a href="https://stackblitz.com/github/OpenSourceAGI/dev-tools-starter-agent/tree/master/apps/Cloud-Computer-Control-Panel"><img height="20px" src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt="Open in StackBlitz" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" /> <img src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white" alt="TypeScript" /> <img src="https://img.shields.io/badge/Next.js-black?logo=nextdotjs&logoColor=white" alt="Next.js" /> <img src="https://img.shields.io/badge/React-20232A?logo=react&logoColor=white" alt="React" /> <img src="https://img.shields.io/badge/Tailwind%20CSS-06B6D4?logo=tailwindcss&logoColor=white" alt="Tailwind CSS" /> <img src="https://img.shields.io/badge/shadcn%2Fui-000000?logo=shadcnui&logoColor=white" alt="shadcn/ui" /> <img src="https://img.shields.io/badge/Drizzle%20ORM-C5F74F?logo=drizzle&logoColor=white" alt="Drizzle ORM" /> <img src="https://img.shields.io/badge/better--auth-000000" alt="better-auth" /> <img src="https://img.shields.io/badge/Zod-3E67B1?logo=zod&logoColor=white" alt="Zod" />
 </p>
 <!-- template-git-repo:badges:end -->
 

--- a/apps/cccp-vscode-ext/README.md
+++ b/apps/cccp-vscode-ext/README.md
@@ -1,6 +1,15 @@
 <!-- template-git-repo:badges:start -->
 <p align="center">
     <a href="https://starterdocs.vtempest.workers.dev/docs/apps/cccp-vscode-ext"><img src="https://img.shields.io/badge/Docs-blue?logo=ReadTheDocs&logoColor=white" alt="Documentation" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" /> <img src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white" alt="TypeScript" /> <img src="https://img.shields.io/badge/Vitest-6E9F18?logo=vitest&logoColor=white" alt="Vitest" />
 </p>
 <!-- template-git-repo:badges:end -->
 

--- a/apps/vscode-cloud/README.md
+++ b/apps/vscode-cloud/README.md
@@ -1,6 +1,15 @@
 <!-- template-git-repo:badges:start -->
 <p align="center">
     <a href="https://starterdocs.vtempest.workers.dev/docs/apps/vscode-cloud"><img src="https://img.shields.io/badge/Docs-blue?logo=ReadTheDocs&logoColor=white" alt="Documentation" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" /> <img src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white" alt="TypeScript" /> <img src="https://img.shields.io/badge/Cloudflare%20Workers-F38020?logo=cloudflareworkers&logoColor=white" alt="Cloudflare Workers" />
 </p>
 <!-- template-git-repo:badges:end -->
 

--- a/packages/about-system-info/README.md
+++ b/packages/about-system-info/README.md
@@ -13,6 +13,15 @@
     <a href="https://www.npmjs.com/package/about-system"><img src="https://img.shields.io/npm/types/about-system" alt="TypeScript types" /></a>
     <a href="https://packagephobia.com/result?p=about-system"><img src="https://packagephobia.com/badge?p=about-system" alt="Install size" /></a>
     <a href="https://app.codecov.io/gh/OpenSourceAGI/dev-tools-starter-agent/flags"><img src="https://img.shields.io/codecov/c/github/OpenSourceAGI/dev-tools-starter-agent?flag=about-system-info&label=about-system-info%20coverage&logo=codecov&logoColor=white" alt="Coverage" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" /> <img src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white" alt="TypeScript" /> <img src="https://img.shields.io/badge/Vite-646CFF?logo=vite&logoColor=white" alt="Vite" /> <img src="https://img.shields.io/badge/Vitest-6E9F18?logo=vitest&logoColor=white" alt="Vitest" />
 </p>
 <!-- template-git-repo:badges:end -->
 

--- a/packages/api2ai-mcp-generator/README.md
+++ b/packages/api2ai-mcp-generator/README.md
@@ -13,6 +13,15 @@
     <a href="https://www.npmjs.com/package/api2ai"><img src="https://img.shields.io/npm/dt/api2ai.svg" alt="NPM Total Downloads" /></a>
     <a href="https://www.npmjs.com/package/api2ai"><img src="https://img.shields.io/npm/types/api2ai" alt="TypeScript types" /></a>
     <a href="https://packagephobia.com/result?p=api2ai"><img src="https://packagephobia.com/badge?p=api2ai" alt="Install size" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" /> <img src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white" alt="TypeScript" /> <img src="https://img.shields.io/badge/Next.js-black?logo=nextdotjs&logoColor=white" alt="Next.js" /> <img src="https://img.shields.io/badge/React-20232A?logo=react&logoColor=white" alt="React" /> <img src="https://img.shields.io/badge/Tailwind%20CSS-06B6D4?logo=tailwindcss&logoColor=white" alt="Tailwind CSS" /> <img src="https://img.shields.io/badge/shadcn%2Fui-000000?logo=shadcnui&logoColor=white" alt="shadcn/ui" /> <img src="https://img.shields.io/badge/Drizzle%20ORM-C5F74F?logo=drizzle&logoColor=white" alt="Drizzle ORM" /> <img src="https://img.shields.io/badge/better--auth-000000" alt="better-auth" /> <img src="https://img.shields.io/badge/Stripe-635BFF?logo=stripe&logoColor=white" alt="Stripe" /> <img src="https://img.shields.io/badge/Vercel%20AI%20SDK-black?logo=vercel&logoColor=white" alt="Vercel AI SDK" /> <img src="https://img.shields.io/badge/Zod-3E67B1?logo=zod&logoColor=white" alt="Zod" /> <img src="https://img.shields.io/badge/Fumadocs-000000" alt="Fumadocs" /> <img src="https://img.shields.io/badge/Vite-646CFF?logo=vite&logoColor=white" alt="Vite" /> <img src="https://img.shields.io/badge/Vitest-6E9F18?logo=vitest&logoColor=white" alt="Vitest" />
 </p>
 <!-- template-git-repo:badges:end -->
 

--- a/packages/cloudflare-to-claude-fix/README.md
+++ b/packages/cloudflare-to-claude-fix/README.md
@@ -11,6 +11,15 @@
     <a href="https://www.npmjs.com/package/cloudflare-to-claude-fix"><img src="https://img.shields.io/npm/dt/cloudflare-to-claude-fix.svg" alt="NPM Total Downloads" /></a>
     <a href="https://www.npmjs.com/package/cloudflare-to-claude-fix"><img src="https://img.shields.io/npm/types/cloudflare-to-claude-fix" alt="TypeScript types" /></a>
     <a href="https://packagephobia.com/result?p=cloudflare-to-claude-fix"><img src="https://packagephobia.com/badge?p=cloudflare-to-claude-fix" alt="Install size" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" /> <img src="https://img.shields.io/badge/Cloudflare%20Workers-F38020?logo=cloudflareworkers&logoColor=white" alt="Cloudflare Workers" /> <img src="https://img.shields.io/badge/Vitest-6E9F18?logo=vitest&logoColor=white" alt="Vitest" />
 </p>
 <!-- template-git-repo:badges:end -->
 

--- a/packages/code-tree-graph/README.md
+++ b/packages/code-tree-graph/README.md
@@ -12,6 +12,15 @@
     <a href="https://www.npmjs.com/package/code-tree-graph"><img src="https://img.shields.io/npm/dt/code-tree-graph.svg" alt="NPM Total Downloads" /></a>
     <a href="https://www.npmjs.com/package/code-tree-graph"><img src="https://img.shields.io/npm/types/code-tree-graph" alt="TypeScript types" /></a>
     <a href="https://packagephobia.com/result?p=code-tree-graph"><img src="https://packagephobia.com/badge?p=code-tree-graph" alt="Install size" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" /> <img src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white" alt="TypeScript" /> <img src="https://img.shields.io/badge/Next.js-black?logo=nextdotjs&logoColor=white" alt="Next.js" /> <img src="https://img.shields.io/badge/React-20232A?logo=react&logoColor=white" alt="React" /> <img src="https://img.shields.io/badge/Vite-646CFF?logo=vite&logoColor=white" alt="Vite" /> <img src="https://img.shields.io/badge/Vitest-6E9F18?logo=vitest&logoColor=white" alt="Vitest" />
 </p>
 <!-- template-git-repo:badges:end -->
 

--- a/packages/create-cloud-db/README.md
+++ b/packages/create-cloud-db/README.md
@@ -8,6 +8,15 @@
     <a href="https://www.npmjs.com/package/create-cloud-db"><img src="https://img.shields.io/npm/dt/create-cloud-db.svg" alt="NPM Total Downloads" /></a>
     <a href="https://www.npmjs.com/package/create-cloud-db"><img src="https://img.shields.io/npm/types/create-cloud-db" alt="TypeScript types" /></a>
     <a href="https://packagephobia.com/result?p=create-cloud-db"><img src="https://packagephobia.com/badge?p=create-cloud-db" alt="Install size" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" /> <img src="https://img.shields.io/badge/Vitest-6E9F18?logo=vitest&logoColor=white" alt="Vitest" />
 </p>
 <!-- template-git-repo:badges:end -->
 

--- a/packages/create-starter-app/readme.md
+++ b/packages/create-starter-app/readme.md
@@ -8,6 +8,15 @@
     <a href="https://www.npmjs.com/package/create-starter-app"><img src="https://img.shields.io/npm/dt/create-starter-app.svg" alt="NPM Total Downloads" /></a>
     <a href="https://www.npmjs.com/package/create-starter-app"><img src="https://img.shields.io/npm/types/create-starter-app" alt="TypeScript types" /></a>
     <a href="https://packagephobia.com/result?p=create-starter-app"><img src="https://packagephobia.com/badge?p=create-starter-app" alt="Install size" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" /> <img src="https://img.shields.io/badge/Vitest-6E9F18?logo=vitest&logoColor=white" alt="Vitest" />
 </p>
 <!-- template-git-repo:badges:end -->
 

--- a/packages/export-svg-icons-typescript/readme.md
+++ b/packages/export-svg-icons-typescript/readme.md
@@ -12,6 +12,15 @@
     <a href="https://www.npmjs.com/package/export-svg-typescript"><img src="https://img.shields.io/npm/dt/export-svg-typescript.svg" alt="NPM Total Downloads" /></a>
     <a href="https://www.npmjs.com/package/export-svg-typescript"><img src="https://img.shields.io/npm/types/export-svg-typescript" alt="TypeScript types" /></a>
     <a href="https://packagephobia.com/result?p=export-svg-typescript"><img src="https://packagephobia.com/badge?p=export-svg-typescript" alt="Install size" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" /> <img src="https://img.shields.io/badge/Vitest-6E9F18?logo=vitest&logoColor=white" alt="Vitest" />
 </p>
 <!-- template-git-repo:badges:end -->
 

--- a/packages/git0-repo-downloader/readme.md
+++ b/packages/git0-repo-downloader/readme.md
@@ -13,6 +13,15 @@
     <a href="https://www.npmjs.com/package/git0"><img src="https://img.shields.io/npm/types/git0" alt="TypeScript types" /></a>
     <a href="https://packagephobia.com/result?p=git0"><img src="https://packagephobia.com/badge?p=git0" alt="Install size" /></a>
     <a href="https://app.codecov.io/gh/OpenSourceAGI/dev-tools-starter-agent/flags"><img src="https://img.shields.io/codecov/c/github/OpenSourceAGI/dev-tools-starter-agent?flag=git0-repo-downloader&label=git0-repo-downloader%20coverage&logo=codecov&logoColor=white" alt="Coverage" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" /> <img src="https://img.shields.io/badge/Vitest-6E9F18?logo=vitest&logoColor=white" alt="Vitest" />
 </p>
 <!-- template-git-repo:badges:end -->
 

--- a/packages/legal-terms-privacy-policy/readme.md
+++ b/packages/legal-terms-privacy-policy/readme.md
@@ -9,6 +9,15 @@
     <a href="https://www.npmjs.com/package/legal-terms"><img src="https://img.shields.io/npm/types/legal-terms" alt="TypeScript types" /></a>
     <a href="https://packagephobia.com/result?p=legal-terms"><img src="https://packagephobia.com/badge?p=legal-terms" alt="Install size" /></a>
     <a href="https://app.codecov.io/gh/OpenSourceAGI/dev-tools-starter-agent/flags"><img src="https://img.shields.io/codecov/c/github/OpenSourceAGI/dev-tools-starter-agent?flag=legal-terms-privacy-policy&label=legal-terms-privacy-policy%20coverage&logo=codecov&logoColor=white" alt="Coverage" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" /> <img src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white" alt="TypeScript" /> <img src="https://img.shields.io/badge/React-20232A?logo=react&logoColor=white" alt="React" /> <img src="https://img.shields.io/badge/Vitest-6E9F18?logo=vitest&logoColor=white" alt="Vitest" />
 </p>
 <!-- template-git-repo:badges:end -->
 

--- a/packages/manage-storage/README.md
+++ b/packages/manage-storage/README.md
@@ -13,6 +13,15 @@
     <a href="https://www.npmjs.com/package/manage-storage"><img src="https://img.shields.io/npm/types/manage-storage" alt="TypeScript types" /></a>
     <a href="https://packagephobia.com/result?p=manage-storage"><img src="https://packagephobia.com/badge?p=manage-storage" alt="Install size" /></a>
     <a href="https://app.codecov.io/gh/OpenSourceAGI/dev-tools-starter-agent/flags"><img src="https://img.shields.io/codecov/c/github/OpenSourceAGI/dev-tools-starter-agent?flag=manage-storage&label=manage-storage%20coverage&logo=codecov&logoColor=white" alt="Coverage" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" /> <img src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white" alt="TypeScript" /> <img src="https://img.shields.io/badge/Vite-646CFF?logo=vite&logoColor=white" alt="Vite" /> <img src="https://img.shields.io/badge/Vitest-6E9F18?logo=vitest&logoColor=white" alt="Vitest" />
 </p>
 <!-- template-git-repo:badges:end -->
 

--- a/packages/native-app-wrapper/README.md
+++ b/packages/native-app-wrapper/README.md
@@ -1,6 +1,15 @@
 <!-- template-git-repo:badges:start -->
 <p align="center">
     <a href="https://starterdocs.vtempest.workers.dev/docs/packages/native-app-wrapper"><img src="https://img.shields.io/badge/Docs-blue?logo=ReadTheDocs&logoColor=white" alt="Documentation" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" /> <img src="https://img.shields.io/badge/Tauri-24C8D8?logo=tauri&logoColor=white" alt="Tauri" /> <img src="https://img.shields.io/badge/Vitest-6E9F18?logo=vitest&logoColor=white" alt="Vitest" />
 </p>
 <!-- template-git-repo:badges:end -->
 

--- a/packages/open-when-ready/README.md
+++ b/packages/open-when-ready/README.md
@@ -12,6 +12,15 @@
     <a href="https://www.npmjs.com/package/open-ready"><img src="https://img.shields.io/npm/dt/open-ready.svg" alt="NPM Total Downloads" /></a>
     <a href="https://www.npmjs.com/package/open-ready"><img src="https://img.shields.io/npm/types/open-ready" alt="TypeScript types" /></a>
     <a href="https://packagephobia.com/result?p=open-ready"><img src="https://packagephobia.com/badge?p=open-ready" alt="Install size" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" /> <img src="https://img.shields.io/badge/Vitest-6E9F18?logo=vitest&logoColor=white" alt="Vitest" />
 </p>
 <!-- template-git-repo:badges:end -->
 

--- a/packages/react-app-store-buttons/README.md
+++ b/packages/react-app-store-buttons/README.md
@@ -14,6 +14,15 @@
     <a href="https://www.npmjs.com/package/react-app-store-buttons"><img src="https://img.shields.io/npm/dt/react-app-store-buttons.svg" alt="NPM Total Downloads" /></a>
     <a href="https://www.npmjs.com/package/react-app-store-buttons"><img src="https://img.shields.io/npm/types/react-app-store-buttons" alt="TypeScript types" /></a>
     <a href="https://packagephobia.com/result?p=react-app-store-buttons"><img src="https://packagephobia.com/badge?p=react-app-store-buttons" alt="Install size" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" /> <img src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white" alt="TypeScript" /> <img src="https://img.shields.io/badge/React-20232A?logo=react&logoColor=white" alt="React" /> <img src="https://img.shields.io/badge/Tailwind%20CSS-06B6D4?logo=tailwindcss&logoColor=white" alt="Tailwind CSS" /> <img src="https://img.shields.io/badge/Vite-646CFF?logo=vite&logoColor=white" alt="Vite" /> <img src="https://img.shields.io/badge/Vitest-6E9F18?logo=vitest&logoColor=white" alt="Vitest" />
 </p>
 <!-- template-git-repo:badges:end -->
 

--- a/packages/server-shell-setup/README.md
+++ b/packages/server-shell-setup/README.md
@@ -5,6 +5,15 @@
 <!-- template-git-repo:badges:start -->
 <p align="center">
     <a href="https://starterdocs.vtempest.workers.dev/docs/packages/server-shell-setup"><img src="https://img.shields.io/badge/Docs-blue?logo=ReadTheDocs&logoColor=white" alt="Documentation" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" />
 </p>
 <!-- template-git-repo:badges:end -->
 

--- a/packages/setup-git-repo/README.md
+++ b/packages/setup-git-repo/README.md
@@ -9,6 +9,15 @@
     <a href="https://www.npmjs.com/package/setup-git-repo"><img src="https://img.shields.io/npm/types/setup-git-repo" alt="TypeScript types" /></a>
     <a href="https://packagephobia.com/result?p=setup-git-repo"><img src="https://packagephobia.com/badge?p=setup-git-repo" alt="Install size" /></a>
     <a href="https://app.codecov.io/gh/OpenSourceAGI/dev-tools-starter-agent/flags"><img src="https://img.shields.io/codecov/c/github/OpenSourceAGI/dev-tools-starter-agent?flag=setup-git-repo&label=setup-git-repo%20coverage&logo=codecov&logoColor=white" alt="Coverage" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" /> <img src="https://img.shields.io/badge/Vitest-6E9F18?logo=vitest&logoColor=white" alt="Vitest" />
 </p>
 <!-- template-git-repo:badges:end -->
 
@@ -69,7 +78,7 @@ rather than shipped pointing at a placeholder:
 | --- | --- |
 | `--package <name>` | npm version + monthly downloads |
 | `--doi <10.5281/zenodo.N>` | Zenodo DOI |
-| `--docs <url>` / `--api <url>` / `--youtube <url>` | link badges |
+| `--website <url>` / `--docs <url>` / `--api <url>` / `--youtube <url>` | link badges |
 | `--uptime <page-id>` | UptimeRobot status page |
 | `--discord-id <id>` + `--discord-invite <url>` | Discord (both required) |
 

--- a/packages/setup-git-repo/bin/setup-git-repo.js
+++ b/packages/setup-git-repo/bin/setup-git-repo.js
@@ -41,6 +41,7 @@ const FLAGS = {
   description: "DESCRIPTION",
   package: "PACKAGE",
   doi: "DOI",
+  website: "WEBSITE_URL",
   docs: "DOCS_URL",
   api: "API_URL",
   youtube: "YOUTUBE_URL",
@@ -119,6 +120,7 @@ ${bold("Optional badges")} ${dim("(a badge whose value is omitted is left out of
 
   --package <name>          npm package, for the version + downloads badges
   --doi <10.5281/zenodo.N>  Zenodo DOI
+  --website <url>           Live app link
   --docs <url>              Documentation link
   --api <url>               API reference link
   --youtube <url>           Demo video link
@@ -196,6 +198,7 @@ async function main() {
       console.log(`\n${bold("  Optional badges")} ${dim("— press Enter to leave one out")}`);
       values.PACKAGE = await prompt(rl, "npm package name", values.PACKAGE);
       values.DOI = await prompt(rl, "Zenodo DOI", values.DOI);
+      values.WEBSITE_URL = await prompt(rl, "Live app URL", values.WEBSITE_URL);
       values.DOCS_URL = await prompt(rl, "Docs URL", values.DOCS_URL);
       values.API_URL = await prompt(rl, "API URL", values.API_URL);
       values.YOUTUBE_URL = await prompt(rl, "YouTube URL", values.YOUTUBE_URL);

--- a/packages/setup-git-repo/src/template.mjs
+++ b/packages/setup-git-repo/src/template.mjs
@@ -11,6 +11,7 @@ import { join, relative, sep } from "node:path";
  */
 export const OPTIONAL_BADGES = {
   doi: ["DOI"],
+  website: ["WEBSITE_URL"],
   docs: ["DOCS_URL"],
   api: ["API_URL"],
   youtube: ["YOUTUBE_URL"],

--- a/packages/setup-git-repo/test/template-integrity.test.mjs
+++ b/packages/setup-git-repo/test/template-integrity.test.mjs
@@ -31,6 +31,7 @@ const KNOWN_PLACEHOLDERS = new Set([
   "DESCRIPTION",
   "PACKAGE",
   "DOI",
+  "WEBSITE_URL",
   "DOCS_URL",
   "API_URL",
   "YOUTUBE_URL",

--- a/packages/template-git-repo/README.md
+++ b/packages/template-git-repo/README.md
@@ -9,6 +9,15 @@
     <a href="https://www.npmjs.com/package/template-git-repo"><img src="https://img.shields.io/npm/types/template-git-repo" alt="TypeScript types" /></a>
     <a href="https://packagephobia.com/result?p=template-git-repo"><img src="https://packagephobia.com/badge?p=template-git-repo" alt="Install size" /></a>
     <a href="https://app.codecov.io/gh/OpenSourceAGI/dev-tools-starter-agent/flags"><img src="https://img.shields.io/codecov/c/github/OpenSourceAGI/dev-tools-starter-agent?flag=template-git-repo&label=template-git-repo%20coverage&logo=codecov&logoColor=white" alt="Coverage" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" /> <img src="https://img.shields.io/badge/Vitest-6E9F18?logo=vitest&logoColor=white" alt="Vitest" />
 </p>
 <!-- template-git-repo:badges:end -->
 

--- a/packages/template-git-repo/bin/template-git-repo.js
+++ b/packages/template-git-repo/bin/template-git-repo.js
@@ -53,6 +53,7 @@ Context (all optional — detected where possible)
 
 Badge inputs (each enables the badge that needs it)
   --doi <10.5281/...>        --docs <url>          --api <url>
+  --website <url>
   --youtube <url>            --uptime <url>        --test-report <url>
   --discord-id <id>          --discord-invite <url>
   --stack <A,B,C>            --cloudflare-deploy
@@ -108,6 +109,7 @@ function overridesFrom(flags) {
     npmPackage: text('npm-package'),
     workflowFile: text('workflow'),
     doi: text('doi'),
+    websiteUrl: text('website'),
     docsUrl: text('docs'),
     apiUrl: text('api'),
     youtubeUrl: text('youtube'),

--- a/packages/template-git-repo/docs/BADGES.md
+++ b/packages/template-git-repo/docs/BADGES.md
@@ -23,12 +23,20 @@ package or finish setting up Codecov.
 | --- | --- | --- |
 | [Zenodo DOI](#doi) `doi` | doi | `--doi <10.5281/zenodo.NNNNNNN>` |
 | [Ask DeepWiki](#deepwiki) `deepwiki` | — | on by default |
+| [Live app](#website) `website` | websiteUrl | `--website <url>` |
 | [Documentation](#docs) `docs` | docsUrl | `--docs <url>` |
 | [API reference](#api) `api` | apiUrl | `--api <url>` |
 | [YouTube demo](#youtube) `youtube` | youtubeUrl | `--youtube <url>` |
 | [Deploy to Cloudflare Workers](#deploy-cloudflare) `deploy-cloudflare` | cloudflareDeploy | `--cloudflare-deploy` |
 | [Open in StackBlitz](#stackblitz) `stackblitz` | stackblitzUrl | `--stackblitz <url>` |
+| [Open in GitHub Codespaces](#codespaces) `codespaces` | — | on by default |
 | [GitHub stars](#stars) `stars` | — | on by default |
+| [GitHub forks](#forks) `forks` | — | on by default |
+| [Contributors](#contributors) `contributors` | — | on by default |
+| [Open issues](#issues) `issues` | — | on by default |
+| [Open pull requests](#pull-requests) `pull-requests` | — | on by default |
+| [Merged pull requests](#prs-merged) `prs-merged` | — | on by default |
+| [GitHub Discussions](#discussions) `discussions` | — | on by default |
 | [npm monthly downloads](#npm-downloads) `npm-downloads` | npmPackage | `--npm-package <name>` |
 | [npm version](#npm-version) `npm-version` | npmPackage | `--npm-package <name>` |
 | [npm total downloads](#npm-total-downloads) `npm-total-downloads` | npmPackage | `--npm-package <name>` |
@@ -63,6 +71,14 @@ Enable with: `--doi <10.5281/zenodo.NNNNNNN>`
 Nothing to configure for a public repo — visit deepwiki.com/<owner>/<repo> once to trigger the first index. Private repos need the DeepWiki GitHub App installed.
 
 Included by default — no configuration needed.
+
+### website
+
+**Live app**
+
+The deployed thing, not the repo. It is first in the row on purpose: a visitor who can click through to a running app decides in seconds whether to read the rest. Static badge — nothing checks that the URL is up, which is what the uptime badge is for.
+
+Enable with: `--website <url>`
 
 ### docs
 
@@ -103,6 +119,14 @@ Enable with: `--cloudflare-deploy`
 Nothing to configure — StackBlitz imports a public repo straight from a URL: `https://stackblitz.com/github/<owner>/<repo>/tree/<branch>/<path>`. Point it at a directory that boots on its own (a package with its own package.json, or an `examples/` folder), because StackBlitz installs from the manifest at that path and a bare monorepo root will not run. Node APIs need the WebContainer runtime, which means the directory must be ESM and its deps must be installable from npm.
 
 Enable with: `--stackblitz <url>`
+
+### codespaces
+
+**Open in GitHub Codespaces**
+
+Nothing to configure — the link boots the repo in a default container. Add a `.devcontainer/devcontainer.json` if the default image is missing something your install needs, because the visitor sees the failure, not you. Codespaces bills the visitor's own free hours, so the button costs you nothing.
+
+Included by default — no configuration needed.
 
 ## Quality — is it working, is it tested, is it shipped
 
@@ -193,6 +217,54 @@ Enable with: `--uptime <url>`
 **GitHub stars**
 
 Nothing to configure. Public repos only — shields.io cannot read a private repo.
+
+Included by default — no configuration needed.
+
+### forks
+
+**GitHub forks**
+
+Nothing to configure. Counts direct forks only, not forks of forks, so it undercounts a repo that has been forked along a chain. Public repos only.
+
+Included by default — no configuration needed.
+
+### contributors
+
+**Contributors**
+
+Nothing to configure, but it counts commit authors GitHub could match to an account — commits made with an unregistered email are attributed to nobody and do not appear here. Use `contributors-anon` instead if your history has many of those.
+
+Included by default — no configuration needed.
+
+### issues
+
+**Open issues**
+
+Nothing to configure beyond having Issues enabled (Settings → Features). Read it as a work-in-flight number, not a defect count: shields.io asks GitHub Search, which counts pull requests as issues unless the badge path excludes them — this one uses the `/issues/` path, which already does.
+
+Included by default — no configuration needed.
+
+### pull-requests
+
+**Open pull requests**
+
+Nothing to configure. Counts open PRs including drafts. Pair it with the merged count below — an open count alone reads the same whether the queue moves in a day or has been stuck for a year.
+
+Included by default — no configuration needed.
+
+### prs-merged
+
+**Merged pull requests**
+
+Nothing to configure. shields.io has no "merged" endpoint — `issues-pr-closed` counts every PR that is no longer open, so PRs closed without merging are in this number too. On a repo that closes a lot of stale PRs, label it "PRs closed" instead of overstating what landed.
+
+Included by default — no configuration needed.
+
+### discussions
+
+**GitHub Discussions**
+
+Discussions has to be turned on (Settings → Features → Discussions) or the badge reads "repo not found" — which looks identical to a private repo. Turn it on before adding the badge, not after.
 
 Included by default — no configuration needed.
 

--- a/packages/template-git-repo/scripts/generate-badge-docs.mjs
+++ b/packages/template-git-repo/scripts/generate-badge-docs.mjs
@@ -26,6 +26,7 @@ const GROUP_TITLES = {
 
 const FLAG_FOR = {
   doi: '--doi <10.5281/zenodo.NNNNNNN>',
+  websiteUrl: '--website <url>',
   docsUrl: '--docs <url>',
   apiUrl: '--api <url>',
   youtubeUrl: '--youtube <url>',

--- a/packages/template-git-repo/src/badges.js
+++ b/packages/template-git-repo/src/badges.js
@@ -64,6 +64,19 @@ export const BADGES = [
       'Nothing to configure for a public repo — visit deepwiki.com/<owner>/<repo> once to trigger the first index. Private repos need the DeepWiki GitHub App installed.',
   },
   {
+    id: 'website',
+    title: 'Live app',
+    group: 'identity',
+    needs: ['websiteUrl'],
+    alt: 'Website',
+    href: (c) => c.websiteUrl,
+    img: () =>
+      shieldsBadge('App', 'blueviolet', { style: 'for-the-badge', logo: 'googlechrome', logoColor: 'white' }),
+    setup:
+      'The deployed thing, not the repo. It is first in the row on purpose: a visitor who can click through to a running app decides in seconds whether to read the rest. Static badge — nothing checks that the URL is up, which is what the uptime badge is for.',
+    height: '20px',
+  },
+  {
     id: 'docs',
     title: 'Documentation',
     group: 'identity',
@@ -120,6 +133,18 @@ export const BADGES = [
     height: '20px',
   },
   {
+    id: 'codespaces',
+    title: 'Open in GitHub Codespaces',
+    group: 'identity',
+    needs: [],
+    alt: 'Open in GitHub Codespaces',
+    href: (c) => `https://codespaces.new/${c.repoSlug}`,
+    img: () => 'https://github.com/codespaces/badge.svg',
+    setup:
+      'Nothing to configure — the link boots the repo in a default container. Add a `.devcontainer/devcontainer.json` if the default image is missing something your install needs, because the visitor sees the failure, not you. Codespaces bills the visitor\'s own free hours, so the button costs you nothing.',
+    height: '20px',
+  },
+  {
     id: 'stars',
     title: 'GitHub stars',
     group: 'community',
@@ -128,6 +153,73 @@ export const BADGES = [
     href: (c) => `https://github.com/${c.repoSlug}/stargazers`,
     img: (c) => `https://img.shields.io/github/stars/${c.repoSlug}`,
     setup: 'Nothing to configure. Public repos only — shields.io cannot read a private repo.',
+  },
+  {
+    id: 'forks',
+    title: 'GitHub forks',
+    group: 'community',
+    needs: [],
+    alt: 'GitHub Forks',
+    href: (c) => `https://github.com/${c.repoSlug}/forks`,
+    img: (c) => `https://img.shields.io/github/forks/${c.repoSlug}`,
+    setup:
+      'Nothing to configure. Counts direct forks only, not forks of forks, so it undercounts a repo that has been forked along a chain. Public repos only.',
+  },
+  {
+    id: 'contributors',
+    title: 'Contributors',
+    group: 'community',
+    needs: [],
+    alt: 'Contributors',
+    href: (c) => `https://github.com/${c.repoSlug}/graphs/contributors`,
+    img: (c) => `https://img.shields.io/github/contributors/${c.repoSlug}`,
+    setup:
+      'Nothing to configure, but it counts commit authors GitHub could match to an account — commits made with an unregistered email are attributed to nobody and do not appear here. Use `contributors-anon` instead if your history has many of those.',
+  },
+  {
+    id: 'issues',
+    title: 'Open issues',
+    group: 'community',
+    needs: [],
+    alt: 'GitHub Issues',
+    href: (c) => `https://github.com/${c.repoSlug}/issues`,
+    img: (c) => `https://img.shields.io/github/issues/${c.repoSlug}?logo=github`,
+    setup:
+      'Nothing to configure beyond having Issues enabled (Settings → Features). Read it as a work-in-flight number, not a defect count: shields.io asks GitHub Search, which counts pull requests as issues unless the badge path excludes them — this one uses the `/issues/` path, which already does.',
+  },
+  {
+    id: 'pull-requests',
+    title: 'Open pull requests',
+    group: 'community',
+    needs: [],
+    alt: 'Open Pull Requests',
+    href: (c) => `https://github.com/${c.repoSlug}/pulls`,
+    img: (c) => `https://img.shields.io/github/issues-pr/${c.repoSlug}?logo=github&label=PRs`,
+    setup:
+      'Nothing to configure. Counts open PRs including drafts. Pair it with the merged count below — an open count alone reads the same whether the queue moves in a day or has been stuck for a year.',
+  },
+  {
+    id: 'prs-merged',
+    title: 'Merged pull requests',
+    group: 'community',
+    needs: [],
+    alt: 'Merged Pull Requests',
+    href: (c) => `https://github.com/${c.repoSlug}/pulls?q=is%3Apr+is%3Aclosed`,
+    img: (c) =>
+      `https://img.shields.io/github/issues-pr-closed/${c.repoSlug}?logo=github&label=PRs%20merged&color=8957e5`,
+    setup:
+      'Nothing to configure. shields.io has no "merged" endpoint — `issues-pr-closed` counts every PR that is no longer open, so PRs closed without merging are in this number too. On a repo that closes a lot of stale PRs, label it "PRs closed" instead of overstating what landed.',
+  },
+  {
+    id: 'discussions',
+    title: 'GitHub Discussions',
+    group: 'community',
+    needs: [],
+    alt: 'GitHub Discussions',
+    href: (c) => `https://github.com/${c.repoSlug}/discussions`,
+    img: (c) => `https://img.shields.io/github/discussions/${c.repoSlug}`,
+    setup:
+      'Discussions has to be turned on (Settings → Features → Discussions) or the badge reads "repo not found" — which looks identical to a private repo. Turn it on before adding the badge, not after.',
   },
   {
     id: 'npm-downloads',
@@ -309,18 +401,90 @@ export const BADGES = [
   },
 ];
 
-/** Brand colors for the stack chips, so the common ones look right by default. */
+/**
+ * Brand colors for the stack chips, so the common ones look right by default.
+ *
+ * Keyed by the lowercased chip name. Anything not listed falls back to a
+ * neutral grey, which is a perfectly good chip — this map is a nicety, not a
+ * gate on what you can name.
+ */
 const STACK_COLORS = {
   claude: 'D97757',
   cloudflare: 'F38020',
+  'cloudflare workers': 'F38020',
+  d1: 'F38020',
+  r2: 'F38020',
+  wrangler: 'F38020',
   'next.js': 'black',
   react: '20232A',
+  svelte: 'FF3E00',
+  'vue.js': '4FC08D',
   typescript: '3178C6',
+  javascript: 'F7DF1E',
+  'node.js': '5FA04E',
   bun: '14151A',
+  npm: 'CB3837',
+  pnpm: 'F69220',
+  turborepo: 'EF4444',
   vite: '646CFF',
+  vitest: '6E9F18',
+  jest: 'C21325',
+  playwright: '2EAD33',
+  biome: '60A5FA',
   vercel: 'black',
   postgresql: '4169E1',
+  sqlite: '003B57',
+  'drizzle orm': 'C5F74F',
   tailwindcss: '06B6D4',
+  'tailwind css': '06B6D4',
+  'shadcn/ui': '000000',
+  'radix ui': '161618',
+  'better-auth': '000000',
+  hono: 'E36002',
+  stripe: '635BFF',
+  zod: '3E67B1',
+  tauri: '24C8D8',
+  electron: '47848F',
+  prosemirror: '000000',
+  tiptap: '000000',
+  fumadocs: '000000',
+  mcp: '000000',
+  'vercel ai sdk': 'black',
+  openai: '412991',
+  python: '3776AB',
+  docker: '2496ED',
+  'github actions': '2088FF',
+};
+
+/**
+ * simple-icons slugs for chips whose name does not reduce to one.
+ *
+ * `?logo=` takes a simpleicons.org slug, and the derivation below (lowercase,
+ * drop dots, spaces and slashes) gets most of them right — `Next.js` really is
+ * `nextjs`. It gets a handful wrong, and a wrong slug renders a chip with a
+ * blank square where the logo should be, so those are written out.
+ *
+ * A name with no icon at all (`better-auth`, `MCP`) maps to the empty string:
+ * the chip renders as plain text rather than carrying someone else's logo.
+ */
+const STACK_LOGOS = {
+  'cloudflare workers': 'cloudflareworkers',
+  d1: 'cloudflare',
+  r2: 'cloudflare',
+  'drizzle orm': 'drizzle',
+  'tailwind css': 'tailwindcss',
+  'vue.js': 'vuedotjs',
+  'node.js': 'nodedotjs',
+  'next.js': 'nextdotjs',
+  'radix ui': 'radixui',
+  'github actions': 'githubactions',
+  'vercel ai sdk': 'vercel',
+  claude: 'claude',
+  'better-auth': '',
+  mcp: '',
+  prosemirror: '',
+  fumadocs: '',
+  zod: 'zod',
 };
 
 /**
@@ -328,10 +492,13 @@ const STACK_COLORS = {
  * @returns {string} an `<img>` chip for one stack entry
  */
 export function stackChip(name) {
-  const key = name.trim().toLowerCase();
+  const label = name.trim();
+  const key = label.toLowerCase();
   const color = STACK_COLORS[key] ?? '555555';
-  const logo = key.replace(/[.\s]/g, '');
-  return `<img src="${shieldsBadge(name.trim(), color, { logo, logoColor: 'white' })}" alt="${name.trim()}" />`;
+  const logo = STACK_LOGOS[key] ?? key.replace(/[.\s/]/g, '');
+
+  const params = logo ? { logo, logoColor: 'white' } : {};
+  return `<img src="${shieldsBadge(label, color, params)}" alt="${label}" />`;
 }
 
 /**

--- a/packages/template-git-repo/src/context.js
+++ b/packages/template-git-repo/src/context.js
@@ -161,6 +161,146 @@ export function detectNpmPackage(root, packagesDir) {
 }
 
 /**
+ * Dependency name -> the stack chip it implies, in the order the chips should
+ * read: language and runtime first, then framework, then the things bolted onto
+ * it, then the test runner.
+ *
+ * Keyed on the dependency rather than on a guess about the project, because the
+ * manifest is the one place that cannot lie about what a package is built with.
+ * A hand-written stack row goes stale the week someone swaps a framework out and
+ * nobody remembers the README says otherwise.
+ *
+ * Several entries collapse many packages into one chip — a ProseMirror app
+ * depends on eight `prosemirror-*` modules and is built with ProseMirror once.
+ * Duplicates are removed by `detectStack`, so listing every alias is safe.
+ */
+const STACK_BY_DEPENDENCY = [
+  ['typescript', 'TypeScript'],
+  ['next', 'Next.js'],
+  ['react', 'React'],
+  ['svelte', 'Svelte'],
+  ['vue', 'Vue.js'],
+  ['@tauri-apps/api', 'Tauri'],
+  ['@tauri-apps/cli', 'Tauri'],
+  ['electron', 'Electron'],
+  ['wrangler', 'Cloudflare Workers'],
+  ['hono', 'Hono'],
+  ['tailwindcss', 'Tailwind CSS'],
+  ['@radix-ui/react-dialog', 'shadcn/ui'],
+  ['drizzle-orm', 'Drizzle ORM'],
+  ['better-auth', 'better-auth'],
+  ['stripe', 'Stripe'],
+  ['ai', 'Vercel AI SDK'],
+  ['@modelcontextprotocol/sdk', 'MCP'],
+  ['@tiptap/core', 'TipTap'],
+  ['prosemirror-state', 'ProseMirror'],
+  ['prosemirror-view', 'ProseMirror'],
+  ['zod', 'Zod'],
+  ['fumadocs-ui', 'Fumadocs'],
+  ['vite', 'Vite'],
+  ['turbo', 'Turborepo'],
+  ['vitest', 'Vitest'],
+  ['jest', 'Jest'],
+  ['@playwright/test', 'Playwright'],
+];
+
+/** The chip for each package manager, so the runtime shows up even with no deps. */
+const STACK_BY_PACKAGE_MANAGER = { bun: 'Bun', pnpm: 'pnpm', yarn: 'Yarn', npm: 'npm' };
+
+/**
+ * De-duplicate chips and put them back in catalog order.
+ *
+ * Needed because the workspace union collects chips manifest by manifest, and
+ * alphabetical directory order is not a sensible reading order for a stack row —
+ * it lands on "Drizzle ORM, Vitest, TypeScript, React". Anything not in the
+ * catalog (a `prepend` like Claude) keeps its position at the front.
+ *
+ * @param {string[]} chips
+ * @returns {string[]}
+ */
+function orderChips(chips) {
+  const order = STACK_BY_DEPENDENCY.map(([, chip]) => chip);
+  const rank = (chip) => {
+    const index = order.indexOf(chip);
+    return index === -1 ? -1 : index;
+  };
+
+  const unique = [...new Set(chips)];
+  const leading = unique.filter((chip) => rank(chip) === -1);
+  const known = unique.filter((chip) => rank(chip) !== -1).sort((a, b) => rank(a) - rank(b));
+
+  return [...leading, ...known];
+}
+
+/**
+ * The stack chips for one manifest, read off its dependencies.
+ *
+ * Returns a comma-separated string because that is what the `stack` badge takes
+ * and what `--stack` passes on the command line. An empty result means the
+ * manifest declared nothing recognizable, and the badge is skipped — better
+ * than a row asserting a framework the package does not use.
+ *
+ * @param {Record<string, any> | null} manifest
+ * @param {{ prepend?: string[], packageManager?: string }} [options]
+ * @returns {string | undefined}
+ */
+export function detectStack(manifest, options = {}) {
+  const { prepend = [], packageManager } = options;
+
+  const declared = new Set([
+    ...Object.keys(manifest?.dependencies ?? {}),
+    ...Object.keys(manifest?.devDependencies ?? {}),
+    ...Object.keys(manifest?.peerDependencies ?? {}),
+  ]);
+
+  const chips = [...prepend];
+
+  const runtime = packageManager ? STACK_BY_PACKAGE_MANAGER[packageManager] : undefined;
+  if (runtime) chips.push(runtime);
+
+  for (const [dependency, chip] of STACK_BY_DEPENDENCY) {
+    if (declared.has(dependency)) chips.push(chip);
+  }
+
+  const ordered = orderChips(chips);
+  return ordered.length > 0 ? ordered.join(',') : undefined;
+}
+
+/**
+ * The stack for a whole workspace: the union of every member's chips.
+ *
+ * A monorepo root manifest lists turbo and little else, so reading it alone
+ * describes the build tooling and none of the product. This walks the workspace
+ * directory instead, which is what the root README's stack row should say.
+ *
+ * @param {string} root
+ * @param {{ packagesDirs?: string[], prepend?: string[], packageManager?: string }} [options]
+ * @returns {string | undefined}
+ */
+export function detectWorkspaceStack(root, options = {}) {
+  const { packagesDirs = ['packages', 'apps'], prepend = [], packageManager } = options;
+
+  const manifests = [readJson(path.join(root, 'package.json'))];
+
+  for (const dir of packagesDirs) {
+    const parent = path.join(root, dir);
+    if (!fs.existsSync(parent)) continue;
+
+    for (const entry of fs.readdirSync(parent, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      manifests.push(readJson(path.join(parent, entry.name, 'package.json')));
+    }
+  }
+
+  const merged = manifests.filter(Boolean).flatMap((manifest) =>
+    (detectStack(manifest, { packageManager }) ?? '').split(',').filter(Boolean),
+  );
+
+  const ordered = orderChips([...prepend, ...merged]);
+  return ordered.length > 0 ? ordered.join(',') : undefined;
+}
+
+/**
  * Everything the templates and badges need, detected then overridden by flags.
  *
  * @param {{ cwd?: string, overrides?: Record<string, string | undefined> }} [options]
@@ -194,6 +334,7 @@ export function buildContext(options = {}) {
     // Everything below has no sensible default — a badge that needs one of
     // these is skipped until it is passed in.
     doi: overrides.doi,
+    websiteUrl: overrides.websiteUrl,
     docsUrl: overrides.docsUrl,
     apiUrl: overrides.apiUrl,
     youtubeUrl: overrides.youtubeUrl,

--- a/packages/template-git-repo/src/index.js
+++ b/packages/template-git-repo/src/index.js
@@ -19,6 +19,8 @@ export {
   detectNpmPackage,
   detectPackageManager,
   detectPackagesDir,
+  detectStack,
+  detectWorkspaceStack,
   findRepoRoot,
   parseRepoSlug,
   substitute,

--- a/packages/template-git-repo/test/badges.test.js
+++ b/packages/template-git-repo/test/badges.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   BADGES,
+  GROUPS,
   renderBadge,
   renderBadgeBlock,
   selectBadges,
@@ -69,8 +70,25 @@ describe('renderBadge', () => {
 
     expect(html).toContain('alt="Claude"');
     expect(html).toContain('alt="Next.js"');
-    // The dot is not part of a simple-icons slug.
-    expect(html).toContain('logo=nextjs');
+    // simple-icons spells the dot out rather than dropping it: the slug is
+    // `nextdotjs`, and `nextjs` renders a chip with a blank square on it.
+    expect(html).toContain('logo=nextdotjs');
+  });
+
+  it('spaces and slashes in a chip name survive into the label but not the slug', () => {
+    const badge = BADGES.find((entry) => entry.id === 'stack');
+    const html = renderBadge(badge, { ...context, stack: 'Tailwind CSS,shadcn/ui' });
+
+    expect(html).toContain('logo=tailwindcss');
+    expect(html).toContain('logo=shadcnui');
+    expect(html).toContain('alt="shadcn/ui"');
+  });
+
+  it('leaves off the logo for a chip simple-icons has no icon for', () => {
+    // A wrong slug renders a blank square where the logo should be, which looks
+    // like a broken image rather than a deliberate text chip.
+    expect(stackChip('better-auth')).not.toContain('logo=');
+    expect(stackChip('better-auth')).toContain('alt="better-auth"');
   });
 
   it('gives every badge a non-empty alt text', () => {
@@ -84,6 +102,43 @@ describe('renderBadge', () => {
   });
 });
 
+describe('GitHub activity badges', () => {
+  // Stars alone say a repo was noticed once. These say whether anything is
+  // moving through it now.
+  it('links each count at the page that explains it', () => {
+    const expected = {
+      issues: '/issues',
+      'pull-requests': '/pulls',
+      'prs-merged': '/pulls?q=is%3Apr+is%3Aclosed',
+      discussions: '/discussions',
+      contributors: '/graphs/contributors',
+      forks: '/forks',
+    };
+
+    for (const [id, suffix] of Object.entries(expected)) {
+      const badge = BADGES.find((entry) => entry.id === id);
+      expect(renderBadge(badge, context), id).toContain(`href="https://github.com/acme/widget${suffix}"`);
+    }
+  });
+
+  it('labels the two PR counts apart', () => {
+    // Both come off shields.io as bare numbers; unlabelled, two adjacent PR
+    // badges read as one number printed twice.
+    const open = BADGES.find((entry) => entry.id === 'pull-requests');
+    const merged = BADGES.find((entry) => entry.id === 'prs-merged');
+
+    expect(renderBadge(open, context)).toContain('label=PRs');
+    expect(renderBadge(merged, context)).toContain('label=PRs%20merged');
+  });
+
+  it('renders every activity count without any configuration', () => {
+    const { included } = selectBadges(context);
+    expect(included.map((badge) => badge.id)).toEqual(
+      expect.arrayContaining(['issues', 'pull-requests', 'prs-merged', 'discussions', 'contributors', 'forks']),
+    );
+  });
+});
+
 describe('renderBadgeBlock', () => {
   it('groups badges into rows separated by <br />', () => {
     const { markdown } = renderBadgeBlock(context);
@@ -91,6 +146,20 @@ describe('renderBadgeBlock', () => {
     expect(markdown.startsWith('<p align="center">')).toBe(true);
     expect(markdown.trimEnd().endsWith('</p>')).toBe(true);
     expect(markdown).toContain('<br />');
+  });
+
+  it('renders one row per group, in GROUPS order', () => {
+    // Four rows is the shape the block is designed around: what it is, whether
+    // it works, whether it is alive, what it is built with. A fifth row would
+    // mean a badge landed in a group nobody named.
+    const { markdown } = renderBadgeBlock({ ...context, stack: 'Bun' });
+    const rows = markdown.split('<br />');
+
+    expect(rows).toHaveLength(GROUPS.length);
+    expect(rows[0]).toContain('deepwiki');
+    expect(rows[1]).toContain('npm/v');
+    expect(rows[2]).toContain('github/stars');
+    expect(rows[3]).toContain('alt="Bun"');
   });
 
   it('never emits an undefined url', () => {

--- a/packages/verify-phone-sms/README.md
+++ b/packages/verify-phone-sms/README.md
@@ -9,6 +9,15 @@
     <a href="https://www.npmjs.com/package/verify-phone-sms"><img src="https://img.shields.io/npm/types/verify-phone-sms" alt="TypeScript types" /></a>
     <a href="https://packagephobia.com/result?p=verify-phone-sms"><img src="https://packagephobia.com/badge?p=verify-phone-sms" alt="Install size" /></a>
     <a href="https://app.codecov.io/gh/OpenSourceAGI/dev-tools-starter-agent/flags"><img src="https://img.shields.io/codecov/c/github/OpenSourceAGI/dev-tools-starter-agent?flag=verify-phone-sms&label=verify-phone-sms%20coverage&logo=codecov&logoColor=white" alt="Coverage" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" /> <img src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white" alt="TypeScript" /> <img src="https://img.shields.io/badge/Cloudflare%20Workers-F38020?logo=cloudflareworkers&logoColor=white" alt="Cloudflare Workers" /> <img src="https://img.shields.io/badge/Hono-E36002?logo=hono&logoColor=white" alt="Hono" /> <img src="https://img.shields.io/badge/Zod-3E67B1?logo=zod&logoColor=white" alt="Zod" /> <img src="https://img.shields.io/badge/Vitest-6E9F18?logo=vitest&logoColor=white" alt="Vitest" />
 </p>
 <!-- template-git-repo:badges:end -->
 

--- a/packages/web2mobile-wrapper/README.md
+++ b/packages/web2mobile-wrapper/README.md
@@ -7,6 +7,15 @@
     <a href="https://starterdocs.vtempest.workers.dev/docs/packages/web2mobile-wrapper"><img src="https://img.shields.io/badge/Docs-blue?logo=ReadTheDocs&logoColor=white" alt="Documentation" /></a>
     <br />
     <a href="https://app.codecov.io/gh/OpenSourceAGI/dev-tools-starter-agent/flags"><img src="https://img.shields.io/codecov/c/github/OpenSourceAGI/dev-tools-starter-agent?flag=web2mobile-wrapper&label=web2mobile-wrapper%20coverage&logo=codecov&logoColor=white" alt="Coverage" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" /> <img src="https://img.shields.io/badge/React-20232A?logo=react&logoColor=white" alt="React" /> <img src="https://img.shields.io/badge/Jest-C21325?logo=jest&logoColor=white" alt="Jest" />
 </p>
 <!-- template-git-repo:badges:end -->
 

--- a/scripts/sync-package-readmes.mjs
+++ b/scripts/sync-package-readmes.mjs
@@ -38,7 +38,7 @@ import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
 import { renderBadgeBlock } from '../packages/template-git-repo/src/badges.js'
-import { buildContext } from '../packages/template-git-repo/src/context.js'
+import { buildContext, detectStack } from '../packages/template-git-repo/src/context.js'
 import {
   END_MARKER,
   START_MARKER,
@@ -64,16 +64,43 @@ const SECTIONS = [
   { dir: 'apps', docsSlug: 'apps', npm: false },
 ]
 
-/** The badges this block carries, and the only ones it rewrites. */
+/**
+ * The badges this block carries, and the only ones it rewrites.
+ *
+ * Read as four rows, and the split between the second and third is the point:
+ *
+ *   row 2 (quality)   measures *this package* — its own npm name, its own
+ *                     tarball, its own Codecov flag. Nothing here is affected
+ *                     by the sixteen packages next to it.
+ *   row 3 (community) measures *the repository* this package ships from —
+ *                     stars, open issues, the PR queue. Those are repo-wide by
+ *                     nature, which is exactly why they are on a separate row
+ *                     and labelled rather than mixed into the package numbers.
+ *
+ * Neither row can stand for the other: a package with no downloads in a busy
+ * repo and a popular package in a quiet one are different situations, and the
+ * two rows together are what tells them apart.
+ */
 const PACKAGE_BADGES = [
+  // identity
   'docs',
   'stackblitz',
+  // quality — this package
   'npm-version',
   'npm-downloads',
   'npm-total-downloads',
   'npm-types',
   'install-size',
   'codecov-flag',
+  // community — the repo it ships from
+  'stars',
+  'issues',
+  'pull-requests',
+  'prs-merged',
+  'discussions',
+  'last-commit',
+  // stack — read off this package's own manifest
+  'stack',
 ]
 
 /**
@@ -247,6 +274,10 @@ export function collectEntries(repoContext) {
             manifest && !NO_STACKBLITZ.has(child.name)
               ? `https://stackblitz.com/github/${repoContext.repoSlug}/tree/${repoContext.defaultBranch}/${relative}`
               : undefined,
+          // Read off this package's own dependencies, not the repo's. The
+          // catalog shares one install, so a repo-wide stack row would put
+          // Next.js on a README for a CLI that has never seen React.
+          stack: detectStack(manifest, { packageManager: repoContext.packageManager }),
         },
       })
     }

--- a/skills/git-badges/SKILL.md
+++ b/skills/git-badges/SKILL.md
@@ -36,9 +36,10 @@ That is why the template keeps one `<a>` per line.
 
 | Setup needed | Badges |
 | --- | --- |
-| **Nothing** (public repo) | Stars, Commit Activity, Last Commit, License, PRs Welcome, DeepWiki, Deploy to Cloudflare, tech-stack chips |
+| **Nothing** (public repo) | Stars, Forks, Contributors, Open Issues, Open PRs, Merged PRs, Commit Activity, Last Commit, License, PRs Welcome, DeepWiki, Deploy to Cloudflare, Codespaces, tech-stack chips |
 | **A workflow or service** | Workflow status, Codecov coverage, npm version, npm downloads |
-| **An external account + an id** | DOI (Zenodo), Discord, UptimeRobot, Docs/API/YouTube links |
+| **An external account + an id** | DOI (Zenodo), Discord, UptimeRobot, live-app/Docs/API/YouTube links |
+| **A repo setting** | Discussions — off by default, and the badge reads "repo not found" until it is on |
 
 Full per-badge setup — where each id comes from, what the URL means, how it
 fails — is in [`API.md`](./API.md) and, in a generated repo, in `docs/BADGES.md`.
@@ -92,8 +93,14 @@ syntax cannot center or set a height. Consequences:
 - GitHub's renderer strips `style` attributes. Sizing comes from the `height`
   attribute or from Shields' own `style=` parameter.
 
-Group by meaning: identity and links first, health and freshness second,
-community third, stack chips last.
+Group by meaning, four rows: identity and links first, health and freshness
+second, community third, stack chips last. Four rows of five reads; twenty
+badges in one run is a wall.
+
+In the community row, carry the counts that show motion — open issues, open PRs,
+merged PRs — not just stars. Stars say a repo was noticed once; the PR queue says
+whether maintenance is happening, which is the question someone deciding to
+depend on you is actually asking.
 
 ## Recipes
 

--- a/skills/repo-badges/SKILL.md
+++ b/skills/repo-badges/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: repo-badges
-description: The README badge template from qwksearch-research-agent — which badges to use (DOI, DeepWiki, docs, npm version and downloads, Codecov, CI status, stars, commit activity, last commit, Discord, uptime, license, PRs welcome, Cloudflare deploy button, tech-stack chips), how they group into rows, and what you must set up outside the repo before each one shows anything real. Use when adding or fixing README badges, or when a badge renders wrong — Codecov stuck on unknown, a CI badge showing a feature branch's failure, npm reading invalid, Discord showing "invite" instead of a member count, shields.io eating a hyphen in a label, or a repo-not-found on a private repo.
+description: The README badge template from qwksearch-research-agent — which badges to use (DOI, DeepWiki, live app, docs, npm version and downloads including all-time totals, Codecov, CI status, stars, forks, contributors, open issues, open and merged pull request counts, discussions, commit activity, last commit, Discord, uptime, license, PRs welcome, Cloudflare deploy button, Codespaces, tech-stack chips), how they group into four rows, and what you must set up outside the repo before each one shows anything real. Use when adding or fixing README badges, or when a badge renders wrong — Codecov stuck on unknown, a CI badge showing a feature branch's failure, npm reading invalid, Discord showing "invite" instead of a member count, shields.io eating a hyphen in a label, or a repo-not-found on a private repo.
 ---
 
 # The Repo Badge Template
@@ -31,10 +31,17 @@ Rows, in order. Four rows of five reads; twenty badges in one run is a wall.
 
 | Row | Badges | Answers |
 | --- | --- | --- |
-| identity | DOI, DeepWiki, Docs, API, YouTube, Cloudflare deploy button, StackBlitz | what is this |
+| identity | DOI, DeepWiki, live app, Docs, API, YouTube, Cloudflare deploy button, StackBlitz, Codespaces | what is this |
 | quality | npm downloads (monthly + total), npm version, types, install size, Codecov, per-flag Codecov, CI status, test report, uptime | does it work |
-| community | stars, commit activity, last commit, Discord, PRs welcome, license | is it alive |
+| community | stars, forks, contributors, open issues, open PRs, merged PRs, discussions, commit activity, last commit, Discord, PRs welcome, license | is it alive |
 | stack | tech chips | what is it built with |
+
+The community row is the one people under-fill. Stars say a repo was noticed
+once; **open issues, open PRs and merged PRs together** say whether anything is
+moving through it now, and a reader deciding whether to depend on you is asking
+the second question. Two PR counts rather than one on purpose: an open count
+alone reads the same whether the queue clears in a day or has been stuck for a
+year.
 
 ## Which need setup outside the repo
 
@@ -55,8 +62,13 @@ Rows, in order. Four rows of five reads; twenty badges in one run is a wall.
 | `test-report` | `--test-report` | `deploy-test-reports.yml` plus the two Cloudflare secrets. |
 | `uptime` | `--uptime` | An UptimeRobot monitor and public status page. |
 | `discord` | `--discord-id` + `--discord-invite` | **Two different values**: the numeric server id (Server Settings → Widget → Enable Server Widget) drives the count; the invite is where it links. |
-| `stars`, `commit-activity`, `last-commit`, `prs-welcome`, `license` | — | Nothing. Public repos only. |
-| `stack` | `--stack A,B,C` | Nothing — any slug from simpleicons.org works as `?logo=`. |
+| `website` | `--website` | Nothing — the deployed thing, not the repo. First in the row: a visitor who can click into a running app decides in seconds. |
+| `codespaces` | — | Nothing. Add a `.devcontainer/` if the default image cannot install your deps — the visitor sees that failure, not you. |
+| `issues` | — | Issues enabled (Settings → Features). The `/issues/` path already excludes PRs from the count. |
+| `pull-requests` / `prs-merged` | — | Nothing. shields.io has no "merged" endpoint: `issues-pr-closed` counts every PR that is no longer open, so a repo that closes many stale PRs should relabel it "PRs closed". |
+| `discussions` | — | Discussions has to be **on** (Settings → Features) or the badge reads "repo not found", which looks exactly like a private repo. |
+| `stars`, `forks`, `contributors`, `commit-activity`, `last-commit`, `prs-welcome`, `license` | — | Nothing. Public repos only. `contributors` counts commit authors GitHub matched to an account, so unregistered-email commits are invisible to it. |
+| `stack` | `--stack A,B,C` | Nothing — any slug from simpleicons.org works as `?logo=`. A name with no icon (`better-auth`, `MCP`) renders as a plain text chip rather than a blank square. In this monorepo the list is read off each package's own `package.json` instead of being passed. |
 
 ## Recipes
 
@@ -77,9 +89,21 @@ month reads as an abandoned project.
 
 **Per-package rows in this monorepo**
 
-The root README's block is the repo's. Each package README gets its own row
-instead — its npm name, its Codecov flag, its docs page, its StackBlitz
-directory — written by:
+The root README's block is the repo's. Each package README gets its own four
+rows instead, and the split between rows two and three is the point:
+
+- **row 2 measures the package** — its npm name, its tarball, its Codecov flag.
+  Nothing in it moves because a sibling package got popular.
+- **row 3 measures the repo it ships from** — stars, issues, the PR queue. Those
+  are repo-wide by nature, which is why they sit on their own row instead of
+  being mixed into the package numbers.
+
+Neither row substitutes for the other: a package with no downloads in a busy
+repo and a popular package in a dead repo are different situations, and it takes
+both rows to tell them apart. Row 4 is read off the package's own
+`package.json`, so a CLI that never imports React does not advertise Next.js.
+
+Written by:
 
 ```bash
 bun run readmes          # write

--- a/starter-templates/template-git-repo/README.md
+++ b/starter-templates/template-git-repo/README.md
@@ -1,28 +1,44 @@
 <p align="center">
 <!-- badge:doi --><a href="https://doi.org/{{DOI}}"><img src="https://zenodo.org/badge/DOI/{{DOI}}.svg" alt="DOI" /></a>
     <a href="https://deepwiki.com/{{OWNER}}/{{REPO}}"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
+<!-- badge:website --><a href="{{WEBSITE_URL}}"><img height="20px" src="https://img.shields.io/badge/App-blueviolet?style=for-the-badge&logo=googlechrome&logoColor=white" alt="Website" /></a>
 <!-- badge:docs --><a href="{{DOCS_URL}}"><img src="https://img.shields.io/badge/Docs-blue?logo=ReadTheDocs&logoColor=white" alt="Documentation" /></a>
 <!-- badge:api --><a href="{{API_URL}}"><img src="https://img.shields.io/badge/API-blue?logo=fastapi&logoColor=white" alt="API" /></a>
 <!-- badge:youtube --><a href="{{YOUTUBE_URL}}"><img height="20px" src="https://img.shields.io/badge/YouTube-red?style=for-the-badge&logo=youtube&logoColor=white" alt="YouTube" /></a>
     <a href="https://deploy.workers.cloudflare.com/?url=https://github.com/{{OWNER}}/{{REPO}}"><img height="24px" src="https://deploy.workers.cloudflare.com/button" alt="Deploy to Cloudflare Workers" /></a>
-    <a href="https://github.com/{{OWNER}}/{{REPO}}/stargazers"><img src="https://img.shields.io/github/stars/{{OWNER}}/{{REPO}}" alt="GitHub Stars" /></a>
+    <a href="https://codespaces.new/{{OWNER}}/{{REPO}}"><img height="20px" src="https://github.com/codespaces/badge.svg" alt="Open in GitHub Codespaces" /></a>
 <br />
+<!-- badge:npm --><a href="https://www.npmjs.com/package/{{PACKAGE}}"><img src="https://img.shields.io/npm/v/{{PACKAGE}}.svg" alt="npm version" /></a>
 <!-- badge:npm --><a href="https://www.npmjs.com/package/{{PACKAGE}}"><img src="https://img.shields.io/npm/dm/{{PACKAGE}}.svg" alt="NPM Monthly Downloads" /></a>
+<!-- badge:npm --><a href="https://www.npmjs.com/package/{{PACKAGE}}"><img src="https://img.shields.io/npm/dt/{{PACKAGE}}.svg" alt="NPM Total Downloads" /></a>
     <a href="https://codecov.io/gh/{{OWNER}}/{{REPO}}"><img src="https://codecov.io/gh/{{OWNER}}/{{REPO}}/graph/badge.svg" alt="Coverage" /></a>
+    <a href="https://github.com/{{OWNER}}/{{REPO}}/actions/workflows/tests.yml"><img src="https://github.com/{{OWNER}}/{{REPO}}/actions/workflows/tests.yml/badge.svg?branch={{DEFAULT_BRANCH}}" alt="Tests" /></a>
+<!-- badge:uptime --><a href="https://stats.uptimerobot.com/{{UPTIME_ID}}"><img src="https://img.shields.io/badge/Uptime-Status-brightgreen?logo=uptimerobot&logoColor=white" alt="Uptime Status" /></a>
+<br />
+    <a href="https://github.com/{{OWNER}}/{{REPO}}/stargazers"><img src="https://img.shields.io/github/stars/{{OWNER}}/{{REPO}}" alt="GitHub Stars" /></a>
+    <a href="https://github.com/{{OWNER}}/{{REPO}}/forks"><img src="https://img.shields.io/github/forks/{{OWNER}}/{{REPO}}" alt="GitHub Forks" /></a>
+    <a href="https://github.com/{{OWNER}}/{{REPO}}/graphs/contributors"><img src="https://img.shields.io/github/contributors/{{OWNER}}/{{REPO}}" alt="Contributors" /></a>
+    <a href="https://github.com/{{OWNER}}/{{REPO}}/issues"><img src="https://img.shields.io/github/issues/{{OWNER}}/{{REPO}}?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/{{OWNER}}/{{REPO}}/pulls"><img src="https://img.shields.io/github/issues-pr/{{OWNER}}/{{REPO}}?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/{{OWNER}}/{{REPO}}/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/{{OWNER}}/{{REPO}}?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/{{OWNER}}/{{REPO}}/discussions"><img src="https://img.shields.io/github/discussions/{{OWNER}}/{{REPO}}" alt="GitHub Discussions" /></a>
     <a href="https://github.com/{{OWNER}}/{{REPO}}/graphs/contributors"><img src="https://img.shields.io/github/commit-activity/m/{{OWNER}}/{{REPO}}" alt="Commit Activity" /></a>
     <a href="https://github.com/{{OWNER}}/{{REPO}}/commits/{{DEFAULT_BRANCH}}/"><img src="https://img.shields.io/github/last-commit/{{OWNER}}/{{REPO}}.svg" alt="Last Commit" /></a>
-    <a href="https://github.com/{{OWNER}}/{{REPO}}/actions/workflows/tests.yml"><img src="https://github.com/{{OWNER}}/{{REPO}}/actions/workflows/tests.yml/badge.svg?branch={{DEFAULT_BRANCH}}" alt="Tests" /></a>
-<br />
-<!-- badge:uptime --><a href="https://stats.uptimerobot.com/{{UPTIME_ID}}"><img src="https://img.shields.io/badge/Uptime-Status-brightgreen?logo=uptimerobot&logoColor=white" alt="Uptime Status" /></a>
-<!-- badge:npm --><a href="https://www.npmjs.com/package/{{PACKAGE}}"><img src="https://img.shields.io/npm/v/{{PACKAGE}}.svg" alt="npm version" /></a>
 <!-- badge:discord --><a href="{{DISCORD_INVITE}}"><img src="https://img.shields.io/discord/{{DISCORD_ID}}.svg?label=Chat&logo=Discord&colorB=7289da&style=flat" alt="Join Discord" /></a>
     <a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" /></a>
     <a href="./LICENSE.md"><img src="https://img.shields.io/github/license/{{OWNER}}/{{REPO}}" alt="License" /></a>
 <br />
     <img src="https://img.shields.io/badge/Claude-D97757?logo=claude&logoColor=fff" alt="Claude AI" />
-    <img src="https://img.shields.io/badge/Cloudflare-F38020?logo=Cloudflare&logoColor=white" alt="Cloudflare" />
+    <img src="https://img.shields.io/badge/Cloudflare%20Workers-F38020?logo=cloudflareworkers&logoColor=white" alt="Cloudflare Workers" />
+    <img src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white" alt="TypeScript" />
+    <img src="https://img.shields.io/badge/Next.js-black?logo=nextdotjs&logoColor=white" alt="Next.js" />
+    <img src="https://img.shields.io/badge/React-20232A?logo=react&logoColor=white" alt="React" />
+    <img src="https://img.shields.io/badge/Tailwind%20CSS-06B6D4?logo=tailwindcss&logoColor=white" alt="Tailwind CSS" />
+    <img src="https://img.shields.io/badge/shadcn%2Fui-000000?logo=shadcnui&logoColor=white" alt="shadcn/ui" />
+    <img src="https://img.shields.io/badge/Drizzle%20ORM-C5F74F?logo=drizzle&logoColor=white" alt="Drizzle ORM" />
     <img src="https://img.shields.io/badge/Turborepo-EF4444?logo=turborepo&logoColor=white" alt="Turborepo" />
-    <img src="https://img.shields.io/badge/Bun-000000?logo=bun&logoColor=white" alt="Bun" />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" />
+    <img src="https://img.shields.io/badge/Vitest-6E9F18?logo=vitest&logoColor=white" alt="Vitest" />
 </p>
 
 # {{REPO}}

--- a/starter-templates/template-git-repo/docs/BADGES.md
+++ b/starter-templates/template-git-repo/docs/BADGES.md
@@ -4,9 +4,9 @@ Every badge in the README falls into one of three groups:
 
 | Group | Setup | Badges |
 | --- | --- | --- |
-| **Zero setup** — works the moment the repo is public | none | Stars, Commit Activity, Last Commit, License, PRs Welcome, Deploy to Cloudflare, DeepWiki, tech-stack chips |
+| **Zero setup** — works the moment the repo is public | none | Stars, Forks, Contributors, Open Issues, Open PRs, Merged PRs, Discussions, Commit Activity, Last Commit, License, PRs Welcome, Deploy to Cloudflare, Codespaces, DeepWiki, tech-stack chips |
 | **Needs a workflow or service connected** | one repo secret or one app install | Tests status, Coverage, npm version, npm downloads |
-| **Needs an account and an id you paste in** | an external account | DOI, Discord, UptimeRobot, YouTube, Docs, API |
+| **Needs an account and an id you paste in** | an external account | DOI, Discord, UptimeRobot, YouTube, Website, Docs, API |
 
 `setup-git-repo` drops the badge lines for group 3 unless you pass the id, so the
 README never ships a badge pointing at `{{DOI}}`. Add them back later by copying
@@ -86,6 +86,69 @@ DeepWiki indexes public repos automatically. The first visit to the link
 triggers indexing if the repo has not been seen; the badge image itself is
 static, so it renders even before indexing finishes.
 
+### Forks and Contributors
+
+```html
+<a href="https://github.com/OWNER/REPO/forks"><img src="https://img.shields.io/github/forks/OWNER/REPO" alt="GitHub Forks" /></a>
+<a href="https://github.com/OWNER/REPO/graphs/contributors"><img src="https://img.shields.io/github/contributors/OWNER/REPO" alt="Contributors" /></a>
+```
+
+`forks` counts direct forks only, not forks of forks, so a repo forked along a
+chain reads lower than it is. `contributors` counts commit authors GitHub could
+match to an account — commits made with an unregistered email belong to nobody
+and are invisible here. Use `contributors-anon` instead if your history has many
+of those.
+
+### Open Issues
+
+```html
+<a href="https://github.com/OWNER/REPO/issues"><img src="https://img.shields.io/github/issues/OWNER/REPO?logo=github" alt="GitHub Issues" /></a>
+```
+
+Needs Issues enabled (Settings → Features). Read it as work in flight, not a
+defect count. Shields asks GitHub Search, which treats pull requests as issues on
+some endpoints — the `/issues/` path used here already excludes them. Add
+`-raw` (`github/issues-raw/...`) for a bare number with no "open" suffix, and
+`-closed` for the closed count.
+
+### Open PRs and Merged PRs
+
+```html
+<a href="https://github.com/OWNER/REPO/pulls"><img src="https://img.shields.io/github/issues-pr/OWNER/REPO?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+<a href="https://github.com/OWNER/REPO/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OWNER/REPO?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+```
+
+Two counts rather than one on purpose. An open count alone reads the same whether
+the queue clears in a day or has been stuck for a year; the pair is what tells a
+reader whether maintenance is actually happening.
+
+Shields has **no "merged" endpoint**. `issues-pr-closed` counts every PR that is
+no longer open, so PRs closed without merging are in the number too. If you close
+a lot of stale PRs, relabel it `label=PRs%20closed` rather than overstating what
+landed. Both take `label=` because unlabelled they render as bare numbers, and
+two adjacent PR badges then look like one number printed twice.
+
+### Discussions
+
+```html
+<a href="https://github.com/OWNER/REPO/discussions"><img src="https://img.shields.io/github/discussions/OWNER/REPO" alt="GitHub Discussions" /></a>
+```
+
+Discussions is **off by default**. Until you turn it on (Settings → Features →
+Discussions) the badge reads `repo not found`, which looks exactly like the
+private-repo failure — turn it on before adding the badge, not after.
+
+### Open in GitHub Codespaces
+
+```html
+<a href="https://codespaces.new/OWNER/REPO"><img height="20px" src="https://github.com/codespaces/badge.svg" alt="Open in GitHub Codespaces" /></a>
+```
+
+Nothing to configure — the link boots the repo in a default container, billed
+against the *visitor's* free hours, so the button costs you nothing. Add a
+`.devcontainer/devcontainer.json` if the default image is missing something your
+install needs: the visitor is the one who sees that failure.
+
 ### Tech-stack chips
 
 Pure decoration — static Shields badges with a brand color and a Simple Icons
@@ -154,6 +217,7 @@ drop to 0%.
 ```html
 <a href="https://www.npmjs.com/package/PACKAGE"><img src="https://img.shields.io/npm/v/PACKAGE.svg" alt="npm version" /></a>
 <a href="https://www.npmjs.com/package/PACKAGE"><img src="https://img.shields.io/npm/dm/PACKAGE.svg" alt="NPM Monthly Downloads" /></a>
+<a href="https://www.npmjs.com/package/PACKAGE"><img src="https://img.shields.io/npm/dt/PACKAGE.svg" alt="NPM Total Downloads" /></a>
 ```
 
 `PACKAGE` is the name in that package's `package.json`, not the repo name. Both
@@ -161,7 +225,10 @@ badges render `invalid` until the package's **first** publish — `npm-publish.y
 does that on the first push to the default branch. Scoped packages work with the
 scope included and URL-encoded slash: `npm/v/%40scope%2Fname`.
 
-`dm` is downloads/month; `dw` weekly, `dt` total. In a monorepo, pick the package
+`dm` is downloads/month; `dw` weekly, `dt` total. Show the monthly and the total
+together rather than either alone: a large all-time total with a flat month means
+something very different from the same total still climbing, and only the monthly
+number says the package is still being installed. In a monorepo, pick the package
 users actually install — or show several, one badge each.
 
 ---
@@ -225,6 +292,17 @@ For a badge that reports the *real* number, use a monitor-specific API key
 That key is read-only for one monitor, which is why it is safe in a README —
 never paste your account-wide API key there.
 
+### Website (live app)
+
+```html
+<a href="https://your.app"><img height="20px" src="https://img.shields.io/badge/App-blueviolet?style=for-the-badge&logo=googlechrome&logoColor=white" alt="Website" /></a>
+```
+
+The deployed thing, not the repo, and first in the row on purpose: a visitor who
+can click straight into a running app decides in seconds whether to read the
+rest. Static — nothing checks the URL is up, which is what the uptime badge is
+for. Pass it with `--website <url>`.
+
 ### Docs / API / YouTube links
 
 ```html
@@ -256,8 +334,9 @@ markdown image syntax cannot center or set a height. Consequences:
 - GitHub's markdown renderer strips `style` attributes. Sizing has to come from
   the `height` attribute or from Shields' own `style=` parameter.
 
-Group by meaning: identity and links on row one, health and freshness on row two,
-community on row three, stack chips last.
+Group by meaning, four rows: identity and links on row one, health and freshness
+on row two, community on row three, stack chips last. Four rows of five reads;
+twenty badges in one run is a wall.
 
 ## Verifying
 


### PR DESCRIPTION
Reorganizes the badge catalog into **four rows** that each answer one question, and fills the community row with the counts that show motion rather than stars alone.

| Row | Answers | Badges |
| --- | --- | --- |
| identity | what is this | DOI, DeepWiki, **live app**, Docs, API, YouTube, Cloudflare deploy, StackBlitz, **Codespaces** |
| quality | does it work | npm version, monthly **and all-time** downloads, types, install size, Codecov, CI, test report, uptime |
| community | is it alive | stars, **forks**, **contributors**, **open issues**, **open PRs**, **merged PRs**, **discussions**, commit activity, last commit, Discord, PRs welcome, license |
| stack | what is it built with | framework chips |

## New badges

- **`issues`, `pull-requests`, `prs-merged`** — the open issue count and both PR counts. Two PR badges rather than one on purpose: an open count alone reads the same whether the queue clears in a day or has been stuck for a year. shields.io has no "merged" endpoint, so `prs-merged` is documented as what it actually counts (every PR no longer open), with a note to relabel it "PRs closed" on a repo that closes many stale ones.
- **`discussions`, `forks`, `contributors`** — the rest of the activity row, each with the caveat that bites: Discussions is off by default and reads `repo not found` until enabled; forks misses forks-of-forks; contributors misses commits from unregistered emails.
- **`website`** — the deployed app, first in the row. A visitor who can click into a running thing decides in seconds whether to read the rest.
- **`codespaces`** — boot-it-yourself, billed against the visitor's own hours.

## Stack chips are now derived, not written

New `detectStack` / `detectWorkspaceStack` read a manifest's dependencies, so each README's framework row comes from that package's own `package.json`. A CLI that never imports React stops advertising Next.js, and the row cannot go stale the week a framework is swapped out.

`STACK_LOGOS` fixes slugs that the chip name does not reduce to. **`Next.js` was rendering `logo=nextjs`, which is not a simple-icons slug** — the chip shipped with a blank square on it. Names with no icon at all (`better-auth`, `MCP`) now render as plain text chips rather than carrying a broken image.

## Package README headers

The generated headers keep the repo-wide numbers on their own row, separate from the package's own npm and coverage numbers. Neither row substitutes for the other: a package with no downloads in a busy repo and a popular package in a dead repo are different situations, and it takes both rows to tell them apart.

## Also updated

- `starter-templates/template-git-repo/README.md` — the scaffold, same four rows, `--website` wired through `setup-git-repo`'s flags, prompts and placeholder list.
- `starter-templates/template-git-repo/docs/BADGES.md` and the generated `packages/template-git-repo/docs/BADGES.md`.
- `skills/repo-badges` and `skills/git-badges`.

## Testing

- `bun run test` in `template-git-repo` — 120 passing, including new coverage for the activity badges' links and labels, the four-row shape, and the corrected `nextdotjs` slug.
- `bun run test` in `setup-git-repo` — 79 passing.
- `bun run readmes:check` — clean.
- `bun run test` from the root: `verify-phone-sms` and `create-mobile-wrapper` fail, but they fail identically on a clean tree (network-dependent VoIP lookups) and are untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016EDMiy2PSq5s6YDjxgNevZ

---
_Generated by [Claude Code](https://claude.ai/code/session_016EDMiy2PSq5s6YDjxgNevZ)_