### PR TITLE
✨ feat(test-google-login): persist a Google sign-in once, replay it everywhere

### DIFF
--- a/.claude/architecture/overview.md
+++ b/.claude/architecture/overview.md
@@ -36,6 +36,7 @@ name is what turbo filters and `--skill` flags use.
 | `server-shell-setup` | *(not a workspace)* | Plain shell scripts: `install-shell.sh`, `get-node.sh`, `clean-server-disk.sh`. No `package.json`, no build, no tests. |
 | `setup-git-repo` | `setup-git-repo` | One command to set up a GitHub repo: Turborepo, CI workflows, README badges |
 | `template-git-repo` | `template-git-repo` | The badge/README **catalog** that both `setup-git-repo` and `.github/scripts/sync-package-readmes.mjs` build on — one definition of what a badge is, used twice |
+| `test-google-login` | `test-google-login` | Google-login E2E harness: a Playwright `storageState` captured once and reused, plus a Workers Browser Rendering Durable Object that replays it. Two build entries (Node + Worker); the Worker half must stay free of `node:` imports. |
 | `verify-phone-sms` | `verify-phone-sms` | SMS phone verification over AWS SNS, Hono server on Workers. No build step. |
 | `web2mobile-wrapper` | `create-mobile-wrapper` *(private)* | Expo/EAS scaffold wrapping a website as a mobile app. **Runs on Jest.** |
 

--- a/.claude/packages/test-google-login/CLAUDE.md
+++ b/.claude/packages/test-google-login/CLAUDE.md
@@ -1,0 +1,42 @@
+# CLAUDE.md — `test-google-login`
+
+**skill:** [`skills/test-google-login`](../../../skills/test-google-login/SKILL.md)
+· **runner:** Vitest · **build:** Vite, two entries (`dist/index.js`, `dist/worker.js`)
+
+Captures a Google sign-in once as a Playwright `storageState`, then reuses it —
+in the local suite, in CI, and from a Cloudflare Browser Rendering Durable Object.
+
+## Rules
+
+- **The state file is the credential, not the password.** `playwright/.auth/*.json`
+  holds live cookies and tokens. Nothing here may log a value, return one over
+  HTTP, write one world-readable, or commit one. Writes are `0600` and the
+  directory is `0700` — do not relax either to make something convenient.
+- **There is no route and no function that returns a live state over the wire.**
+  The Worker's `GET /state` returns `redactStorageState()` output on purpose.
+  Adding a "just for debugging" raw route turns this into a credential
+  exfiltration endpoint with a test-shaped name.
+- **Real Google sign-in stays opt-in and off by default.** Two gates:
+  `TEST_GOOGLE_LOGIN_ALLOW_REAL` plus credentials on the Playwright side,
+  `ALLOW_REAL_GOOGLE_LOGIN === "true"` plus credentials in the Worker. Never
+  default either on, and never add a path around MFA, CAPTCHA or a device check.
+- **`src/state-core.ts` must not import a Node builtin.** It is the half the
+  Worker bundle pulls in; one `node:fs` there and the deploy fails rather than a
+  test. `storage-state.ts` is the filesystem layer and re-exports it, so Node
+  callers still see one surface. `grep -n "node:" dist/worker.js` must print
+  nothing after a build.
+- **No runtime dependencies.** Playwright and `@cloudflare/puppeteer` are optional
+  peers; every function takes the `page` / `context` / `request` it needs as an
+  argument. That is also what lets the suite run with no browser — keep it that
+  way rather than importing either at module scope.
+- **The three format differences between Playwright and CDP are load-bearing**
+  (session-cookie `expires`, `sameSite` casing, `localStorage` needing a
+  document). Each has a test naming the failure it prevents; if you touch
+  `puppeteer-state.ts`, those tests are the specification.
+- The negative assertions in the suite — "this string does not appear in the
+  output" — are the point of several tests. Do not weaken one to accommodate a
+  new field.
+
+```bash
+cd packages/test-google-login && bun run test && bun run typecheck && bun run build
+```

--- a/.github/scripts/sync-package-readmes.mjs
+++ b/.github/scripts/sync-package-readmes.mjs
@@ -155,6 +155,7 @@ const SKILLS_BY_PACKAGE = {
   'server-shell-setup': ['server-shell-setup'],
   'setup-git-repo': ['github-actions-setup', 'git-badges'],
   'template-git-repo': ['template-git-repo', 'repo-badges'],
+  'test-google-login': ['test-google-login'],
   'verify-phone-sms': ['verify-phone-sms'],
   'web2mobile-wrapper': ['web2mobile'],
 }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,6 +71,12 @@ jobs:
             install: npm install --ignore-scripts --legacy-peer-deps
             coverage: true
 
+          - name: test-google-login
+            dir: packages/test-google-login
+            runtime: bun
+            install: bun install
+            coverage: true
+
           - name: verify-phone-sms
             dir: packages/verify-phone-sms
             runtime: node

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,5 +118,6 @@ one tree rather than beside the source.
 | `packages/server-shell-setup` | [.claude/packages/server-shell-setup/CLAUDE.md](.claude/packages/server-shell-setup/CLAUDE.md) |
 | `packages/setup-git-repo` | [.claude/packages/setup-git-repo/CLAUDE.md](.claude/packages/setup-git-repo/CLAUDE.md) |
 | `packages/template-git-repo` | [.claude/packages/template-git-repo/CLAUDE.md](.claude/packages/template-git-repo/CLAUDE.md) |
+| `packages/test-google-login` | [.claude/packages/test-google-login/CLAUDE.md](.claude/packages/test-google-login/CLAUDE.md) |
 | `packages/verify-phone-sms` | [.claude/packages/verify-phone-sms/CLAUDE.md](.claude/packages/verify-phone-sms/CLAUDE.md) |
 | `packages/web2mobile-wrapper` | [.claude/packages/web2mobile-wrapper/CLAUDE.md](.claude/packages/web2mobile-wrapper/CLAUDE.md) |

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@
 [![npm downloads](https://img.shields.io/npm/dm/template-git-repo.svg)](https://www.npmjs.com/package/template-git-repo) **[template-git-repo](packages/template-git-repo/)** - One command to give a repo the CI setup from qwksearch-research-agent: GitHub Actions for a discovered per-package test matrix, content-based npm publishing, agent PR auto-merge and hosted test reports, plus `turbo.json`, `codecov.yml` and a README badge block. Detects the repo slug, default branch, package manager and workspace layout; skips badges it has no input for instead of rendering them broken.
 `bunx template-git-repo` · `bunx template-git-repo --dry-run`
 
+[![npm downloads](https://img.shields.io/npm/dm/test-google-login.svg)](https://www.npmjs.com/package/test-google-login) **[test-google-login](packages/test-google-login/)** - End-to-end test harness for Google sign-in. Sign in once by hand, persist the Playwright `storageState` under `playwright/.auth/` (0600, gitignored two ways), and every test after that starts already signed in — with a setup-project guard that throws the exact `playwright codegen` command when the session is missing and how long ago it lapsed when it expired. For CI it mints your app's own session through a test-only endpoint, so no Google password is ever a repo secret. Ships a Cloudflare Browser Rendering Durable Object that replays the same session from a Worker, keeping one browser alive across a suite, and a CLI that inspects or redacts a state file without ever printing a value. Zero runtime dependencies; the whole suite runs without launching a browser.
+`npx test-google-login init` · `npm install --save-dev test-google-login`
+
 [![npm downloads](https://img.shields.io/npm/dm/verify-phone-sms.svg)](https://www.npmjs.com/package/verify-phone-sms) **[verify-phone-sms](packages/verify-phone-sms/)** - SMS phone verification API server built with Hono on Cloudflare Workers, backed by AWS SNS. Sends one-time codes, blocks VoIP numbers, enforces API-key authentication, applies rate limiting, and exposes auto-generated OpenAPI documentation. Includes health-check endpoints and CORS/security-header middleware.
 `npm install verify-phone-sms` · `wrangler deploy`
 
@@ -140,7 +143,7 @@ See [skills/README.md](skills/README.md) for the full index.
 
 ### ✅ Tests
 
-Six packages are wired into CI reporting today. Each exposes a `test:ci` script that writes a
+Seven packages are wired into CI reporting today. Each exposes a `test:ci` script that writes a
 `junit.xml` (and lcov coverage where its runner can produce one) for
 [`.github/workflows/tests.yml`](.github/workflows/tests.yml) to upload to Codecov
 Test Analytics, which tracks run times, failure rates and flaky tests, and comments
@@ -154,6 +157,7 @@ the failing ones on the pull request.
 | [verify-phone-sms](packages/verify-phone-sms/) | Vitest | `npm test` |
 | [manage-storage](packages/manage-storage/) | Vitest | `bun run test` |
 | [template-git-repo](packages/template-git-repo/) | Vitest | `bun run test` |
+| [test-google-login](packages/test-google-login/) | Vitest | `bun run test` |
 
 Wiring up another package means adding a `test:ci` script that writes `junit.xml`
 into the package directory, then adding a matrix entry to that workflow. Coverage

--- a/codecov.yml
+++ b/codecov.yml
@@ -52,6 +52,9 @@ flag_management:
     - name: verify-phone-sms
       paths:
         - packages/verify-phone-sms/
+    - name: test-google-login
+      paths:
+        - packages/test-google-login/
 
 comment:
   layout: "header, diff, flags, files"

--- a/packages/test-google-login/.env.example
+++ b/packages/test-google-login/.env.example
@@ -1,0 +1,23 @@
+# ─── Where the app under test is ──────────────────────────────────────────────
+E2E_BASE_URL=http://localhost:3000
+
+# ─── The recommended path: mint your app's own session ────────────────────────
+# A long random secret, shared with the test-only endpoint that creates the same
+# session a successful Google callback creates. This is the only secret the normal
+# suite needs — no Google credentials anywhere.
+#   export E2E_TEST_AUTH_SECRET="$(openssl rand -hex 32)"
+E2E_TEST_AUTH_SECRET=
+E2E_TEST_AUTH_ENDPOINT=/api/test-auth/google-user
+
+# ─── Where the persisted session is written ───────────────────────────────────
+# Optional override. Defaults to playwright/.auth/google-test-user.json, which
+# must be gitignored — `test-google-login init` does that for you.
+# TEST_GOOGLE_LOGIN_STATE=playwright/.auth/google-test-user.json
+
+# ─── The narrow escape hatch: real Google sign-in ─────────────────────────────
+# Only for a manually triggered smoke workflow, never for pull requests. Use a
+# dedicated Google account with nothing else enabled on it. Both the opt-in flag
+# and the credentials must be present or signInWithGoogle() refuses to run.
+TEST_GOOGLE_LOGIN_ALLOW_REAL=
+GOOGLE_TEST_EMAIL=
+GOOGLE_TEST_PASSWORD=

--- a/packages/test-google-login/.gitignore
+++ b/packages/test-google-login/.gitignore
@@ -1,0 +1,12 @@
+# The persisted browser session is a live credential — see README.md.
+playwright/.auth/
+*.storage-state.json
+
+.env
+.env.*
+!.env.example
+
+coverage/
+junit.xml
+dist/
+.wrangler/

--- a/packages/test-google-login/README.md
+++ b/packages/test-google-login/README.md
@@ -1,0 +1,378 @@
+<!-- template-git-repo:badges:start -->
+<p align="center">
+    <a href="https://starterdocs.vtempest.workers.dev/docs/packages/test-google-login"><img src="https://img.shields.io/badge/Docs-blue?logo=ReadTheDocs&logoColor=white" alt="Documentation" /></a>
+    <a href="https://stackblitz.com/github/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/test-google-login"><img height="20px" src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt="Open in StackBlitz" /></a>
+    <br />
+    <a href="https://www.npmjs.com/package/test-google-login"><img src="https://img.shields.io/npm/dm/test-google-login.svg" alt="NPM Monthly Downloads" /></a>
+    <a href="https://www.npmjs.com/package/test-google-login"><img src="https://img.shields.io/npm/v/test-google-login.svg" alt="npm version" /></a>
+    <a href="https://www.npmjs.com/package/test-google-login"><img src="https://img.shields.io/npm/dt/test-google-login.svg" alt="NPM Total Downloads" /></a>
+    <a href="https://www.npmjs.com/package/test-google-login"><img src="https://img.shields.io/npm/types/test-google-login" alt="TypeScript types" /></a>
+    <a href="https://packagephobia.com/result?p=test-google-login"><img src="https://packagephobia.com/badge?p=test-google-login" alt="Install size" /></a>
+    <a href="https://app.codecov.io/gh/OpenSourceAGI/dev-tools-starter-agent/flags"><img src="https://img.shields.io/codecov/c/github/OpenSourceAGI/dev-tools-starter-agent?flag=test-google-login&label=test-google-login%20coverage&logo=codecov&logoColor=white" alt="Coverage" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" /> <img src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white" alt="TypeScript" /> <img src="https://img.shields.io/badge/Cloudflare%20Workers-F38020?logo=cloudflareworkers&logoColor=white" alt="Cloudflare Workers" /> <img src="https://img.shields.io/badge/Vite-646CFF?logo=vite&logoColor=white" alt="Vite" /> <img src="https://img.shields.io/badge/Vitest-6E9F18?logo=vitest&logoColor=white" alt="Vitest" /> <img src="https://img.shields.io/badge/Playwright-2EAD33?logo=playwright&logoColor=white" alt="Playwright" />
+</p>
+<!-- template-git-repo:badges:end -->
+
+<!-- skills:install:start -->
+**🤖 Agent skill** — `npx skills@latest add https://github.com/OpenSourceAGI/dev-tools-starter-agent --skill test-google-login` ([what it covers](../../skills/test-google-login/SKILL.md))
+<!-- skills:install:end -->
+
+# Test Google Login
+
+Sign in with Google **once**, by hand, and let every test after that start
+already signed in — locally, in CI, and from a Cloudflare Worker.
+
+Two halves, one session file:
+
+- **Playwright** (`test-google-login`) — captures, validates, inspects and
+  redacts a `storageState`, and guards a setup project so the first run tells a
+  new contributor exactly what to do instead of timing out on a login form.
+- **Cloudflare Workers** (`test-google-login/worker`) — a Browser Rendering
+  Durable Object that replays the same session against a deployed app, keeping
+  one browser alive across a whole suite.
+
+It has **no runtime dependencies**. Playwright and `@cloudflare/puppeteer` are
+optional peers: every function takes the `page`, `context` or `request` it needs
+as an argument, which is also why the whole package is unit-tested without ever
+launching a browser.
+
+## ⚠ The security boundary — read this first
+
+Putting `GOOGLE_TEST_PASSWORD` in `.env` protects nothing if you then write:
+
+```text
+playwright/.auth/google-test-user.json
+```
+
+**That file is a live credential.** It can contain your app's session cookie,
+Google's cookies for `accounts.google.com`, OAuth tokens in `localStorage` or
+IndexedDB, and — depending on your auth library — something refresh-capable.
+Anyone holding it is signed in as the test account.
+
+So:
+
+- Use a **dedicated Google account** for testing, with nothing sensitive on it.
+- **Never commit it.** `test-google-login init` adds the rules, twice.
+- **Never upload it as a public CI artifact**, and never paste it into a log,
+  an issue or a chat. Use `test-google-login redact` when you need to show it.
+- **Regenerate it** when it stops working, rather than trying to repair it.
+- Prefer testing **your app's own session**. Keep real Google sign-in as a
+  narrow, occasional smoke test.
+
+This package is built around that last point. Everything that touches Google
+is opt-in and off by default; everything that touches the file is 0600.
+
+## Install
+
+```bash
+bun add -d test-google-login
+npm install --save-dev test-google-login
+```
+
+## Quick start
+
+### 1. Set up the directory and the gitignore rules
+
+```bash
+npx test-google-login init
+```
+
+```text
+Created playwright/.auth/ (mode 0700)
+Wrote   playwright/.auth/.gitignore — ignores everything in that directory
+Added to .gitignore: playwright/.auth/, .env, .env.*, !.env.example
+
+Now capture a session by hand — this avoids automating Google's password form,
+which is what MFA, CAPTCHA and device checks all break:
+
+  npx playwright codegen --save-storage=playwright/.auth/google-test-user.json http://localhost:3000
+```
+
+Two gitignores on purpose: the root one, and `playwright/.auth/.gitignore`
+containing `*`. The root file gets reverted, reformatted and replaced by tooling;
+the nested one travels with the directory.
+
+### 2. Capture a session, by hand, once
+
+Run the command `init` printed. In the window that opens: click **Sign in with
+Google**, use the dedicated test account, finish the redirect back to *your* app,
+confirm you are on an authenticated page, then close the window — Playwright
+writes the state file on exit.
+
+This is manual on purpose. Google may ask for MFA, a CAPTCHA or a device check,
+and none of those should be automated around.
+
+### 3. Reuse it
+
+`playwright.config.ts`:
+
+```ts
+import { defineConfig, devices } from "@playwright/test";
+import { DEFAULT_AUTH_FILE } from "test-google-login";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  use: { baseURL: process.env.E2E_BASE_URL ?? "http://localhost:3000" },
+  projects: [
+    { name: "auth-setup", testMatch: /.*\.setup\.ts/ },
+    {
+      name: "chromium",
+      dependencies: ["auth-setup"],
+      use: { ...devices["Desktop Chrome"], storageState: DEFAULT_AUTH_FILE },
+    },
+  ],
+});
+```
+
+`tests/auth.setup.ts`:
+
+```ts
+import { test as setup } from "@playwright/test";
+import { requireStoredSession } from "test-google-login";
+
+setup("an authenticated session is available", () => {
+  const summary = requireStoredSession({ baseUrl: process.env.E2E_BASE_URL });
+  console.log(`session ok — ${summary.cookieCount} cookies, ${summary.domains.join(", ")}`);
+});
+```
+
+Your tests now start signed in:
+
+```ts
+test("an authenticated user can open the dashboard", async ({ page }) => {
+  await page.goto("/dashboard");
+  await expect(page.getByRole("heading", { name: /dashboard/i })).toBeVisible();
+});
+```
+
+`requireStoredSession` is the part that earns its keep. A missing file throws the
+`codegen` command; an expired one throws *how long ago* it lapsed:
+
+```text
+The persisted session is no longer usable — it expired 380 minutes ago.
+
+Re-capture it:
+  npx playwright codegen --save-storage=playwright/.auth/google-test-user.json http://localhost:3000
+```
+
+Without that, an expired session presents as a selector timeout on an
+unauthenticated page, which reads like a broken test rather than a stale cookie.
+
+## For CI: let your app mint the session
+
+Do **not** make a Google password a repository secret every fork's pull request
+can reach. Instead, add a test-only endpoint to your own staging environment that
+creates the same session a successful Google callback creates, and hold one secret
+of yours.
+
+```ts
+import { bootstrapAppSession } from "test-google-login";
+
+setup("create authenticated test session", async ({ page, context, request }) => {
+  await bootstrapAppSession({
+    request,
+    page,
+    context,
+    secret: process.env.E2E_TEST_AUTH_SECRET,   // required; never defaulted
+    endpoint: "/api/test-auth/google-user",
+    landingPath: "/dashboard",
+  });
+});
+```
+
+State is regenerated each run, no Google traffic is involved, and a PR check can
+never fail because Google showed a consent screen. See
+[`examples/test-auth-endpoint.ts`](examples/test-auth-endpoint.ts) for the
+endpoint — it must 404 in production, require a strong secret compared in
+constant time, and create a session identical to the real callback's.
+
+### Which strategy where
+
+| Strategy | Use for | Secrets held |
+| --- | --- | --- |
+| `bootstrapAppSession` — your app mints it | every PR check | `E2E_TEST_AUTH_SECRET` |
+| `requireStoredSession` — captured by hand | local development | none |
+| Encrypted stored state | private, controlled CI | the encryption key; delete state after the run |
+| `signInWithGoogle` — real Google | occasional manual smoke test | a dedicated account's credentials, environment-scoped |
+| Mock the OAuth callback | unit and integration tests | none |
+
+## Inspecting a session without opening it
+
+```bash
+npx test-google-login check
+```
+
+```text
+State file   playwright/.auth/google-test-user.json
+Cookies      3 (1 session-only)
+Domains      .google.com, app.example.test
+Origins      1
+Google cookies present: yes
+Expiry       earliest in 718 minutes
+```
+
+Exit codes are meant for CI: `0` healthy, `1` missing or expired, `2` present but
+malformed. `--json` for machine-readable output, `--within 30` to warn about
+cookies expiring inside a window.
+
+```bash
+npx test-google-login redact   # safe to paste into an issue
+npx test-google-login clear    # delete the session
+```
+
+`redact` keeps the shape — names, domains, flags, expiries — and replaces every
+value with `«redacted 21 chars»`. Nothing in this package ever prints a value:
+`summarizeStorageState` returns names and domains only, and the Worker's
+`GET /state` returns a redacted copy.
+
+## The Cloudflare Workers half
+
+```ts
+import { GoogleLoginBrowser, handleRequest } from "test-google-login/worker";
+
+export { GoogleLoginBrowser };
+export default { fetch: handleRequest };
+```
+
+```bash
+wrangler secret put TEST_AUTH_SECRET
+wrangler deploy
+```
+
+A Durable Object per named session, holding one Browser Rendering browser. Why a
+DO rather than `puppeteer.launch()` in the Worker: a launch costs seconds and is
+billed, so one browser serves a whole suite; and Browser Rendering allows only a
+few concurrent sessions per account, which a parallel test run would otherwise
+trip. An alarm closes the browser once idle — an *unclosed* session is billed too.
+
+| Route | Does |
+| --- | --- |
+| `POST /state` | Store a Playwright storage state. Validated on the way in; the response summarises it and never echoes it |
+| `GET /state` | A redacted summary. **There is no route that returns live cookies** |
+| `DELETE /state` | Forget the session and close the browser |
+| `POST /check` | Replay the session against a URL; reports `authenticated`, the landing URL, title, and optionally a screenshot |
+| `POST /login` | Real Google sign-in, off unless `ALLOW_REAL_GOOGLE_LOGIN="true"`. Needs `loginUrl` **and** `expectUrl` |
+| `POST /close` | Close the browser now rather than waiting for the alarm |
+
+Every request must carry `x-test-auth-secret`. If `TEST_AUTH_SECRET` is not set
+the Worker returns `503` to everything rather than serving an anonymous browser to
+whoever finds the URL.
+
+```bash
+curl -X POST "$WORKER/check?session=signed-in" \
+  -H "x-test-auth-secret: $TEST_AUTH_SECRET" \
+  -H 'content-type: application/json' \
+  -d '{"url":"https://app.example.test/dashboard","expectSelector":"[data-testid=user-menu]","rejectUrl":"/login"}'
+```
+
+`rejectUrl` matters: a redirect to `/login` returns `200`, so without it a
+signed-out check reads as a pass.
+
+See [`examples/worker-check.ts`](examples/worker-check.ts) for the whole loop.
+
+### Carrying a session between Playwright and Puppeteer
+
+`applyStorageState` / `extractStorageState` convert in both directions, and the
+three differences between the formats are each a way to lose a session silently:
+
+- **Session cookies.** Playwright writes `expires: -1`; CDP reads `-1` as an
+  expiry in 1969 and drops the cookie. The key must be *omitted*.
+- **`sameSite`.** CDP wants exactly `Strict`, `Lax` or `None`. One lowercase
+  value rejects the whole batch.
+- **`localStorage` needs a document.** There is no blind write — the page has to
+  be on the origin first, so restoring it costs one navigation per origin.
+
+```ts
+import { applyStorageState } from "test-google-login";
+
+await applyStorageState(page, state, { origins: ["https://app.example.test"] });
+```
+
+Narrow `origins` to your own app. A state captured through a real Google sign-in
+also holds `accounts.google.com` storage, and navigating a datacentre browser to
+Google to restore it is slow and is exactly the traffic its risk checks look for.
+A cookie-only state costs **no** navigation at all.
+
+## If you automate Google anyway
+
+```ts
+import { signInWithGoogle } from "test-google-login";
+
+setup("real Google OAuth smoke bootstrap", async ({ page, context }) => {
+  await signInWithGoogle({ page, context, loginPath: "/login" });
+});
+```
+
+It refuses to run unless `TEST_GOOGLE_LOGIN_ALLOW_REAL=1` **and** both
+`GOOGLE_TEST_EMAIL` and `GOOGLE_TEST_PASSWORD` are set. Restrict that workflow to
+a protected branch with environment-scoped secrets, trigger it by hand, and expect
+failures that are not your app's fault — Google changes its UI, its labels and its
+language, and a datacentre IP makes its risk checks *more* likely.
+
+It waits for your own origin rather than clicking through whatever appears. If a
+consent screen, a device check or MFA shows up, the wait times out, which is the
+correct outcome: those are the controls protecting the account.
+
+## Refreshing an expired session
+
+```bash
+npx test-google-login clear
+npx playwright codegen --save-storage=playwright/.auth/google-test-user.json http://localhost:3000
+```
+
+With the test-only endpoint, just re-run the setup project — it regenerates state
+on its own.
+
+Note that `storageState` covers cookies and `localStorage` (and IndexedDB when you
+pass `indexedDB: true`), but **not `sessionStorage`**. If your app keeps anything
+there, restore it yourself with an init script.
+
+## API
+
+| Export | Does |
+| --- | --- |
+| `requireStoredSession(options)` | Assert a usable session exists; returns a safe summary, throws with the fix |
+| `bootstrapAppSession(options)` | Mint a session through your test-only endpoint and persist it |
+| `signInWithGoogle(options)` | Drive Google's real form. Off unless opted in |
+| `loadStorageStateFor(options)` | Read the state for `browser.newContext({ storageState })` |
+| `summarizeStorageState(state)` | Counts, domains, names, expiry — no values |
+| `redactStorageState(state)` | The same state with every value replaced by its length |
+| `findExpiringCookies(state, o)` | Cookies expiring inside a window — the warning before the failure |
+| `assertStorageStateUsable(state, o)` | Throw unless still usable, with how long ago it lapsed |
+| `readStorageState` / `writeStorageState` | Read; write 0600 |
+| `hardenStorageStateFile(file)` | Chmod + validate a file Playwright wrote, preserving its extra keys |
+| `applyStorageState(page, state, o)` | Restore a whole session into a Puppeteer page |
+| `extractStorageState(page, o)` | Capture one back out, in Playwright's format |
+| `to/fromPuppeteerCookies` | Cookie-format conversion, both directions |
+| `ensureGitignored` / `writeAuthDirGitignore` | The two gitignore rules |
+| `resolveAuthFile` / `codegenCommand` | Path resolution and the capture command |
+| `constantTimeEqual` / `isAuthorized` | Secret comparison, usable in a Worker |
+| `GoogleLoginBrowser` / `handleRequest` | The Durable Object and the Worker entry |
+
+Full details in the agent skill:
+[`skills/test-google-login`](../../skills/test-google-login/SKILL.md).
+
+## Development
+
+```bash
+cd packages/test-google-login
+bun run test        # no browser is launched
+bun run build       # two entries: index (Node) and worker (Cloudflare)
+bun run typecheck
+```
+
+The suite drives fakes for the page, the browser and the DO's storage, so it runs
+anywhere in under a second. The assertions that matter most are the negative ones:
+that no value ever reaches a log, a response or a summary.
+
+## License
+
+MIT

--- a/packages/test-google-login/bin/cli.js
+++ b/packages/test-google-login/bin/cli.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+// Thin wrapper: the implementation is `runCli` in src/cli.ts, which returns an
+// exit code instead of calling process.exit so it can be tested directly.
+import { runCli } from "../dist/index.js";
+
+process.exitCode = await runCli(process.argv.slice(2));

--- a/packages/test-google-login/examples/auth.setup.ts
+++ b/packages/test-google-login/examples/auth.setup.ts
@@ -1,0 +1,42 @@
+/**
+ * The setup project. Pick one of the two bodies below.
+ *
+ * **Verify a hand-captured session** (the default, and what a laptop should do):
+ * no credentials anywhere, no Google traffic, and a sub-millisecond check.
+ *
+ * **Mint your app's own session** (what CI should do): your app creates the same
+ * session a successful Google callback creates, so the run holds one secret of
+ * yours instead of a Google password.
+ */
+import { test as setup } from "@playwright/test";
+import { bootstrapAppSession, requireStoredSession } from "test-google-login";
+
+const SECRET = process.env.E2E_TEST_AUTH_SECRET;
+
+setup("an authenticated session is available", async ({ page, context, request }) => {
+  if (SECRET) {
+    // CI path. Regenerates state every run, so nothing persists between jobs.
+    const file = await bootstrapAppSession({
+      request,
+      page,
+      context,
+      secret: SECRET,
+      endpoint: process.env.E2E_TEST_AUTH_ENDPOINT ?? "/api/test-auth/google-user",
+      landingPath: "/dashboard",
+    });
+
+    console.log(`minted a fresh app session → ${file}`);
+    return;
+  }
+
+  // Local path. Throws with the exact `playwright codegen` command on the first
+  // run, which is the whole onboarding story for a new contributor.
+  const summary = requireStoredSession({ baseUrl: process.env.E2E_BASE_URL });
+
+  console.log(
+    `session ok — ${summary.cookieCount} cookies across ${summary.domains.join(", ")}` +
+      (summary.expiresInSeconds === null
+        ? " (no expiry; dies with the browser)"
+        : `, earliest expiry in ${Math.round(summary.expiresInSeconds / 60)} min`),
+  );
+});

--- a/packages/test-google-login/examples/dashboard.spec.ts
+++ b/packages/test-google-login/examples/dashboard.spec.ts
@@ -1,0 +1,20 @@
+/**
+ * What the tests look like once the setup project has done its work: nothing
+ * about auth, because the browser is already signed in.
+ */
+import { expect, test } from "@playwright/test";
+
+test("an authenticated user can open the dashboard", async ({ page }) => {
+  await page.goto("/dashboard");
+
+  await expect(page.getByRole("heading", { name: /dashboard/i })).toBeVisible();
+});
+
+test("the session survives a reload", async ({ page }) => {
+  await page.goto("/dashboard");
+  await page.reload();
+
+  // The assertion worth making explicitly: a storageState that restores cookies
+  // but not localStorage often passes the first navigation and fails this one.
+  await expect(page).not.toHaveURL(/\/login/);
+});

--- a/packages/test-google-login/examples/playwright.config.ts
+++ b/packages/test-google-login/examples/playwright.config.ts
@@ -1,0 +1,38 @@
+/**
+ * The setup-project layout: capture (or verify) the session once, then every
+ * browser project starts signed in.
+ *
+ * Copy this next to your tests. The two projects matter — `chromium` declares
+ * `dependencies: ["auth-setup"]`, so Playwright runs the setup once per run
+ * rather than once per test file, and a failure there fails fast with a message
+ * that says what to do instead of timing out on a login form.
+ */
+import { defineConfig, devices } from "@playwright/test";
+import { DEFAULT_AUTH_FILE } from "test-google-login";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 30_000,
+
+  use: {
+    baseURL: process.env.E2E_BASE_URL ?? "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+
+  projects: [
+    {
+      name: "auth-setup",
+      testMatch: /.*\.setup\.ts/,
+    },
+    {
+      name: "chromium",
+      dependencies: ["auth-setup"],
+      use: {
+        ...devices["Desktop Chrome"],
+        // Imported rather than written out, so the config and the CLI cannot
+        // drift onto different paths — which looks exactly like an expired session.
+        storageState: DEFAULT_AUTH_FILE,
+      },
+    },
+  ],
+});

--- a/packages/test-google-login/examples/test-auth-endpoint.ts
+++ b/packages/test-google-login/examples/test-auth-endpoint.ts
@@ -1,0 +1,58 @@
+/**
+ * The test-only endpoint `bootstrapAppSession` calls — the piece that lives in
+ * *your* app, not in this package.
+ *
+ * Written for a Next.js route handler; the shape is the same anywhere. Four
+ * things are not optional:
+ *
+ * 1. **It must not exist in production.** The 404 below is the floor, not the
+ *    ceiling — prefer excluding the file from the production build entirely, and
+ *    write a deployment test that asserts the route 404s in prod.
+ * 2. **It must require a strong secret**, compared in constant time.
+ * 3. **It must create the same session** a real Google callback creates: same
+ *    format, same claims, same roles, same cookie attributes. A subtly different
+ *    session turns your whole suite into a test of a code path that never ships.
+ * 4. **It must not accept a user id from the request** beyond what you are
+ *    willing to let any caller with the secret create.
+ */
+import { constantTimeEqual } from "test-google-login";
+
+// Stand-ins for your app's own modules.
+declare const db: {
+  user: {
+    upsert(args: Record<string, unknown>): Promise<{ id: string }>;
+  };
+};
+declare function createSessionForUser(userId: string): Promise<{ id: string }>;
+declare function buildSessionCookie(session: { id: string }): string;
+
+export async function POST(request: Request): Promise<Response> {
+  // Defence in depth. The real protection is this file not being in the bundle.
+  if (process.env.NODE_ENV === "production") {
+    return new Response("Not found", { status: 404 });
+  }
+
+  if (!constantTimeEqual(request.headers.get("x-e2e-auth-secret"), process.env.E2E_TEST_AUTH_SECRET)) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const user = await db.user.upsert({
+    where: { email: "google-e2e@example.test" },
+    create: {
+      email: "google-e2e@example.test",
+      name: "Google E2E User",
+      googleSubject: "google-e2e-subject-001",
+      emailVerified: true,
+    },
+    update: {},
+  });
+
+  const session = await createSessionForUser(user.id);
+
+  return new Response(JSON.stringify({ ok: true }), {
+    headers: {
+      "content-type": "application/json",
+      "set-cookie": buildSessionCookie(session),
+    },
+  });
+}

--- a/packages/test-google-login/examples/worker-check.ts
+++ b/packages/test-google-login/examples/worker-check.ts
@@ -1,0 +1,49 @@
+/**
+ * Driving the Durable Object from a test, so one captured session can be checked
+ * against a deployed environment from Cloudflare's network.
+ *
+ * Worth doing when "does the session work?" depends on where the request comes
+ * from — geo-routed auth, Cloudflare Access in front of the app, a WAF rule that
+ * treats your CI runner's IP differently from a real visitor.
+ */
+import { AUTH_HEADER, loadStorageStateFor } from "test-google-login";
+
+const WORKER = process.env.TGL_WORKER_URL ?? "https://test-google-login.example.workers.dev";
+const SECRET = process.env.TGL_WORKER_SECRET;
+
+if (!SECRET) throw new Error("TGL_WORKER_SECRET is required.");
+
+async function worker(path: string, body?: unknown) {
+  const response = await fetch(`${WORKER}${path}`, {
+    method: body === undefined ? "GET" : "POST",
+    headers: { [AUTH_HEADER]: SECRET!, "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+  if (!response.ok) throw new Error(`${path} → ${response.status}: ${await response.text()}`);
+  return response.json();
+}
+
+// Upload the session captured locally. This is the one request that carries live
+// cookies, so it goes over HTTPS to a Worker that only accepts the shared secret —
+// and there is deliberately no route that reads them back out.
+await worker("/state?session=signed-in", loadStorageStateFor());
+
+const result = (await worker("/check?session=signed-in", {
+  url: "https://app.example.test/dashboard",
+  expectSelector: "[data-testid=user-menu]",
+  rejectUrl: "/login",
+  // Narrow the origins: restoring accounts.google.com storage means navigating a
+  // datacentre browser to Google, which is slow and trips its risk checks.
+  origins: ["https://app.example.test"],
+  screenshot: true,
+})) as { authenticated: boolean; reason: string; screenshot?: string };
+
+console.log(result.authenticated ? `signed in — ${result.reason}` : `NOT signed in — ${result.reason}`);
+
+// GET /state returns a redacted summary, never the values. Safe to log in CI.
+console.log(await worker("/state?session=signed-in"));
+
+// Close the browser rather than waiting for the idle alarm: an open Browser
+// Rendering session is billed.
+await worker("/close?session=signed-in", {});

--- a/packages/test-google-login/package.json
+++ b/packages/test-google-login/package.json
@@ -1,0 +1,82 @@
+{
+  "name": "test-google-login",
+  "version": "0.1.0",
+  "description": "End-to-end test harness for Google sign-in: persist a Playwright storageState once, reuse it everywhere, and replay it from a Cloudflare Workers Browser Rendering Durable Object",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./worker": {
+      "types": "./dist/worker.d.ts",
+      "import": "./dist/worker.js"
+    }
+  },
+  "bin": {
+    "test-google-login": "./bin/cli.js"
+  },
+  "files": [
+    "dist",
+    "bin",
+    "examples"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "prepublishOnly": "bun run build",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:ci": "vitest run --reporter=default --reporter=junit --outputFile=junit.xml --coverage",
+    "coverage": "vitest run --coverage",
+    "deploy": "wrangler deploy",
+    "dev:worker": "wrangler dev",
+    "ship": "npx standard-version --release-as patch; npm publish"
+  },
+  "keywords": [
+    "playwright",
+    "puppeteer",
+    "google-login",
+    "oauth",
+    "storage-state",
+    "e2e",
+    "testing",
+    "cloudflare-workers",
+    "browser-rendering",
+    "durable-objects"
+  ],
+  "author": "vtempest",
+  "license": "MIT",
+  "devDependencies": {
+    "@cloudflare/puppeteer": "^1.4.0",
+    "@cloudflare/workers-types": "^4.20260507.1",
+    "@types/node": "^22.10.0",
+    "@vitest/coverage-v8": "^4.1.0",
+    "typescript": "^5.9.3",
+    "vite": "^6.3.5",
+    "vite-plugin-dts": "^4.5.4",
+    "vitest": "^4.1.0",
+    "wrangler": "^4.24.0"
+  },
+  "peerDependencies": {
+    "@cloudflare/puppeteer": "*",
+    "@playwright/test": "*"
+  },
+  "peerDependenciesMeta": {
+    "@playwright/test": {
+      "optional": true
+    },
+    "@cloudflare/puppeteer": {
+      "optional": true
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OpenSourceAGI/dev-tools-starter-agent.git",
+    "directory": "packages/test-google-login"
+  },
+  "homepage": "https://github.com/OpenSourceAGI/dev-tools-starter-agent/tree/master/packages/test-google-login"
+}

--- a/packages/test-google-login/src/auth-file.ts
+++ b/packages/test-google-login/src/auth-file.ts
@@ -1,0 +1,209 @@
+/**
+ * Where the persisted session lives, and keeping it out of git.
+ *
+ * Playwright's documented location is `playwright/.auth/`, ignored in git and
+ * read back from a setup project. This module owns that path and the `.gitignore`
+ * edit, because "the password is in .env so we're fine" is the mistake this
+ * package exists to prevent: the state file is the credential, not the password.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+/** Playwright's documented directory for persisted auth state. */
+export const DEFAULT_AUTH_DIR = "playwright/.auth";
+
+/** The state file this package reads and writes unless told otherwise. */
+export const DEFAULT_AUTH_FILE = `${DEFAULT_AUTH_DIR}/google-test-user.json`;
+
+/** Env var that overrides the state file path, for CI layouts that differ. */
+export const STATE_PATH_ENV = "TEST_GOOGLE_LOGIN_STATE";
+
+/**
+ * The lines `init` adds to `.gitignore`.
+ *
+ * `.env` is here too. Not scope creep: the same bootstrap that produces a state
+ * file is the one that puts `GOOGLE_TEST_PASSWORD` in a local `.env`, and a repo
+ * that ignores one but not the other is still one `git add -A` from a leak.
+ */
+export const GITIGNORE_LINES = [
+  "playwright/.auth/",
+  ".env",
+  ".env.*",
+  "!.env.example",
+] as const;
+
+export interface AuthFileOptions {
+  /** Project root. Defaults to `process.cwd()`. */
+  cwd?: string;
+  /** Explicit path, absolute or relative to `cwd`. */
+  file?: string;
+  /** Environment to read `TEST_GOOGLE_LOGIN_STATE` from. Defaults to `process.env`. */
+  env?: Record<string, string | undefined>;
+}
+
+/**
+ * The absolute path of the state file, resolving explicit argument → env var →
+ * default, in that order.
+ *
+ * @example
+ * resolveAuthFile()                                  // <cwd>/playwright/.auth/google-test-user.json
+ * resolveAuthFile({ file: "ci/state.json" })         // <cwd>/ci/state.json
+ */
+export function resolveAuthFile(options: AuthFileOptions = {}): string {
+  const cwd = options.cwd ?? process.cwd();
+  const env = options.env ?? process.env;
+  const file = options.file || env[STATE_PATH_ENV] || DEFAULT_AUTH_FILE;
+
+  return path.isAbsolute(file) ? file : path.resolve(cwd, file);
+}
+
+/**
+ * Create the directory a state file goes in, owner-only.
+ *
+ * `0o700` rather than the default `0o755`: on a shared CI box or a multi-user
+ * machine, a world-readable directory holding session cookies is the leak, and
+ * nobody notices because the file itself looks fine.
+ *
+ * @returns the absolute directory path
+ */
+export function ensureAuthDir(file: string): string {
+  const dir = path.dirname(file);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+
+  // `mkdirSync` applies `mode` only to directories it creates, and umask can trim
+  // it. Re-assert so an already-existing `playwright/.auth` is tightened too.
+  try {
+    fs.chmodSync(dir, 0o700);
+  } catch {
+    // Windows and some mounts do not implement chmod. The directory exists, which
+    // is the part the caller needs; permissions are best-effort there.
+  }
+
+  return dir;
+}
+
+/**
+ * A second line of defence inside the auth directory itself: `playwright/.auth/.gitignore`
+ * containing `*`.
+ *
+ * The root `.gitignore` can be reverted, reformatted or replaced wholesale by a
+ * tool; a `.gitignore` living in the directory travels with it and keeps the
+ * state file ignored even if someone adds `!playwright/**` upstream of it.
+ */
+export function writeAuthDirGitignore(file: string): string {
+  const dir = ensureAuthDir(file);
+  const target = path.join(dir, ".gitignore");
+
+  fs.writeFileSync(
+    target,
+    [
+      "# Everything in this directory is a live browser session.",
+      "# Nothing here is ever committed — see test-google-login's README.",
+      "*",
+      "",
+    ].join("\n"),
+  );
+
+  return target;
+}
+
+/**
+ * Does `.gitignore` already cover this pattern?
+ *
+ * Compares ignore *lines*, not paths: a real match check would mean
+ * reimplementing gitignore globbing, and being over-eager here means wrongly
+ * concluding a repo is safe. So `playwright/.auth/` counts as covered by
+ * `playwright/.auth`, `playwright/.auth/`, `/playwright/.auth/` or `playwright/`,
+ * and nothing cleverer. A pattern we fail to recognise costs a duplicate line,
+ * which is harmless.
+ */
+export function isIgnored(gitignore: string, pattern: string): boolean {
+  const normalize = (line: string) => line.trim().replace(/^\/+/, "").replace(/\/+$/, "");
+  const wanted = normalize(pattern);
+  if (!wanted) return true;
+
+  for (const raw of gitignore.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+
+    const candidate = normalize(line);
+    if (candidate === wanted) return true;
+
+    // A negation of exactly this pattern un-ignores it — treat as not covered.
+    if (line.startsWith("!")) continue;
+
+    // A parent directory entry (`playwright/`) covers everything under it.
+    if (!candidate.includes("*") && wanted.startsWith(`${candidate}/`)) return true;
+  }
+
+  return false;
+}
+
+export interface GitignoreResult {
+  /** Absolute path of the `.gitignore` written. */
+  file: string;
+  /** Patterns appended by this call. */
+  added: string[];
+  /** Patterns some existing line already covered. */
+  alreadyIgnored: string[];
+}
+
+/**
+ * Append whichever of {@link GITIGNORE_LINES} the repo does not already ignore.
+ *
+ * Idempotent, and never rewrites or reorders what is already there — a
+ * `.gitignore` is hand-maintained and a tool that reformats it gets turned off.
+ */
+export function ensureGitignored(options: { cwd?: string; patterns?: readonly string[] } = {}): GitignoreResult {
+  const cwd = options.cwd ?? process.cwd();
+  const patterns = options.patterns ?? GITIGNORE_LINES;
+  const file = path.join(cwd, ".gitignore");
+
+  const existing = fs.existsSync(file) ? fs.readFileSync(file, "utf8") : "";
+
+  const added: string[] = [];
+  const alreadyIgnored: string[] = [];
+
+  for (const pattern of patterns) {
+    // A negation (`!.env.example`) is only meaningful next to the rule it negates,
+    // so it is added whenever anything else in this batch is, and otherwise only
+    // if absent verbatim.
+    const covered = pattern.startsWith("!")
+      ? existing.split(/\r?\n/).some((line) => line.trim() === pattern)
+      : isIgnored(existing, pattern);
+
+    (covered ? alreadyIgnored : added).push(pattern);
+  }
+
+  if (added.length > 0) {
+    const parts: string[] = [];
+
+    if (existing.length > 0) {
+      parts.push(existing.endsWith("\n") ? existing : `${existing}\n`);
+      parts.push("\n");
+    }
+
+    parts.push("# test-google-login: persisted browser sessions are credentials\n");
+    for (const pattern of added) parts.push(`${pattern}\n`);
+
+    fs.writeFileSync(file, parts.join(""));
+  }
+
+  return { file, added, alreadyIgnored };
+}
+
+/**
+ * The `playwright codegen` command that captures a session by hand.
+ *
+ * Generated rather than pasted into prose, because it carries the state path —
+ * and a README telling you to save state to a path the suite does not read is a
+ * half-hour of confusion every time.
+ */
+export function codegenCommand(options: { file?: string; baseUrl?: string; cwd?: string } = {}): string {
+  const cwd = options.cwd ?? process.cwd();
+  const absolute = resolveAuthFile({ cwd, file: options.file });
+  const relative = path.relative(cwd, absolute) || absolute;
+  const baseUrl = options.baseUrl || "http://localhost:3000";
+
+  return `npx playwright codegen --save-storage=${relative} ${baseUrl}`;
+}

--- a/packages/test-google-login/src/cli.ts
+++ b/packages/test-google-login/src/cli.ts
@@ -1,0 +1,254 @@
+/**
+ * `test-google-login` — the four things you do to a state file from a terminal.
+ *
+ * `init` is the one that matters: it creates `playwright/.auth/` owner-only, makes
+ * git ignore it two ways, and prints the `codegen` command with the right path
+ * already in it. The rest exist so that inspecting a session never requires
+ * opening it — `check` tells you whether it is still good, `redact` gives you
+ * something safe to paste into an issue, `clear` removes it.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  DEFAULT_AUTH_FILE,
+  GITIGNORE_LINES,
+  codegenCommand,
+  ensureAuthDir,
+  ensureGitignored,
+  resolveAuthFile,
+  writeAuthDirGitignore,
+} from "./auth-file.js";
+import {
+  MissingStorageStateError,
+  findExpiringCookies,
+  readStorageState,
+  redactStorageState,
+  summarizeStorageState,
+} from "./storage-state.js";
+
+const HELP = `test-google-login — persist a Google test session for Playwright, safely
+
+Usage
+  test-google-login init [--file <path>] [--url <baseUrl>]
+      Create the auth directory (0700), add the gitignore rules, and print the
+      playwright codegen command that captures a session.
+
+  test-google-login check [--file <path>] [--within <minutes>]
+      Report what the stored session holds and whether it is still usable.
+      Exits 1 when it is missing or expired, so CI can fail early and clearly.
+
+  test-google-login redact [--file <path>]
+      Print the state with every cookie and localStorage value replaced by its
+      length. This is the only form that is safe to share.
+
+  test-google-login clear [--file <path>]
+      Delete the stored session.
+
+Options
+  --file <path>     State file. Default: ${DEFAULT_AUTH_FILE}
+                    (or $TEST_GOOGLE_LOGIN_STATE)
+  --url <baseUrl>   App URL used in the codegen command. Default: http://localhost:3000
+  --within <mins>   'check' warns about cookies expiring within this window. Default: 60
+  --json            Machine-readable output for 'check'.
+
+The state file contains live cookies and tokens. Treat it exactly like the
+password that produced it: dedicated Google test account only, never committed,
+never a public CI artifact, never pasted into a log.
+`;
+
+/** Parse `--flag value` and `--flag=value`, collecting the rest positionally. */
+export function parseArgs(argv: string[]): { command: string; flags: Record<string, string | true> } {
+  const flags: Record<string, string | true> = {};
+  const positional: string[] = [];
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (!arg.startsWith("--")) {
+      positional.push(arg);
+      continue;
+    }
+
+    const [name, inline] = arg.slice(2).split("=", 2);
+    if (inline !== undefined) {
+      flags[name] = inline;
+      continue;
+    }
+
+    const next = argv[i + 1];
+    if (next && !next.startsWith("--")) {
+      flags[name] = next;
+      i += 1;
+    } else {
+      flags[name] = true;
+    }
+  }
+
+  return { command: positional[0] ?? "help", flags };
+}
+
+type Writer = (line: string) => void;
+
+export interface CliIo {
+  out?: Writer;
+  err?: Writer;
+  cwd?: string;
+}
+
+/**
+ * Run the CLI.
+ *
+ * Returns an exit code rather than calling `process.exit`, and takes its writers
+ * as arguments, so the whole surface is testable without spawning anything.
+ */
+export async function runCli(argv: string[], io: CliIo = {}): Promise<number> {
+  const out = io.out ?? ((line: string) => console.log(line));
+  const err = io.err ?? ((line: string) => console.error(line));
+  const cwd = io.cwd ?? process.cwd();
+
+  const { command, flags } = parseArgs(argv);
+  const file = resolveAuthFile({ cwd, file: typeof flags.file === "string" ? flags.file : undefined });
+  const baseUrl = typeof flags.url === "string" ? flags.url : undefined;
+
+  switch (command) {
+    case "init":
+      return init({ cwd, file, baseUrl, out });
+
+    case "check":
+      return check({ cwd, file, baseUrl, flags, out, err });
+
+    case "redact":
+      return redact({ file, out, err });
+
+    case "clear":
+      return clear({ cwd, file, out });
+
+    case "help":
+    case "--help":
+    case "-h":
+      out(HELP);
+      return 0;
+
+    default:
+      err(`Unknown command: ${command}\n`);
+      err(HELP);
+      return 1;
+  }
+}
+
+function init(options: { cwd: string; file: string; baseUrl?: string; out: Writer }): number {
+  const { cwd, file, baseUrl, out } = options;
+
+  const dir = ensureAuthDir(file);
+  const nested = writeAuthDirGitignore(file);
+  const gitignore = ensureGitignored({ cwd });
+
+  out(`Created ${path.relative(cwd, dir) || dir}/ (mode 0700)`);
+  out(`Wrote   ${path.relative(cwd, nested)} — ignores everything in that directory`);
+
+  if (gitignore.added.length > 0) {
+    out(`Added to .gitignore: ${gitignore.added.join(", ")}`);
+  } else {
+    out(`.gitignore already covers: ${GITIGNORE_LINES.join(", ")}`);
+  }
+
+  out("");
+  out("Now capture a session by hand — this avoids automating Google's password form,");
+  out("which is what MFA, CAPTCHA and device checks all break:");
+  out("");
+  out(`  ${codegenCommand({ cwd, file, baseUrl })}`);
+  out("");
+  out("In the window that opens: click your app's 'Sign in with Google', sign in with");
+  out("the dedicated test account, finish the redirect back to your app, confirm you");
+  out("are on an authenticated page, then close the window. Playwright writes the");
+  out("state file on exit.");
+
+  return 0;
+}
+
+function check(options: {
+  cwd: string;
+  file: string;
+  baseUrl?: string;
+  flags: Record<string, string | true>;
+  out: Writer;
+  err: Writer;
+}): number {
+  const { cwd, file, baseUrl, flags, out, err } = options;
+
+  let state;
+  try {
+    state = readStorageState(file, { cwd, baseUrl });
+  } catch (error) {
+    err((error as Error).message);
+    return error instanceof MissingStorageStateError ? 1 : 2;
+  }
+
+  const summary = summarizeStorageState(state);
+  const withinMinutes = Number.parseFloat(String(flags.within ?? "60"));
+  const expiring = findExpiringCookies(state, { withinMs: withinMinutes * 60_000 });
+
+  if (flags.json) {
+    out(JSON.stringify({ file, summary, expiringSoon: expiring.map((cookie) => cookie.name) }, null, 2));
+  } else {
+    out(`State file   ${path.relative(cwd, file) || file}`);
+    out(`Cookies      ${summary.cookieCount} (${summary.sessionCookies} session-only)`);
+    out(`Domains      ${summary.domains.join(", ") || "none"}`);
+    out(`Origins      ${summary.originCount}`);
+    out(`Google cookies present: ${summary.hasGoogleCookies ? "yes" : "no"}`);
+
+    if (summary.expiresInSeconds === null) {
+      out("Expiry       no cookie carries one — this session dies with the browser");
+    } else {
+      const minutes = Math.round(summary.expiresInSeconds / 60);
+      out(
+        summary.expiresInSeconds > 0
+          ? `Expiry       earliest in ${minutes} minutes`
+          : `Expiry       lapsed ${Math.abs(minutes)} minutes ago`,
+      );
+    }
+
+    if (expiring.length > 0 && summary.usable) {
+      out("");
+      out(
+        `⚠ ${expiring.length} cookie(s) expire within ${withinMinutes} minutes: ` +
+          `${expiring.map((cookie) => cookie.name).join(", ")}`,
+      );
+      out(`  Re-capture before a long run: ${codegenCommand({ cwd, file, baseUrl })}`);
+    }
+  }
+
+  if (!summary.usable || summary.expired) {
+    err("");
+    err("This session is no longer usable. Re-capture it:");
+    err(`  ${codegenCommand({ cwd, file, baseUrl })}`);
+    return 1;
+  }
+
+  return 0;
+}
+
+function redact(options: { file: string; out: Writer; err: Writer }): number {
+  try {
+    const state = readStorageState(options.file);
+    options.out(JSON.stringify(redactStorageState(state), null, 2));
+    return 0;
+  } catch (error) {
+    options.err((error as Error).message);
+    return 1;
+  }
+}
+
+function clear(options: { cwd: string; file: string; out: Writer }): number {
+  const { cwd, file, out } = options;
+
+  if (!fs.existsSync(file)) {
+    out(`Nothing to clear — ${path.relative(cwd, file) || file} does not exist.`);
+    return 0;
+  }
+
+  fs.rmSync(file);
+  out(`Deleted ${path.relative(cwd, file) || file}`);
+  return 0;
+}

--- a/packages/test-google-login/src/google-login.ts
+++ b/packages/test-google-login/src/google-login.ts
@@ -1,0 +1,289 @@
+/**
+ * The three ways to get a signed-in browser, in the order you should prefer them.
+ *
+ * 1. {@link requireStoredSession} — a session captured once by hand with
+ *    `playwright codegen`, reused by every test. No credentials anywhere, no
+ *    Google traffic in the suite. This is the default.
+ * 2. {@link bootstrapAppSession} — your app mints its own session through a
+ *    test-only endpoint, so CI regenerates state on every run and holds one
+ *    secret instead of a Google password. This is what pull requests should use.
+ * 3. {@link signInWithGoogle} — actually drive Google's sign-in form. A narrow,
+ *    manually triggered smoke test and nothing more: it can fail for MFA,
+ *    CAPTCHA, a consent prompt, a device check or a UI change, none of which are
+ *    your app's fault. It refuses to run unless explicitly opted in.
+ *
+ * Nothing here imports Playwright. Every function takes the `page`, `context` or
+ * `request` fixture it needs, which keeps the package dependency-free and lets
+ * the whole module be tested without a browser.
+ */
+import { codegenCommand, resolveAuthFile } from "./auth-file.js";
+import { assertStorageStateUsable, hardenStorageStateFile, readStorageState } from "./storage-state.js";
+import type { StorageState, StorageStateSummary } from "./types.js";
+
+/** Env var that must be set before {@link signInWithGoogle} will run. */
+export const ALLOW_REAL_LOGIN_ENV = "TEST_GOOGLE_LOGIN_ALLOW_REAL";
+
+/** Header the test-only session endpoint authenticates with. */
+export const BOOTSTRAP_HEADER = "x-e2e-auth-secret";
+
+/** The subset of Playwright's `BrowserContext` used here. */
+export interface ContextLike {
+  storageState(options?: { path?: string; indexedDB?: boolean }): Promise<unknown>;
+}
+
+/** The subset of Playwright's `APIRequestContext` used here. */
+export interface RequestLike {
+  post(
+    url: string,
+    options?: { headers?: Record<string, string>; data?: unknown },
+  ): Promise<{ ok(): boolean; status(): number; text(): Promise<string> }>;
+}
+
+/** The subset of Playwright's `Locator` used here. */
+export interface LocatorLike {
+  click(options?: Record<string, unknown>): Promise<void>;
+  fill(value: string, options?: Record<string, unknown>): Promise<void>;
+}
+
+/** The subset of Playwright's `Page` used here. */
+export interface PlaywrightPageLike {
+  goto(url: string, options?: Record<string, unknown>): Promise<unknown>;
+  waitForURL(url: string | RegExp, options?: Record<string, unknown>): Promise<void>;
+  url(): string;
+  getByRole(role: string, options?: { name?: string | RegExp }): LocatorLike;
+  getByLabel(text: string | RegExp, options?: Record<string, unknown>): LocatorLike;
+}
+
+export interface StoredSessionOptions {
+  /** State file path. Defaults to `playwright/.auth/google-test-user.json`. */
+  file?: string;
+  /** Project root for relative paths and for the hint in error messages. */
+  cwd?: string;
+  /** App URL used in the `playwright codegen` hint. */
+  baseUrl?: string;
+  /** Injectable clock, so expiry assertions are deterministic in tests. */
+  now?: number;
+}
+
+/**
+ * Assert that a usable persisted session exists, and describe it.
+ *
+ * This is the whole body of a Playwright setup project. It deliberately does not
+ * *create* the session: scripting Google's password form is the brittle part, so
+ * the first run tells you how to do it by hand and every run after that is a
+ * sub-millisecond file check.
+ *
+ * @returns a summary safe to print — no cookie value is in it
+ * @throws when the file is missing, malformed, or expired, in each case with the
+ *   command that fixes it
+ *
+ * @example
+ * // tests/auth.setup.ts
+ * setup("Google test-user session exists", () => {
+ *   const summary = requireStoredSession({ baseUrl: process.env.E2E_BASE_URL });
+ *   console.log(`session ok — ${summary.cookieCount} cookies, expires in ${summary.expiresInSeconds}s`);
+ * });
+ */
+export function requireStoredSession(options: StoredSessionOptions = {}): StorageStateSummary {
+  const file = resolveAuthFile(options);
+  const state = readStorageState(file, options);
+  return assertStorageStateUsable(state, { ...options, file });
+}
+
+export interface BootstrapAppSessionOptions extends StoredSessionOptions {
+  /** Playwright's `request` fixture. */
+  request: RequestLike;
+  /** Playwright's `page` fixture — needed to put the app's origin in the context. */
+  page: PlaywrightPageLike;
+  /** Playwright's `context` fixture, which the state is read off. */
+  context: ContextLike;
+  /**
+   * The test-only endpoint that creates a session. Must 404 in production, and be
+   * covered by a test that proves it does.
+   */
+  endpoint?: string;
+  /** The shared secret the endpoint checks. Required; never defaulted. */
+  secret?: string;
+  /** Where to land afterwards, so the app's cookies are in the context. */
+  landingPath?: string;
+  /** Body posted to the endpoint — which user to create, what roles to give it. */
+  user?: Record<string, unknown>;
+  /** Capture IndexedDB too. Needed when your auth library keeps tokens there. */
+  indexedDB?: boolean;
+}
+
+/**
+ * Ask your own app for a session that looks exactly like a successful Google
+ * callback, then persist the browser state.
+ *
+ * The recommended path for CI. The only secret involved is yours, it is scoped to
+ * your own staging environment, and nothing in the run touches Google — so a PR
+ * check cannot fail because Google showed a consent screen.
+ *
+ * The endpoint on your side must create the *same* session format, claims, roles
+ * and cookies as the real callback. An endpoint that mints a subtly different
+ * session turns the whole suite into a test of a code path that does not ship.
+ *
+ * @throws when `secret` is absent — an unauthenticated session-minting endpoint
+ *   is a far worse outcome than a failed test, so this never falls back
+ */
+export async function bootstrapAppSession(options: BootstrapAppSessionOptions): Promise<string> {
+  const {
+    request,
+    page,
+    context,
+    endpoint = "/api/test-auth/google-user",
+    secret,
+    landingPath = "/dashboard",
+    user,
+    indexedDB = true,
+  } = options;
+
+  if (!secret) {
+    throw new Error(
+      "bootstrapAppSession() needs the shared secret for the test-only auth endpoint. " +
+        "Set E2E_TEST_AUTH_SECRET and pass it as `secret` — it is never defaulted, because an " +
+        "endpoint that mints sessions without one is a production incident waiting to happen.",
+    );
+  }
+
+  const response = await request.post(endpoint, {
+    headers: { [BOOTSTRAP_HEADER]: secret },
+    data: user ?? {},
+  });
+
+  if (!response.ok()) {
+    const body = await response.text().catch(() => "");
+    throw new Error(
+      [
+        `Test-auth endpoint ${endpoint} returned ${response.status()}.`,
+        body ? `Body: ${body.slice(0, 400)}` : "",
+        "",
+        "A 401 means the secret does not match; a 404 means the endpoint is disabled for this",
+        "environment — which is correct in production and a misconfiguration anywhere else.",
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  }
+
+  // The cookie the endpoint set is attached to the API request context; navigating
+  // the page is what puts the app's origin — and its localStorage — into the
+  // browser context that `storageState()` reads.
+  await page.goto(landingPath);
+
+  const file = resolveAuthFile(options);
+
+  // Playwright writes the file itself rather than us re-serialising what it
+  // returns: `indexedDB: true` puts a key in there that this package has no type
+  // for, and round-tripping through our own writer would silently drop it — along
+  // with whichever auth library keeps its tokens in IndexedDB. So Playwright
+  // writes, and we tighten the mode afterwards.
+  await context.storageState({ path: file, indexedDB });
+  hardenStorageStateFile(file);
+
+  return file;
+}
+
+/** Is real Google sign-in opted into, and are the credentials present? */
+export function realGoogleLoginEnabled(env: Record<string, string | undefined> = process.env): boolean {
+  const flag = env[ALLOW_REAL_LOGIN_ENV];
+  const optedIn = flag === "1" || flag?.toLowerCase() === "true";
+  return Boolean(optedIn && env.GOOGLE_TEST_EMAIL && env.GOOGLE_TEST_PASSWORD);
+}
+
+export interface GoogleSignInOptions extends StoredSessionOptions {
+  page: PlaywrightPageLike;
+  context: ContextLike;
+  /** Environment the opt-in flag and credentials are read from. */
+  env?: Record<string, string | undefined>;
+  /** Your app's login page. */
+  loginPath?: string;
+  /** Accessible name of your app's "sign in with Google" button. */
+  signInButton?: string | RegExp;
+  /** URL the flow must land on before the state is captured. */
+  expectUrl?: RegExp;
+  indexedDB?: boolean;
+  /** Google's own field and button labels, overridable because Google changes them. */
+  googleSelectors?: {
+    email?: RegExp;
+    password?: RegExp;
+    next?: RegExp;
+  };
+}
+
+/**
+ * Drive Google's real sign-in form and persist the result.
+ *
+ * Use this once, in a workflow a human triggers, to confirm your OAuth client is
+ * configured — not in a PR check. The selectors below are illustrative: Google
+ * changes its UI, its labels and its language, and none of that is something this
+ * package can keep up with.
+ *
+ * It will not attempt to get past MFA, CAPTCHA, a suspicious-sign-in prompt or
+ * device verification, and you should not add that: those are the controls
+ * protecting the account, and automating around them is how a test account
+ * becomes a compromised one. If you hit them, capture the session by hand with
+ * `playwright codegen` instead.
+ *
+ * @throws when {@link ALLOW_REAL_LOGIN_ENV} is not set or credentials are missing
+ */
+export async function signInWithGoogle(options: GoogleSignInOptions): Promise<string> {
+  const {
+    page,
+    context,
+    env = process.env,
+    loginPath = "/login",
+    signInButton = /continue with google|sign in with google/i,
+    expectUrl = /dashboard|app/,
+    indexedDB = true,
+    googleSelectors = {},
+  } = options;
+
+  if (!realGoogleLoginEnabled(env)) {
+    throw new Error(
+      [
+        "Real Google sign-in is not enabled.",
+        "",
+        `Set ${ALLOW_REAL_LOGIN_ENV}=1 together with GOOGLE_TEST_EMAIL and GOOGLE_TEST_PASSWORD,`,
+        "and only in a manually triggered workflow on a protected branch — never where a fork's",
+        "pull request can reach the secrets.",
+        "",
+        "For everything else, prefer a session captured once by hand:",
+        `  ${codegenCommand(options)}`,
+      ].join("\n"),
+    );
+  }
+
+  const email = env.GOOGLE_TEST_EMAIL as string;
+  const password = env.GOOGLE_TEST_PASSWORD as string;
+
+  const emailField = googleSelectors.email ?? /email or phone/i;
+  const passwordField = googleSelectors.password ?? /enter your password/i;
+  const next = googleSelectors.next ?? /^next$/i;
+
+  await page.goto(loginPath);
+  await page.getByRole("button", { name: signInButton }).click();
+
+  await page.getByLabel(emailField).fill(email);
+  await page.getByRole("button", { name: next }).click();
+
+  await page.getByLabel(passwordField).fill(password);
+  await page.getByRole("button", { name: next }).click();
+
+  // Back on your own origin. Anything else — a consent screen, a device check —
+  // times out here, and that is the correct outcome: it is not something to
+  // click through automatically.
+  await page.waitForURL(expectUrl);
+
+  const file = resolveAuthFile(options);
+  await context.storageState({ path: file, indexedDB });
+  hardenStorageStateFile(file);
+
+  return file;
+}
+
+/** Load a state file for passing to `browser.newContext({ storageState })`. */
+export function loadStorageStateFor(options: StoredSessionOptions = {}): StorageState {
+  return readStorageState(resolveAuthFile(options), options);
+}

--- a/packages/test-google-login/src/index.ts
+++ b/packages/test-google-login/src/index.ts
@@ -1,0 +1,90 @@
+/**
+ * test-google-login — persist a Google sign-in once, reuse it everywhere.
+ *
+ * The Node/Playwright half of the package. The Cloudflare Workers half is a
+ * separate entry point, `test-google-login/worker`, so that importing this one
+ * never drags a Worker runtime into your test process (and vice versa).
+ *
+ * Start with {@link requireStoredSession} in a Playwright setup project, or
+ * {@link bootstrapAppSession} if your app can mint its own test sessions — which
+ * is the one to use in CI.
+ *
+ * @see README.md for the security boundary around the state file. It is short,
+ *      and it is the most important part of this package.
+ */
+export type {
+  ApplyStorageStateOptions,
+  ApplyStorageStateResult,
+} from "./puppeteer-state.js";
+export type {
+  PageLike,
+  PuppeteerCookie,
+  SameSite,
+  StorageState,
+  StorageStateCookie,
+  StorageStateOrigin,
+  StorageStateSummary,
+} from "./types.js";
+export type {
+  BootstrapAppSessionOptions,
+  ContextLike,
+  GoogleSignInOptions,
+  LocatorLike,
+  PlaywrightPageLike,
+  RequestLike,
+  StoredSessionOptions,
+} from "./google-login.js";
+export type { CliIo } from "./cli.js";
+export type { GitignoreResult, AuthFileOptions } from "./auth-file.js";
+
+export {
+  DEFAULT_AUTH_DIR,
+  DEFAULT_AUTH_FILE,
+  GITIGNORE_LINES,
+  STATE_PATH_ENV,
+  codegenCommand,
+  ensureAuthDir,
+  ensureGitignored,
+  isIgnored,
+  resolveAuthFile,
+  writeAuthDirGitignore,
+} from "./auth-file.js";
+
+export {
+  InvalidStorageStateError,
+  MissingStorageStateError,
+  SESSION_COOKIE_EXPIRES,
+  assertStorageStateUsable,
+  findExpiringCookies,
+  hardenStorageStateFile,
+  isGoogleDomain,
+  normalizeStorageState,
+  parseStorageState,
+  readStorageState,
+  redactStorageState,
+  summarizeStorageState,
+  writeStorageState,
+} from "./storage-state.js";
+
+export {
+  ALLOW_REAL_LOGIN_ENV,
+  BOOTSTRAP_HEADER,
+  bootstrapAppSession,
+  loadStorageStateFor,
+  realGoogleLoginEnabled,
+  requireStoredSession,
+  signInWithGoogle,
+} from "./google-login.js";
+
+export {
+  applyLocalStorage,
+  applyStorageState,
+  extractStorageState,
+  fromPuppeteerCookies,
+  storageStateOrigins,
+  toPuppeteerCookies,
+} from "./puppeteer-state.js";
+
+export { AUTH_HEADER, constantTimeEqual, isAuthorized } from "./secret.js";
+
+export { parseArgs, runCli } from "./cli.js";

--- a/packages/test-google-login/src/puppeteer-state.ts
+++ b/packages/test-google-login/src/puppeteer-state.ts
@@ -1,0 +1,244 @@
+/**
+ * Carrying a Playwright storage state into a Puppeteer browser, and back out.
+ *
+ * This is what lets one captured session serve both halves of the package: you
+ * sign in once with Playwright on your machine, and a Cloudflare Browser
+ * Rendering Durable Object — which only speaks Puppeteer — replays the same
+ * session against your deployed app.
+ *
+ * The two formats are close but not identical, and every difference is a way to
+ * lose a session silently:
+ *
+ * - **Session cookies.** Playwright writes `expires: -1`; CDP reads `-1` as "this
+ *   cookie expired in 1969" and drops it. The expiry must be *omitted* instead.
+ * - **`sameSite`.** Playwright writes `Strict | Lax | None`, and CDP wants exactly
+ *   those, capitalised. A lowercase value is rejected for the whole batch.
+ * - **`localStorage` is per origin and needs a document.** There is no CDP call to
+ *   write it blind — the page must be on the origin first, which means a
+ *   navigation per origin, in order, before the app's own code runs.
+ *
+ * Every function takes the page as an argument rather than importing Puppeteer,
+ * so all of this is unit-testable without a browser — and so the package keeps
+ * its zero runtime dependencies.
+ */
+import { SESSION_COOKIE_EXPIRES } from "./state-core.js";
+import type { PageLike, PuppeteerCookie, StorageState, StorageStateCookie } from "./types.js";
+
+/**
+ * Playwright cookies → Puppeteer/CDP cookies.
+ *
+ * The one transformation that matters: a session cookie loses its `expires` key
+ * entirely rather than carrying `-1`.
+ */
+export function toPuppeteerCookies(state: StorageState): PuppeteerCookie[] {
+  return state.cookies.map((cookie) => {
+    const converted: PuppeteerCookie = {
+      name: cookie.name,
+      value: cookie.value,
+      domain: cookie.domain,
+      path: cookie.path,
+      httpOnly: cookie.httpOnly,
+      secure: cookie.secure,
+      sameSite: cookie.sameSite,
+    };
+
+    if (cookie.expires > 0) converted.expires = cookie.expires;
+
+    return converted;
+  });
+}
+
+/**
+ * Puppeteer/CDP cookies → Playwright cookies.
+ *
+ * The inverse, plus the normalizations a CDP read needs: `session: true` or a
+ * missing expiry becomes `-1`, and `sameSite` is re-capitalised (CDP has been
+ * known to return `"unspecified"`, which is not one of the three).
+ */
+export function fromPuppeteerCookies(cookies: PuppeteerCookie[]): StorageStateCookie[] {
+  return cookies.map((cookie) => {
+    const hasExpiry = cookie.session !== true && typeof cookie.expires === "number" && cookie.expires > 0;
+
+    const sameSite = ["Strict", "Lax", "None"].find(
+      (candidate) => candidate.toLowerCase() === String(cookie.sameSite ?? "").toLowerCase(),
+    );
+
+    return {
+      name: cookie.name,
+      value: cookie.value,
+      domain: cookie.domain,
+      path: cookie.path || "/",
+      expires: hasExpiry ? (cookie.expires as number) : SESSION_COOKIE_EXPIRES,
+      httpOnly: cookie.httpOnly === true,
+      secure: cookie.secure === true,
+      sameSite: (sameSite as StorageStateCookie["sameSite"]) ?? "Lax",
+    };
+  });
+}
+
+/** The origins a state file carries `localStorage` for, in file order. */
+export function storageStateOrigins(state: StorageState): string[] {
+  return state.origins.map((origin) => origin.origin);
+}
+
+/**
+ * Write one origin's `localStorage` into a page that is already on that origin.
+ *
+ * Exported because it is the half that can fail for reasons worth surfacing: a
+ * page on `about:blank` or a cross-origin page throws `SecurityError`, and a
+ * browser with storage disabled throws `QuotaExceededError`. Both are far easier
+ * to read here than three steps later as a login screen.
+ */
+export async function applyLocalStorage(
+  page: PageLike,
+  entries: { name: string; value: string }[],
+): Promise<void> {
+  if (entries.length === 0) return;
+
+  await page.evaluate(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- runs in the page, not here
+    ((items: { name: string; value: string }[]) => {
+      for (const item of items) window.localStorage.setItem(item.name, item.value);
+    }) as never,
+    entries,
+  );
+}
+
+export interface ApplyStorageStateOptions {
+  /**
+   * Only restore `localStorage` for these origins. Defaults to every origin in
+   * the state.
+   *
+   * Worth narrowing: the state captured during a real Google sign-in also holds
+   * `accounts.google.com` storage, and navigating a test browser to Google to
+   * restore it is both slow and a way to trip Google's own bot checks. Pass your
+   * app's origin and nothing else for the common case.
+   */
+  origins?: string[];
+  /** Passed through to `page.goto` for each origin navigation. */
+  gotoOptions?: Record<string, unknown>;
+}
+
+export interface ApplyStorageStateResult {
+  cookiesSet: number;
+  /** Origins whose `localStorage` was restored. */
+  originsRestored: string[];
+  /** Origins skipped, and why — a navigation that failed is not fatal on its own. */
+  skipped: { origin: string; reason: string }[];
+}
+
+/**
+ * Restore a whole captured session into a Puppeteer page.
+ *
+ * Cookies go in first and in one call — `setCookie` is variadic and a
+ * cookie-at-a-time loop is a round trip each. Then one navigation per origin to
+ * get a document that `localStorage` can be written through.
+ *
+ * A state file with no `origins` therefore costs no navigation at all, which is
+ * the case for most apps: if your session lives in a cookie, this is a single
+ * CDP call and you can `goto` wherever you actually wanted to go.
+ */
+export async function applyStorageState(
+  page: PageLike,
+  state: StorageState,
+  options: ApplyStorageStateOptions = {},
+): Promise<ApplyStorageStateResult> {
+  const result: ApplyStorageStateResult = { cookiesSet: 0, originsRestored: [], skipped: [] };
+
+  const cookies = toPuppeteerCookies(state);
+  if (cookies.length > 0) {
+    if (typeof page.setCookie !== "function") {
+      throw new TypeError(
+        "This page cannot set cookies — `page.setCookie` is missing. Puppeteer 23+ moved it to " +
+          "`browserContext.setCookie`; pass a page from an older API, or set them on the context yourself.",
+      );
+    }
+    await page.setCookie(...cookies);
+    result.cookiesSet = cookies.length;
+  }
+
+  const wanted = options.origins;
+  const origins = wanted
+    ? state.origins.filter((origin) => wanted.includes(origin.origin))
+    : state.origins;
+
+  for (const origin of origins) {
+    if (origin.localStorage.length === 0) {
+      result.skipped.push({ origin: origin.origin, reason: "no localStorage entries" });
+      continue;
+    }
+
+    try {
+      // `domcontentloaded` rather than `load`: a document is all `localStorage`
+      // needs, and waiting for every subresource of an unauthenticated page is
+      // time spent on a page that is about to be navigated away from.
+      await page.goto(origin.origin, { waitUntil: "domcontentloaded", ...options.gotoOptions });
+      await applyLocalStorage(page, origin.localStorage);
+      result.originsRestored.push(origin.origin);
+    } catch (error) {
+      // One unreachable origin must not lose the cookies that are already set —
+      // those alone are usually enough to be signed in.
+      result.skipped.push({ origin: origin.origin, reason: (error as Error).message });
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Capture the current session out of a Puppeteer page, in Playwright's format.
+ *
+ * The mirror of {@link applyStorageState}: what a Worker produces here can be
+ * dropped into `playwright/.auth/` and used by the local suite, and vice versa.
+ *
+ * `origins` must be given explicitly — `localStorage` can only be read from the
+ * origin that owns it, so there is nothing to enumerate from. Defaults to the
+ * page's current origin, which is the common case.
+ */
+export async function extractStorageState(
+  page: PageLike,
+  options: { origins?: string[]; gotoOptions?: Record<string, unknown> } = {},
+): Promise<StorageState> {
+  if (typeof page.cookies !== "function") {
+    throw new TypeError("This page cannot read cookies — `page.cookies` is missing.");
+  }
+
+  const cookies = fromPuppeteerCookies(await page.cookies());
+
+  const current = page.url();
+  const origins = options.origins ?? (current && current !== "about:blank" ? [originOf(current)] : []);
+
+  const captured: StorageState["origins"] = [];
+
+  for (const origin of origins) {
+    try {
+      if (originOf(page.url()) !== origin) {
+        await page.goto(origin, { waitUntil: "domcontentloaded", ...options.gotoOptions });
+      }
+
+      const localStorage = await page.evaluate(
+        (() =>
+          Object.keys(window.localStorage).map((name) => ({
+            name,
+            value: window.localStorage.getItem(name) ?? "",
+          }))) as never,
+      );
+
+      captured.push({ origin, localStorage: localStorage as { name: string; value: string }[] });
+    } catch {
+      // An origin we cannot reach contributes nothing. Returning the cookies is
+      // strictly better than throwing away a capture over one navigation.
+    }
+  }
+
+  return { cookies, origins: captured };
+}
+
+/** `https://app.example.com/dashboard?x=1` → `https://app.example.com`. */
+function originOf(url: string): string {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return url;
+  }
+}

--- a/packages/test-google-login/src/secret.ts
+++ b/packages/test-google-login/src/secret.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared-secret comparison, in a form that runs in both halves of this package.
+ *
+ * `node:crypto.timingSafeEqual` would do, and the Worker could reach it through
+ * `nodejs_compat` — but this is twenty lines, needs no compatibility flag, and
+ * the Worker half is deliberately free of Node builtins so its bundle stays a
+ * Worker bundle. Hence the hand-rolled compare.
+ */
+
+const encoder = new TextEncoder();
+
+/**
+ * Compare two secrets without leaking their contents through timing.
+ *
+ * A length mismatch is answered in the same shape as a content mismatch — the
+ * loop always runs over the expected value's full length — so an attacker
+ * learns neither the length nor the position of the first wrong byte.
+ *
+ * @param supplied what the caller presented (`null`/`undefined` is a miss, not a throw)
+ * @param expected the configured secret (empty or unset is always a miss)
+ */
+export function constantTimeEqual(
+  supplied: string | null | undefined,
+  expected: string | null | undefined,
+): boolean {
+  // An unset expected secret must never match anything, including "". Checking
+  // it first is safe: its value is configuration, not attacker-controlled.
+  if (!expected) return false;
+  if (supplied == null) return false;
+
+  const a = encoder.encode(supplied);
+  const b = encoder.encode(expected);
+
+  let diff = a.length ^ b.length;
+  for (let i = 0; i < b.length; i += 1) {
+    // Index past the end of `a` reads `undefined`; `| 0` turns that into 0 so the
+    // comparison stays arithmetic and the loop keeps its constant shape.
+    diff |= (a[i] ?? 0xff_ff) ^ (b[i] as number);
+  }
+
+  return diff === 0;
+}
+
+/** Header every request to the Worker half must carry. */
+export const AUTH_HEADER = "x-test-auth-secret";
+
+/**
+ * Whether a request presented the configured secret.
+ *
+ * Returns `false` when the secret is not configured at all, so a Worker deployed
+ * without `TEST_AUTH_SECRET` set refuses every request rather than serving an
+ * open browser to the internet.
+ */
+export function isAuthorized(
+  headers: { get(name: string): string | null },
+  expected: string | null | undefined,
+): boolean {
+  return constantTimeEqual(headers.get(AUTH_HEADER), expected);
+}

--- a/packages/test-google-login/src/state-core.ts
+++ b/packages/test-google-login/src/state-core.ts
@@ -1,0 +1,230 @@
+/**
+ * The parts of storage-state handling that touch nothing but data.
+ *
+ * Split out from `storage-state.ts` for one concrete reason: the Cloudflare Worker
+ * half of this package validates, summarises and redacts storage states inside a
+ * Worker isolate, where `node:fs` does not exist. Anything the Worker needs lives
+ * here; anything that reads or writes a file lives next door and re-exports this
+ * module, so callers on the Node side see one surface.
+ *
+ * Keep it that way — a single `node:` import in this file makes the Worker bundle
+ * fail to start, and it fails at deploy time rather than in a test.
+ */
+import type {
+  SameSite,
+  StorageState,
+  StorageStateCookie,
+  StorageStateOrigin,
+  StorageStateSummary,
+} from "./types.js";
+
+/** Playwright's sentinel for "dies with the browser". Not a timestamp. */
+export const SESSION_COOKIE_EXPIRES = -1;
+
+const SAME_SITE: SameSite[] = ["Strict", "Lax", "None"];
+
+const GOOGLE_DOMAINS = ["google.com", "accounts.google.com", "googleusercontent.com", "gstatic.com"];
+
+
+/** Thrown when a state file exists but is not a storage state. */
+export class InvalidStorageStateError extends Error {
+  constructor(reason: string) {
+    super(`Not a Playwright storage state: ${reason}`);
+    this.name = "InvalidStorageStateError";
+  }
+}
+
+function asSameSite(value: unknown): SameSite {
+  if (typeof value === "string") {
+    const match = SAME_SITE.find((candidate) => candidate.toLowerCase() === value.toLowerCase());
+    if (match) return match;
+  }
+  // Chrome's own default for a cookie that arrived without the attribute.
+  return "Lax";
+}
+
+function parseCookie(raw: unknown, index: number): StorageStateCookie {
+  if (typeof raw !== "object" || raw === null) {
+    throw new InvalidStorageStateError(`cookies[${index}] is not an object`);
+  }
+
+  const cookie = raw as Record<string, unknown>;
+  if (typeof cookie.name !== "string" || typeof cookie.value !== "string") {
+    throw new InvalidStorageStateError(`cookies[${index}] has no name/value pair`);
+  }
+  if (typeof cookie.domain !== "string" || cookie.domain === "") {
+    throw new InvalidStorageStateError(`cookies[${index}] (${cookie.name}) has no domain`);
+  }
+
+  return {
+    name: cookie.name,
+    value: cookie.value,
+    domain: cookie.domain,
+    path: typeof cookie.path === "string" ? cookie.path : "/",
+    expires: typeof cookie.expires === "number" ? cookie.expires : SESSION_COOKIE_EXPIRES,
+    httpOnly: cookie.httpOnly === true,
+    secure: cookie.secure === true,
+    sameSite: asSameSite(cookie.sameSite),
+  };
+}
+
+function parseOrigin(raw: unknown, index: number): StorageStateOrigin {
+  if (typeof raw !== "object" || raw === null) {
+    throw new InvalidStorageStateError(`origins[${index}] is not an object`);
+  }
+
+  const origin = raw as Record<string, unknown>;
+  if (typeof origin.origin !== "string" || origin.origin === "") {
+    throw new InvalidStorageStateError(`origins[${index}] has no origin`);
+  }
+
+  const entries = Array.isArray(origin.localStorage) ? origin.localStorage : [];
+
+  return {
+    origin: origin.origin,
+    localStorage: entries.flatMap((entry) => {
+      if (typeof entry !== "object" || entry === null) return [];
+      const { name, value } = entry as Record<string, unknown>;
+      if (typeof name !== "string") return [];
+      return [{ name, value: typeof value === "string" ? value : String(value ?? "") }];
+    }),
+  };
+}
+
+/**
+ * Validate and normalize a parsed storage state.
+ *
+ * Normalizing rather than trusting: a state file may have been written by an
+ * older Playwright, hand-edited, or produced by the Puppeteer half of this
+ * package, and a missing `path` or a lowercase `sameSite` should not fail a
+ * suite three calls later with an opaque CDP error.
+ */
+export function normalizeStorageState(raw: unknown): StorageState {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new InvalidStorageStateError("top level is not an object");
+  }
+
+  const state = raw as Record<string, unknown>;
+  const cookies = state.cookies;
+  const origins = state.origins;
+
+  if (cookies !== undefined && !Array.isArray(cookies)) {
+    throw new InvalidStorageStateError("`cookies` is present but not an array");
+  }
+  if (origins !== undefined && !Array.isArray(origins)) {
+    throw new InvalidStorageStateError("`origins` is present but not an array");
+  }
+  if (cookies === undefined && origins === undefined) {
+    throw new InvalidStorageStateError("neither `cookies` nor `origins` is present");
+  }
+
+  return {
+    cookies: (cookies ?? []).map(parseCookie),
+    origins: (origins ?? []).map(parseOrigin),
+  };
+}
+
+/** Parse JSON text into a validated storage state. */
+export function parseStorageState(text: string): StorageState {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    throw new InvalidStorageStateError(`not valid JSON (${(error as Error).message})`);
+  }
+  return normalizeStorageState(parsed);
+}
+
+
+/** Is this domain Google's, rather than the app under test's? */
+export function isGoogleDomain(domain: string): boolean {
+  const bare = domain.replace(/^\./, "").toLowerCase();
+  return GOOGLE_DOMAINS.some((google) => bare === google || bare.endsWith(`.${google}`));
+}
+
+/** Cookies that carry an expiry, i.e. everything but session cookies. */
+function expiringCookies(state: StorageState): StorageStateCookie[] {
+  return state.cookies.filter((cookie) => cookie.expires > 0);
+}
+
+/**
+ * Everything worth knowing about a state file, with no value from it included.
+ *
+ * `now` is injectable because every assertion about expiry otherwise depends on
+ * the wall clock, which makes for a test suite that passes until it doesn't.
+ *
+ * @param now milliseconds since epoch. Defaults to `Date.now()`.
+ */
+export function summarizeStorageState(
+  state: StorageState,
+  options: { now?: number } = {},
+): StorageStateSummary {
+  const nowSeconds = Math.floor((options.now ?? Date.now()) / 1000);
+  const expiring = expiringCookies(state);
+
+  const earliestExpiry =
+    expiring.length > 0 ? Math.min(...expiring.map((cookie) => cookie.expires)) : null;
+
+  const sessionCookies = state.cookies.length - expiring.length;
+  // A session cookie has no expiry to have passed, so a state that is *only*
+  // session cookies is not "expired" — it is simply not portable to a new
+  // browser. Calling it expired would send people re-capturing state that is fine.
+  const expired = expiring.length > 0 && expiring.every((cookie) => cookie.expires <= nowSeconds);
+
+  const live = state.cookies.filter(
+    (cookie) => cookie.expires === SESSION_COOKIE_EXPIRES || cookie.expires > nowSeconds,
+  );
+
+  return {
+    cookieCount: state.cookies.length,
+    originCount: state.origins.length,
+    domains: [...new Set(state.cookies.map((cookie) => cookie.domain))].sort(),
+    cookieNames: [...new Set(state.cookies.map((cookie) => cookie.name))].sort(),
+    localStorageKeys: Object.fromEntries(
+      state.origins.map((origin) => [origin.origin, origin.localStorage.map((entry) => entry.name).sort()]),
+    ),
+    sessionCookies,
+    earliestExpiry,
+    expiresInSeconds: earliestExpiry === null ? null : earliestExpiry - nowSeconds,
+    expired,
+    usable: live.length > 0,
+    hasGoogleCookies: state.cookies.some((cookie) => isGoogleDomain(cookie.domain)),
+  };
+}
+
+/**
+ * Cookies that expire within `withinMs` — the warning before the failure.
+ *
+ * Worth running at the start of a suite: "3 cookies expire in 40 minutes" in the
+ * log beats a flaky-looking selector timeout at minute 41.
+ */
+export function findExpiringCookies(
+  state: StorageState,
+  options: { now?: number; withinMs?: number } = {},
+): StorageStateCookie[] {
+  const nowSeconds = Math.floor((options.now ?? Date.now()) / 1000);
+  const withinSeconds = Math.floor((options.withinMs ?? 60 * 60 * 1000) / 1000);
+
+  return expiringCookies(state).filter((cookie) => cookie.expires - nowSeconds <= withinSeconds);
+}
+
+/**
+ * The same state with every secret replaced by a description of its length.
+ *
+ * Shape, names, domains, flags and expiries survive; cookie values and
+ * `localStorage` values do not. This is the only form of a state file that is
+ * safe to print, log, attach to an issue or return over HTTP — and having it
+ * means the answer to "can I see the state file?" is yes, this one.
+ */
+export function redactStorageState(state: StorageState): StorageState {
+  const redact = (value: string) => `«redacted ${value.length} chars»`;
+
+  return {
+    cookies: state.cookies.map((cookie) => ({ ...cookie, value: redact(cookie.value) })),
+    origins: state.origins.map((origin) => ({
+      origin: origin.origin,
+      localStorage: origin.localStorage.map((entry) => ({ name: entry.name, value: redact(entry.value) })),
+    })),
+  };
+}
+

--- a/packages/test-google-login/src/storage-state.ts
+++ b/packages/test-google-login/src/storage-state.ts
@@ -1,0 +1,135 @@
+/**
+ * Reading, writing, inspecting and redacting a persisted browser session.
+ *
+ * Three things here are the point of the module:
+ *
+ * 1. **Writes are 0600.** A state file is a live credential; the default 0644 is
+ *    not an acceptable mode for one.
+ * 2. **Expiry is reported, not guessed at.** A suite that fails with "element not
+ *    found" because the session lapsed overnight is the single most expensive
+ *    failure mode of this approach, so {@link summarizeStorageState} answers
+ *    "is this still good?" directly.
+ * 3. **Nothing ever prints a value.** {@link redactStorageState} exists so there
+ *    is an obvious safe thing to paste into an issue, and so the CLI has
+ *    something to print that is not the cookies themselves.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+import { ensureAuthDir, codegenCommand } from "./auth-file.js";
+import { parseStorageState, summarizeStorageState } from "./state-core.js";
+import type { StorageState, StorageStateSummary } from "./types.js";
+
+// Re-exported so the Node side has one place to import from; the Worker side
+// imports `./state-core.js` directly and never reaches this module.
+export * from "./state-core.js";
+
+/** Thrown when a state file is absent — carries the command that creates one. */
+export class MissingStorageStateError extends Error {
+  readonly file: string;
+
+  constructor(file: string, hint: string) {
+    super(
+      [
+        `Missing persisted auth state: ${file}`,
+        "",
+        "Create it locally with:",
+        `  ${hint}`,
+        "",
+        "Then complete Google sign-in manually with the dedicated test account and",
+        "close the browser window — Playwright writes the state file on exit.",
+      ].join("\n"),
+    );
+    this.name = "MissingStorageStateError";
+    this.file = file;
+  }
+}
+
+/**
+ * Read a state file from disk.
+ *
+ * @throws {MissingStorageStateError} when the file is absent, with the codegen
+ *   command that creates it — the message is the whole fix, so it belongs in the
+ *   error rather than in documentation the reader has to go find.
+ */
+export function readStorageState(file: string, options: { baseUrl?: string; cwd?: string } = {}): StorageState {
+  let text: string;
+  try {
+    text = fs.readFileSync(file, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new MissingStorageStateError(file, codegenCommand({ file, ...options }));
+    }
+    throw error;
+  }
+  return parseStorageState(text);
+}
+
+/**
+ * Write a state file, owner-read-write only.
+ *
+ * The `chmod` after the write is not redundant: `writeFileSync`'s `mode` applies
+ * only when it creates the file, so re-saving over an existing 0644 state file
+ * would otherwise keep the loose mode it already had.
+ */
+export function writeStorageState(file: string, state: StorageState): string {
+  ensureAuthDir(file);
+  fs.writeFileSync(file, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+
+  try {
+    fs.chmodSync(file, 0o600);
+  } catch {
+    // Windows has no POSIX mode. The file is written, which is what matters.
+  }
+
+  return path.resolve(file);
+}
+
+/**
+ * Tighten an existing state file to 0600 and confirm it parses.
+ *
+ * For the files Playwright writes itself. `context.storageState({ path })` keeps
+ * shapes this package has no type for — `indexedDB: true` adds one — so
+ * round-tripping such a file through {@link writeStorageState} would quietly drop
+ * data the app needs. This validates and chmods in place instead.
+ *
+ * @returns a summary of what the file holds, safe to log
+ * @throws {InvalidStorageStateError} if the file is not a storage state after all
+ */
+export function hardenStorageStateFile(file: string): StorageStateSummary {
+  try {
+    fs.chmodSync(file, 0o600);
+  } catch {
+    // Windows has no POSIX mode; the validation below is still worth doing.
+  }
+
+  return summarizeStorageState(parseStorageState(fs.readFileSync(file, "utf8")));
+}
+
+/**
+ * Throw unless the state is still usable, with a message that says what to do.
+ *
+ * This is what a Playwright setup project calls: it turns "the dashboard heading
+ * never appeared" into "the session expired 6 hours ago, re-capture it like this".
+ */
+export function assertStorageStateUsable(
+  state: StorageState,
+  options: { now?: number; file?: string; baseUrl?: string; cwd?: string } = {},
+): StorageStateSummary {
+  const summary = summarizeStorageState(state, options);
+  if (summary.usable && !summary.expired) return summary;
+
+  const ago =
+    summary.expiresInSeconds === null
+      ? "it carries no usable cookie"
+      : `it expired ${Math.abs(Math.round(summary.expiresInSeconds / 60))} minutes ago`;
+
+  throw new Error(
+    [
+      `The persisted session is no longer usable — ${ago}.`,
+      "",
+      "Re-capture it:",
+      `  ${codegenCommand(options)}`,
+    ].join("\n"),
+  );
+}

--- a/packages/test-google-login/src/types.ts
+++ b/packages/test-google-login/src/types.ts
@@ -1,0 +1,99 @@
+/**
+ * The shapes this package works in.
+ *
+ * `StorageState` is Playwright's `storageState()` output, declared here rather
+ * than imported from `@playwright/test` on purpose: the Worker half of this
+ * package reads the same file inside a Cloudflare isolate, where Playwright is
+ * not installed and cannot be. Keeping the type local is what lets one state
+ * file be produced by Playwright and consumed by Puppeteer.
+ */
+
+/** Playwright's `sameSite` spelling. Puppeteer/CDP uses the same three words. */
+export type SameSite = "Strict" | "Lax" | "None";
+
+/** One cookie as Playwright writes it into a storage-state file. */
+export interface StorageStateCookie {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  /**
+   * Unix seconds, **not** milliseconds — and `-1` for a session cookie, which is
+   * the single most common way to get expiry arithmetic wrong here.
+   */
+  expires: number;
+  httpOnly: boolean;
+  secure: boolean;
+  sameSite: SameSite;
+}
+
+/** `localStorage` for one origin. Playwright groups storage by origin, not by domain. */
+export interface StorageStateOrigin {
+  origin: string;
+  localStorage: { name: string; value: string }[];
+}
+
+/**
+ * A whole persisted browser session: cookies plus per-origin `localStorage`.
+ *
+ * **This is a credential.** A populated instance of this type grants whatever the
+ * signed-in test account can do, which is why nothing in this package logs one,
+ * returns one over HTTP, or writes one anywhere but a 0600 file under
+ * `playwright/.auth/`.
+ */
+export interface StorageState {
+  cookies: StorageStateCookie[];
+  origins: StorageStateOrigin[];
+}
+
+/** What a cookie looks like to Puppeteer's `setCookie`/`cookies` (CDP naming). */
+export interface PuppeteerCookie {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  /** Unix seconds. Absent (not `-1`) for a session cookie. */
+  expires?: number;
+  httpOnly: boolean;
+  secure: boolean;
+  sameSite?: SameSite;
+  /** CDP sets this on read; it is the inverse of "has an expiry". */
+  session?: boolean;
+}
+
+/**
+ * What `summarizeStorageState` reports — everything you would want to know about
+ * a state file without ever seeing a value from it. Safe to print and to log.
+ */
+export interface StorageStateSummary {
+  cookieCount: number;
+  originCount: number;
+  /** Cookie domains, deduped and sorted. Names and values are never included. */
+  domains: string[];
+  /** Cookie names, deduped and sorted — a name is not a secret, a value is. */
+  cookieNames: string[];
+  /** `localStorage` keys per origin, values omitted. */
+  localStorageKeys: Record<string, string[]>;
+  /** How many cookies carry no expiry and die with the browser. */
+  sessionCookies: number;
+  /** Earliest expiry among cookies that have one, as Unix seconds; `null` if none do. */
+  earliestExpiry: number | null;
+  /** Seconds until `earliestExpiry`; negative once it has passed. `null` if none do. */
+  expiresInSeconds: number | null;
+  /** True when every cookie that had an expiry has passed it. */
+  expired: boolean;
+  /** True when the state still has at least one cookie a browser would send. */
+  usable: boolean;
+  /** True when any cookie belongs to a Google domain. */
+  hasGoogleCookies: boolean;
+}
+
+/** The minimum of a Puppeteer/Playwright `Page` that this package calls. */
+export interface PageLike {
+  goto(url: string, options?: Record<string, unknown>): Promise<unknown>;
+  evaluate<T>(fn: (...args: never[]) => T, ...args: unknown[]): Promise<T>;
+  url(): string;
+  setCookie?(...cookies: PuppeteerCookie[]): Promise<void>;
+  cookies?(...urls: string[]): Promise<PuppeteerCookie[]>;
+  deleteCookie?(...cookies: { name: string; domain?: string; path?: string }[]): Promise<void>;
+}

--- a/packages/test-google-login/src/worker.ts
+++ b/packages/test-google-login/src/worker.ts
@@ -1,0 +1,523 @@
+/**
+ * The Cloudflare half: a Durable Object holding one Browser Rendering session,
+ * replaying a persisted Google login against a deployed app.
+ *
+ * Why a Durable Object at all — a Worker could call `puppeteer.launch()` directly.
+ * Two reasons, and both are why Cloudflare's own guidance points here:
+ *
+ * 1. **A browser launch costs seconds and is billed.** A DO is a single addressable
+ *    instance, so the browser survives between requests and a suite of twenty
+ *    checks pays for one launch. An alarm closes it once idle, because an
+ *    *unclosed* browser is billed too.
+ * 2. **Concurrency.** Browser Rendering allows a small number of concurrent
+ *    sessions per account. Routing every check for a named session through one DO
+ *    serialises them instead of tripping that limit under a parallel test run.
+ *
+ * Everything about this module is "test infrastructure exposed over HTTP", so the
+ * security posture is deliberate and strict:
+ *
+ * - Every request must present `TEST_AUTH_SECRET`; if the secret is not configured
+ *   the Worker refuses *all* requests rather than serving an open browser.
+ * - `GET /state` returns a redacted summary. The stored session is never readable
+ *   back over HTTP — an endpoint that hands out live cookies is a credential
+ *   exfiltration endpoint with a test-shaped name.
+ * - `POST /login` (real Google sign-in) is off unless `ALLOW_REAL_GOOGLE_LOGIN` is
+ *   exactly "true".
+ *
+ * This module imports no Node builtin. See `state-core.ts` for why that matters.
+ */
+import { normalizeStorageState, redactStorageState, summarizeStorageState } from "./state-core.js";
+import { applyStorageState, extractStorageState } from "./puppeteer-state.js";
+import { AUTH_HEADER, isAuthorized } from "./secret.js";
+import type { PageLike, StorageState, StorageStateSummary } from "./types.js";
+
+/** Bindings this Worker expects. See `wrangler.jsonc`. */
+export interface Env {
+  /** Browser Rendering binding. Requires the Workers Paid plan. */
+  BROWSER: unknown;
+  /** The `GoogleLoginBrowser` namespace. */
+  BROWSER_SESSION: DurableObjectNamespaceLike;
+  /** Shared secret every request must present. Unset = the Worker serves nothing. */
+  TEST_AUTH_SECRET?: string;
+  /** "true" to enable `POST /login`. Anything else leaves it disabled. */
+  ALLOW_REAL_GOOGLE_LOGIN?: string;
+  GOOGLE_TEST_EMAIL?: string;
+  GOOGLE_TEST_PASSWORD?: string;
+  /** Minutes of inactivity before the browser is closed. Default 3. */
+  BROWSER_IDLE_MINUTES?: string;
+}
+
+/** The shape of a DO namespace, declared structurally so tests can fake it. */
+export interface DurableObjectNamespaceLike {
+  idFromName(name: string): unknown;
+  get(id: unknown): { fetch(request: Request): Promise<Response> };
+}
+
+const KEY_STATE = "storage-state";
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body, null, 2), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}
+
+/**
+ * Route a request to the DO that owns its session, after checking the secret.
+ *
+ * The session name comes from `?session=` and defaults to `default`. Distinct
+ * names are distinct browsers — useful for one signed-in and one anonymous
+ * session in the same suite, and for keeping two concurrent CI jobs apart.
+ */
+export async function handleRequest(request: Request, env: Env): Promise<Response> {
+  if (!env.TEST_AUTH_SECRET) {
+    return json(
+      {
+        error: "not_configured",
+        message:
+          "TEST_AUTH_SECRET is not set, so this Worker refuses every request. " +
+          "Set it with `wrangler secret put TEST_AUTH_SECRET`.",
+      },
+      503,
+    );
+  }
+
+  if (!isAuthorized(request.headers, env.TEST_AUTH_SECRET)) {
+    // No detail, and no hint about which part was wrong.
+    return new Response("Unauthorized", { status: 401, headers: { "x-required-header": AUTH_HEADER } });
+  }
+
+  const url = new URL(request.url);
+  if (url.pathname === "/health") return json({ ok: true });
+
+  const session = url.searchParams.get("session") || "default";
+  const stub = env.BROWSER_SESSION.get(env.BROWSER_SESSION.idFromName(session));
+
+  return stub.fetch(request);
+}
+
+export default {
+  fetch: handleRequest,
+};
+
+/** The minimum of `@cloudflare/puppeteer` this module calls. */
+export interface PuppeteerLike {
+  launch(binding: unknown): Promise<BrowserLike>;
+  connect?(binding: unknown, sessionId: string): Promise<BrowserLike>;
+}
+
+export interface BrowserLike {
+  newPage(): Promise<PageLike & { close(): Promise<void>; title(): Promise<string>; screenshot(options?: Record<string, unknown>): Promise<ArrayBuffer | Uint8Array> }>;
+  close(): Promise<void>;
+  isConnected?(): boolean;
+}
+
+/**
+ * Resolve `@cloudflare/puppeteer` at call time rather than import time.
+ *
+ * It is an optional peer dependency: the Playwright half of this package is
+ * useful on its own, and a hard import would make every consumer install a
+ * Cloudflare-only module. A test can also hand in a fake and exercise the whole
+ * Durable Object without a browser.
+ */
+let puppeteerOverride: PuppeteerLike | undefined;
+
+/** Inject a Puppeteer implementation — for tests, and for bring-your-own builds. */
+export function setPuppeteer(implementation: PuppeteerLike | undefined): void {
+  puppeteerOverride = implementation;
+}
+
+async function getPuppeteer(): Promise<PuppeteerLike> {
+  if (puppeteerOverride) return puppeteerOverride;
+
+  const loaded = (await import("@cloudflare/puppeteer")) as unknown as {
+    default?: PuppeteerLike;
+    launch?: PuppeteerLike["launch"];
+  };
+
+  const implementation = loaded.default ?? (loaded as PuppeteerLike);
+  if (typeof implementation?.launch !== "function") {
+    throw new TypeError(
+      "Could not load @cloudflare/puppeteer. Install it in the Worker that deploys this, or call " +
+        "setPuppeteer() with your own implementation.",
+    );
+  }
+
+  return implementation;
+}
+
+/** State-checking result, returned by `POST /check`. */
+export interface CheckResult {
+  authenticated: boolean;
+  status: number | null;
+  url: string;
+  title: string;
+  /** Why the check concluded what it did — the useful half when it says `false`. */
+  reason: string;
+  applied: { cookiesSet: number; originsRestored: string[]; skipped: { origin: string; reason: string }[] };
+}
+
+/**
+ * Holds one browser and one persisted session.
+ *
+ * Written against a structural `state`/`env` rather than extending
+ * `DurableObject`, so the class is constructible in a plain Vitest process. The
+ * runtime passes the real ones.
+ */
+export class GoogleLoginBrowser {
+  private readonly storage: DurableObjectStorageLike;
+  private readonly env: Env;
+  private browser: BrowserLike | undefined;
+
+  constructor(state: { storage: DurableObjectStorageLike }, env: Env) {
+    this.storage = state.storage;
+    this.env = env;
+  }
+
+  private get idleMs(): number {
+    const minutes = Number.parseFloat(this.env.BROWSER_IDLE_MINUTES ?? "3");
+    return (Number.isFinite(minutes) && minutes > 0 ? minutes : 3) * 60_000;
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    try {
+      switch (`${request.method} ${url.pathname}`) {
+        case "POST /state":
+          return await this.putState(request);
+        case "GET /state":
+          return await this.describeState();
+        case "DELETE /state":
+          return await this.clearState();
+        case "POST /check":
+          return await this.check(request);
+        case "POST /login":
+          return await this.login(request);
+        case "POST /close":
+          await this.closeBrowser();
+          return json({ closed: true });
+        default:
+          return json({ error: "not_found", message: `No route for ${request.method} ${url.pathname}` }, 404);
+      }
+    } catch (error) {
+      // The message may quote a selector or a URL, never a cookie: every path that
+      // handles state here passes it straight into Puppeteer without formatting it.
+      return json({ error: "failed", message: (error as Error).message }, 500);
+    }
+  }
+
+  /**
+   * Store a storage state for this session.
+   *
+   * Validated on the way in, so a malformed upload fails here with a precise
+   * reason rather than as an opaque CDP error during the next check.
+   */
+  private async putState(request: Request): Promise<Response> {
+    const state = normalizeStorageState(await request.json());
+    await this.storage.put(KEY_STATE, state);
+
+    // The response describes the state; it never echoes it.
+    return json({ stored: true, summary: summarizeStorageState(state) });
+  }
+
+  /**
+   * Describe the stored state — redacted, always.
+   *
+   * There is no route that returns the live values. That is the point: this Worker
+   * can be handed to CI without handing CI a way to read the session back out.
+   */
+  private async describeState(): Promise<Response> {
+    const state = await this.storage.get<StorageState>(KEY_STATE);
+    if (!state) return json({ present: false }, 404);
+
+    return json({
+      present: true,
+      summary: summarizeStorageState(state),
+      redacted: redactStorageState(state),
+    });
+  }
+
+  private async clearState(): Promise<Response> {
+    const existed = await this.storage.delete(KEY_STATE);
+    await this.closeBrowser();
+    return json({ cleared: existed });
+  }
+
+  /**
+   * Replay the stored session against a URL and report whether it is signed in.
+   *
+   * "Signed in" is whatever you say it is: `expectSelector` is checked in the page
+   * and `rejectUrl` catches the redirect-to-login case, which is the failure that
+   * otherwise looks like a passing 200.
+   */
+  private async check(request: Request): Promise<Response> {
+    const body = (await request.json()) as {
+      url?: string;
+      expectSelector?: string;
+      rejectUrl?: string;
+      origins?: string[];
+      screenshot?: boolean;
+    };
+
+    if (!body.url) return json({ error: "bad_request", message: "`url` is required" }, 400);
+
+    const state = await this.storage.get<StorageState>(KEY_STATE);
+    if (!state) {
+      return json(
+        {
+          error: "no_state",
+          message: "No stored session for this name. POST /state with a Playwright storage state first.",
+        },
+        409,
+      );
+    }
+
+    const browser = await this.ensureBrowser();
+    const page = await browser.newPage();
+
+    try {
+      const applied = await applyStorageState(page, state, { origins: body.origins });
+
+      const response = (await page.goto(body.url, { waitUntil: "domcontentloaded" })) as {
+        status?: () => number;
+      } | null;
+
+      const landedUrl = page.url();
+      const title = await page.title();
+
+      let authenticated = true;
+      let reason = "navigated without being redirected away";
+
+      if (body.rejectUrl && landedUrl.includes(body.rejectUrl)) {
+        authenticated = false;
+        reason = `redirected to ${body.rejectUrl} — the session was not accepted`;
+      } else if (body.expectSelector) {
+        const found = await page.evaluate(
+          ((selector: string) => document.querySelector(selector) !== null) as never,
+          body.expectSelector,
+        );
+        authenticated = found === true;
+        reason = found
+          ? `found ${body.expectSelector}`
+          : `${body.expectSelector} is not on the page — probably signed out`;
+      }
+
+      const result: CheckResult & { screenshot?: string } = {
+        authenticated,
+        status: typeof response?.status === "function" ? response.status() : null,
+        url: landedUrl,
+        title,
+        reason,
+        applied,
+      };
+
+      if (body.screenshot) {
+        const shot = await page.screenshot({ type: "png" });
+        result.screenshot = toBase64(shot);
+      }
+
+      return json(result);
+    } finally {
+      // The page closes; the browser does not. That is the whole reason this is a
+      // Durable Object.
+      await page.close();
+      await this.touch();
+    }
+  }
+
+  /**
+   * Sign in to Google for real, in the Worker, and store the resulting session.
+   *
+   * Gated twice — the flag and the credentials — and still the path you should
+   * reach for last. Read {@link signInWithGoogle}'s notes in `google-login.ts`:
+   * they apply here in full, with the extra wrinkle that a datacentre IP makes
+   * Google's risk checks more likely, not less.
+   */
+  private async login(request: Request): Promise<Response> {
+    if (this.env.ALLOW_REAL_GOOGLE_LOGIN !== "true") {
+      return json(
+        {
+          error: "disabled",
+          message:
+            'Real Google sign-in is disabled. Set ALLOW_REAL_GOOGLE_LOGIN="true" and the ' +
+            "GOOGLE_TEST_EMAIL / GOOGLE_TEST_PASSWORD secrets to enable POST /login — and prefer " +
+            "capturing the session locally with `playwright codegen` instead.",
+        },
+        403,
+      );
+    }
+
+    const email = this.env.GOOGLE_TEST_EMAIL;
+    const password = this.env.GOOGLE_TEST_PASSWORD;
+    if (!email || !password) {
+      return json(
+        { error: "disabled", message: "GOOGLE_TEST_EMAIL and GOOGLE_TEST_PASSWORD must both be set." },
+        403,
+      );
+    }
+
+    const body = (await request.json()) as {
+      loginUrl?: string;
+      signInSelector?: string;
+      expectUrl?: string;
+      origins?: string[];
+      /** How long to wait to land on `expectUrl`. Capped at two minutes. */
+      timeoutMs?: number;
+    };
+
+    if (!body.loginUrl) return json({ error: "bad_request", message: "`loginUrl` is required" }, 400);
+
+    // Required, not defaulted to the login page's origin: the flow *starts* on
+    // that origin, so an origin match is satisfied before Google is involved at
+    // all and every login "succeeds". Name the authenticated URL instead.
+    if (!body.expectUrl) {
+      return json(
+        {
+          error: "bad_request",
+          message:
+            "`expectUrl` is required — a substring of the URL you land on once signed in, e.g. \"/dashboard\". " +
+            "It is not defaulted to your origin, because the login page is on that origin too and the wait " +
+            "would pass before sign-in even started.",
+        },
+        400,
+      );
+    }
+
+    const browser = await this.ensureBrowser();
+    const page = await browser.newPage();
+
+    try {
+      await page.goto(body.loginUrl, { waitUntil: "domcontentloaded" });
+
+      // Typed through the page rather than assembled into a script string: a
+      // password interpolated into `page.evaluate` source ends up in CDP logs.
+      await clickSelector(page, body.signInSelector ?? 'a[href*="google"], button[data-provider="google"]');
+      await typeInto(page, 'input[type="email"]', email);
+      await clickSelector(page, "#identifierNext button, #identifierNext");
+      await typeInto(page, 'input[type="password"]', password);
+      await clickSelector(page, "#passwordNext button, #passwordNext");
+
+      await waitForUrlContaining(
+        page,
+        body.expectUrl,
+        // Capped rather than trusted: an unbounded wait pins a billed browser
+        // session open for as long as the caller likes.
+        Math.min(Math.max(body.timeoutMs ?? 30_000, 250), 120_000),
+      );
+
+      const state = await extractStorageState(page, { origins: body.origins });
+      await this.storage.put(KEY_STATE, state);
+
+      return json({ stored: true, summary: summarizeStorageState(state) });
+    } finally {
+      await page.close();
+      await this.touch();
+    }
+  }
+
+  private async ensureBrowser(): Promise<BrowserLike> {
+    if (this.browser?.isConnected?.() === false) this.browser = undefined;
+
+    if (!this.browser) {
+      const puppeteer = await getPuppeteer();
+      this.browser = await puppeteer.launch(this.env.BROWSER);
+    }
+
+    await this.touch();
+    return this.browser;
+  }
+
+  /** Push the idle alarm out. Called after every request that used the browser. */
+  private async touch(): Promise<void> {
+    await this.storage.setAlarm(Date.now() + this.idleMs);
+  }
+
+  /**
+   * Close the browser when the session goes quiet.
+   *
+   * Not an optimisation — a Browser Rendering session left open is billed and
+   * counts against the account's concurrency limit, so the alarm is the difference
+   * between a test tool and a surprise invoice.
+   */
+  async alarm(): Promise<void> {
+    await this.closeBrowser();
+  }
+
+  private async closeBrowser(): Promise<void> {
+    const browser = this.browser;
+    this.browser = undefined;
+    if (!browser) return;
+
+    try {
+      await browser.close();
+    } catch {
+      // Already gone — Browser Rendering reaps idle sessions on its own too.
+    }
+  }
+}
+
+/** The part of a DO's storage this class uses. */
+export interface DurableObjectStorageLike {
+  get<T>(key: string): Promise<T | undefined>;
+  put(key: string, value: unknown): Promise<void>;
+  delete(key: string): Promise<boolean>;
+  setAlarm(time: number): Promise<void>;
+}
+
+async function clickSelector(page: PageLike, selector: string): Promise<void> {
+  await page.evaluate(
+    ((css: string) => {
+      const element = document.querySelector(css) as HTMLElement | null;
+      if (!element) throw new Error(`No element matched ${css}`);
+      element.click();
+    }) as never,
+    selector,
+  );
+}
+
+async function typeInto(page: PageLike, selector: string, value: string): Promise<void> {
+  await page.evaluate(
+    (([css, text]: [string, string]) => {
+      const element = document.querySelector(css) as HTMLInputElement | null;
+      if (!element) throw new Error(`No element matched ${css}`);
+      element.focus();
+      element.value = text;
+      element.dispatchEvent(new Event("input", { bubbles: true }));
+      element.dispatchEvent(new Event("change", { bubbles: true }));
+    }) as never,
+    [selector, value],
+  );
+}
+
+/**
+ * Poll until the page's URL contains `fragment`.
+ *
+ * Hand-rolled rather than `page.waitForNavigation`: a Google sign-in is several
+ * navigations, and the interesting condition is "we are back on our own origin",
+ * not "a navigation happened".
+ */
+async function waitForUrlContaining(page: PageLike, fragment: string, timeoutMs = 30_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (page.url().includes(fragment)) return;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  throw new Error(
+    `Timed out waiting for a URL containing "${fragment}" — currently ${page.url()}. ` +
+      "A consent screen, a device check or MFA looks like this, and none of them should be " +
+      "automated: capture the session by hand instead.",
+  );
+}
+
+function toBase64(bytes: ArrayBuffer | Uint8Array): string {
+  const view = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  let binary = "";
+  for (const byte of view) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+/** Exported for tests and for the summary type. */
+export type { StorageStateSummary };

--- a/packages/test-google-login/test/auth-file.test.ts
+++ b/packages/test-google-login/test/auth-file.test.ts
@@ -1,0 +1,164 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_AUTH_FILE,
+  GITIGNORE_LINES,
+  codegenCommand,
+  ensureAuthDir,
+  ensureGitignored,
+  isIgnored,
+  resolveAuthFile,
+  writeAuthDirGitignore,
+} from "../src/auth-file.js";
+
+let cwd: string;
+
+beforeEach(() => {
+  cwd = fs.mkdtempSync(path.join(os.tmpdir(), "tgl-auth-"));
+});
+
+afterEach(() => {
+  fs.rmSync(cwd, { recursive: true, force: true });
+});
+
+describe("resolveAuthFile", () => {
+  it("defaults to Playwright's documented location", () => {
+    expect(resolveAuthFile({ cwd, env: {} })).toBe(path.join(cwd, DEFAULT_AUTH_FILE));
+  });
+
+  it("prefers an explicit file over the env var", () => {
+    const resolved = resolveAuthFile({ cwd, file: "ci/state.json", env: { TEST_GOOGLE_LOGIN_STATE: "env.json" } });
+    expect(resolved).toBe(path.join(cwd, "ci/state.json"));
+  });
+
+  it("falls back to the env var when no file is given", () => {
+    const resolved = resolveAuthFile({ cwd, env: { TEST_GOOGLE_LOGIN_STATE: "env/state.json" } });
+    expect(resolved).toBe(path.join(cwd, "env/state.json"));
+  });
+
+  it("leaves an absolute path alone", () => {
+    const absolute = path.join(os.tmpdir(), "elsewhere", "state.json");
+    expect(resolveAuthFile({ cwd, file: absolute, env: {} })).toBe(absolute);
+  });
+});
+
+describe("ensureAuthDir", () => {
+  it("creates the directory owner-only", () => {
+    const file = path.join(cwd, "playwright/.auth/google-test-user.json");
+    const dir = ensureAuthDir(file);
+
+    expect(fs.existsSync(dir)).toBe(true);
+    // The whole point: a directory holding live session cookies must not be
+    // group- or world-readable on a shared machine.
+    expect(fs.statSync(dir).mode & 0o777).toBe(0o700);
+  });
+
+  it("tightens a directory that already existed with loose permissions", () => {
+    const dir = path.join(cwd, "playwright/.auth");
+    fs.mkdirSync(dir, { recursive: true, mode: 0o755 });
+    fs.chmodSync(dir, 0o755);
+
+    ensureAuthDir(path.join(dir, "state.json"));
+
+    expect(fs.statSync(dir).mode & 0o777).toBe(0o700);
+  });
+});
+
+describe("writeAuthDirGitignore", () => {
+  it("ignores everything inside the auth directory", () => {
+    const written = writeAuthDirGitignore(path.join(cwd, "playwright/.auth/state.json"));
+    expect(fs.readFileSync(written, "utf8")).toMatch(/^\*$/m);
+  });
+});
+
+describe("isIgnored", () => {
+  it.each([
+    ["playwright/.auth/", "playwright/.auth/"],
+    ["playwright/.auth", "playwright/.auth/"],
+    ["/playwright/.auth/", "playwright/.auth/"],
+    ["playwright/", "playwright/.auth/"],
+  ])("treats %j as covering %j", (line, pattern) => {
+    expect(isIgnored(line, pattern)).toBe(true);
+  });
+
+  it("ignores comments and blank lines", () => {
+    expect(isIgnored("# playwright/.auth/\n\n", "playwright/.auth/")).toBe(false);
+  });
+
+  it("does not accept a negation as coverage", () => {
+    expect(isIgnored("!playwright/.auth/", "playwright/.auth/")).toBe(false);
+  });
+
+  it("does not treat a sibling directory as coverage", () => {
+    expect(isIgnored("playwright-report/", "playwright/.auth/")).toBe(false);
+  });
+});
+
+describe("ensureGitignored", () => {
+  it("creates .gitignore with every rule when there is none", () => {
+    const result = ensureGitignored({ cwd });
+
+    expect(result.added).toEqual([...GITIGNORE_LINES]);
+    const written = fs.readFileSync(result.file, "utf8");
+    for (const line of GITIGNORE_LINES) expect(written).toContain(line);
+  });
+
+  it("is idempotent — a second run adds nothing", () => {
+    ensureGitignored({ cwd });
+    const before = fs.readFileSync(path.join(cwd, ".gitignore"), "utf8");
+
+    const second = ensureGitignored({ cwd });
+
+    expect(second.added).toEqual([]);
+    expect(second.alreadyIgnored).toEqual([...GITIGNORE_LINES]);
+    expect(fs.readFileSync(path.join(cwd, ".gitignore"), "utf8")).toBe(before);
+  });
+
+  it("appends without disturbing what is already there", () => {
+    fs.writeFileSync(path.join(cwd, ".gitignore"), "node_modules\ndist\n");
+
+    ensureGitignored({ cwd });
+
+    const written = fs.readFileSync(path.join(cwd, ".gitignore"), "utf8");
+    expect(written.startsWith("node_modules\ndist\n")).toBe(true);
+    expect(written).toContain("playwright/.auth/");
+  });
+
+  it("adds a separating newline to a file that did not end with one", () => {
+    fs.writeFileSync(path.join(cwd, ".gitignore"), "node_modules");
+
+    ensureGitignored({ cwd });
+
+    const lines = fs.readFileSync(path.join(cwd, ".gitignore"), "utf8").split("\n");
+    expect(lines[0]).toBe("node_modules");
+    expect(lines).toContain("playwright/.auth/");
+  });
+
+  it("recognises a broader existing rule rather than duplicating it", () => {
+    fs.writeFileSync(path.join(cwd, ".gitignore"), "playwright/\n.env\n.env.*\n!.env.example\n");
+
+    const result = ensureGitignored({ cwd });
+
+    expect(result.added).toEqual([]);
+  });
+});
+
+describe("codegenCommand", () => {
+  it("carries the state path the suite actually reads", () => {
+    const command = codegenCommand({ cwd, file: "playwright/.auth/google-test-user.json" });
+
+    expect(command).toBe(
+      "npx playwright codegen --save-storage=playwright/.auth/google-test-user.json http://localhost:3000",
+    );
+  });
+
+  it("uses the given base URL", () => {
+    expect(codegenCommand({ cwd, baseUrl: "https://staging.example.test" })).toContain(
+      "https://staging.example.test",
+    );
+  });
+});

--- a/packages/test-google-login/test/cli.test.ts
+++ b/packages/test-google-login/test/cli.test.ts
@@ -1,0 +1,241 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { parseArgs, runCli } from "../src/cli.js";
+import { writeStorageState } from "../src/storage-state.js";
+import { NOW_SECONDS, sampleState } from "./fixtures.js";
+
+let cwd: string;
+
+beforeEach(() => {
+  cwd = fs.mkdtempSync(path.join(os.tmpdir(), "tgl-cli-"));
+});
+
+afterEach(() => {
+  fs.rmSync(cwd, { recursive: true, force: true });
+});
+
+function capture() {
+  const out: string[] = [];
+  const err: string[] = [];
+  return { out, err, io: { out: (line: string) => out.push(line), err: (line: string) => err.push(line), cwd } };
+}
+
+const text = (lines: string[]) => lines.join("\n");
+
+describe("parseArgs", () => {
+  it("reads --flag value", () => {
+    expect(parseArgs(["check", "--file", "a.json"])).toEqual({ command: "check", flags: { file: "a.json" } });
+  });
+
+  it("reads --flag=value", () => {
+    expect(parseArgs(["check", "--file=a.json"])).toEqual({ command: "check", flags: { file: "a.json" } });
+  });
+
+  it("treats a trailing flag as a boolean", () => {
+    expect(parseArgs(["check", "--json"])).toEqual({ command: "check", flags: { json: true } });
+  });
+
+  it("does not swallow the next flag as a value", () => {
+    expect(parseArgs(["check", "--json", "--file", "a.json"])).toEqual({
+      command: "check",
+      flags: { json: true, file: "a.json" },
+    });
+  });
+
+  it("defaults to help with no arguments", () => {
+    expect(parseArgs([])).toEqual({ command: "help", flags: {} });
+  });
+});
+
+describe("init", () => {
+  it("creates the directory, both gitignores, and prints the codegen command", async () => {
+    const { out, io } = capture();
+
+    const code = await runCli(["init"], io);
+
+    expect(code).toBe(0);
+    expect(fs.statSync(path.join(cwd, "playwright/.auth")).mode & 0o777).toBe(0o700);
+    expect(fs.readFileSync(path.join(cwd, "playwright/.auth/.gitignore"), "utf8")).toMatch(/^\*$/m);
+    expect(fs.readFileSync(path.join(cwd, ".gitignore"), "utf8")).toContain("playwright/.auth/");
+    expect(text(out)).toContain(
+      "npx playwright codegen --save-storage=playwright/.auth/google-test-user.json http://localhost:3000",
+    );
+  });
+
+  it("uses the app URL it is given", async () => {
+    const { out, io } = capture();
+
+    await runCli(["init", "--url", "http://localhost:5173"], io);
+
+    expect(text(out)).toContain("http://localhost:5173");
+  });
+
+  it("says so rather than duplicating rules on a second run", async () => {
+    await runCli(["init"], capture().io);
+    const { out, io } = capture();
+
+    await runCli(["init"], io);
+
+    expect(text(out)).toContain(".gitignore already covers");
+  });
+
+  it("tells you to sign in by hand, and why", async () => {
+    const { out, io } = capture();
+
+    await runCli(["init"], io);
+
+    expect(text(out)).toMatch(/MFA, CAPTCHA and device checks/);
+  });
+});
+
+describe("check", () => {
+  it("reports a healthy session and exits 0", async () => {
+    writeStorageState(path.join(cwd, "playwright/.auth/google-test-user.json"), sampleState());
+    const { out, io } = capture();
+
+    const code = await runCli(["check"], io);
+
+    expect(code).toBe(0);
+    expect(text(out)).toContain("Cookies      3 (1 session-only)");
+    expect(text(out)).toContain("Google cookies present: yes");
+  });
+
+  it("never prints a cookie value", async () => {
+    writeStorageState(path.join(cwd, "playwright/.auth/google-test-user.json"), sampleState());
+    const { out, err, io } = capture();
+
+    await runCli(["check"], io);
+
+    const printed = text([...out, ...err]);
+    for (const cookie of sampleState().cookies) expect(printed).not.toContain(cookie.value);
+  });
+
+  it("exits 1 and prints the codegen command when there is no session yet", async () => {
+    const { err, io } = capture();
+
+    const code = await runCli(["check"], io);
+
+    expect(code).toBe(1);
+    expect(text(err)).toContain("playwright codegen --save-storage=");
+  });
+
+  it("exits 2 for a file that exists but is not a storage state", async () => {
+    const file = path.join(cwd, "playwright/.auth/google-test-user.json");
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, "<html>login page</html>");
+    const { err, io } = capture();
+
+    // Distinct from 1: a missing file means "capture one", a malformed file means
+    // "something wrote the wrong thing there".
+    expect(await runCli(["check"], io)).toBe(2);
+    expect(text(err)).toMatch(/not valid JSON/);
+  });
+
+  it("exits 1 on an expired session and says how to refresh it", async () => {
+    writeStorageState(path.join(cwd, "playwright/.auth/google-test-user.json"), {
+      cookies: [{ ...sampleState().cookies[0], expires: NOW_SECONDS - 3600 }],
+      origins: [],
+    });
+    const { err, io } = capture();
+
+    expect(await runCli(["check"], io)).toBe(1);
+    expect(text(err)).toContain("no longer usable");
+    expect(text(err)).toContain("playwright codegen");
+  });
+
+  it("warns about cookies expiring inside the window", async () => {
+    writeStorageState(path.join(cwd, "state.json"), {
+      cookies: [{ ...sampleState().cookies[0], name: "soon", expires: Math.floor(Date.now() / 1000) + 600 }],
+      origins: [],
+    });
+    const { out, io } = capture();
+
+    await runCli(["check", "--file", "state.json", "--within", "30"], io);
+
+    expect(text(out)).toContain("⚠ 1 cookie(s) expire within 30 minutes: soon");
+  });
+
+  it("emits machine-readable output for --json", async () => {
+    writeStorageState(path.join(cwd, "state.json"), sampleState());
+    const { out, io } = capture();
+
+    await runCli(["check", "--file", "state.json", "--json"], io);
+
+    const parsed = JSON.parse(text(out)) as { summary: { cookieCount: number }; expiringSoon: string[] };
+    expect(parsed.summary.cookieCount).toBe(3);
+    expect(JSON.stringify(parsed)).not.toContain("sess_abcdef0123456789");
+  });
+
+  it("says plainly when a session has no expiry to report", async () => {
+    writeStorageState(path.join(cwd, "state.json"), { cookies: [sampleState().cookies[2]], origins: [] });
+    const { out, io } = capture();
+
+    await runCli(["check", "--file", "state.json"], io);
+
+    expect(text(out)).toContain("dies with the browser");
+  });
+});
+
+describe("redact", () => {
+  it("prints a shareable copy and nothing secret", async () => {
+    writeStorageState(path.join(cwd, "state.json"), sampleState());
+    const { out, io } = capture();
+
+    const code = await runCli(["redact", "--file", "state.json"], io);
+
+    expect(code).toBe(0);
+    const printed = text(out);
+    expect(printed).toContain("«redacted");
+    expect(printed).toContain("app_session");
+    for (const cookie of sampleState().cookies) expect(printed).not.toContain(cookie.value);
+    expect(() => JSON.parse(printed)).not.toThrow();
+  });
+
+  it("exits 1 with the reason when there is nothing to redact", async () => {
+    const { err, io } = capture();
+
+    expect(await runCli(["redact"], io)).toBe(1);
+    expect(text(err)).toContain("Missing persisted auth state");
+  });
+});
+
+describe("clear", () => {
+  it("deletes the session", async () => {
+    const file = path.join(cwd, "playwright/.auth/google-test-user.json");
+    writeStorageState(file, sampleState());
+    const { out, io } = capture();
+
+    expect(await runCli(["clear"], io)).toBe(0);
+    expect(fs.existsSync(file)).toBe(false);
+    expect(text(out)).toContain("Deleted");
+  });
+
+  it("is not an error when there is nothing to delete", async () => {
+    const { out, io } = capture();
+
+    expect(await runCli(["clear"], io)).toBe(0);
+    expect(text(out)).toContain("Nothing to clear");
+  });
+});
+
+describe("help", () => {
+  it("documents every command and restates the security boundary", async () => {
+    const { out, io } = capture();
+
+    expect(await runCli(["help"], io)).toBe(0);
+    const help = text(out);
+    for (const command of ["init", "check", "redact", "clear"]) expect(help).toContain(command);
+    expect(help).toContain("never committed");
+  });
+
+  it("exits 1 and shows help for an unknown command", async () => {
+    const { err, io } = capture();
+
+    expect(await runCli(["frobnicate"], io)).toBe(1);
+    expect(text(err)).toContain("Unknown command: frobnicate");
+  });
+});

--- a/packages/test-google-login/test/fixtures.ts
+++ b/packages/test-google-login/test/fixtures.ts
@@ -1,0 +1,291 @@
+/**
+ * Shared fixtures: one realistic storage state, and fakes standing in for a
+ * Puppeteer page, a Durable Object's storage and Playwright's fixtures.
+ *
+ * The fakes record what they were called with, because most of what is worth
+ * asserting in this package is *ordering* and *what was not sent* — cookies
+ * before navigation, no password in an evaluate source, no cookie value in an
+ * HTTP response.
+ */
+import type { PuppeteerCookie, StorageState } from "../src/types.js";
+
+/** A fixed "now" so every expiry assertion is deterministic. 2026-09-12T00:00:00Z. */
+export const NOW_MS = Date.UTC(2026, 8, 12, 0, 0, 0);
+export const NOW_SECONDS = Math.floor(NOW_MS / 1000);
+
+export const HOUR = 3600;
+
+/**
+ * A state file shaped like one a real Google sign-in produces: the app's own
+ * session cookie, a Google `SID`, a session-only CSRF cookie, and an access token
+ * in the app origin's localStorage.
+ */
+export function sampleState(overrides: Partial<StorageState> = {}): StorageState {
+  return {
+    cookies: [
+      {
+        name: "app_session",
+        value: "sess_abcdef0123456789",
+        domain: "app.example.test",
+        path: "/",
+        expires: NOW_SECONDS + 12 * HOUR,
+        httpOnly: true,
+        secure: true,
+        sameSite: "Lax",
+      },
+      {
+        name: "SID",
+        value: "google-sid-value-xyz",
+        domain: ".google.com",
+        path: "/",
+        expires: NOW_SECONDS + 48 * HOUR,
+        httpOnly: true,
+        secure: true,
+        sameSite: "None",
+      },
+      {
+        name: "csrf",
+        value: "csrf-token-0001",
+        domain: "app.example.test",
+        path: "/",
+        expires: -1,
+        httpOnly: false,
+        secure: true,
+        sameSite: "Strict",
+      },
+    ],
+    origins: [
+      {
+        origin: "https://app.example.test",
+        localStorage: [
+          { name: "access_token", value: "ya29.a0AfH6SMB-token" },
+          { name: "theme", value: "dark" },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+export interface RecordedCall {
+  method: string;
+  args: unknown[];
+}
+
+/** A Puppeteer-ish page that records everything and keeps a localStorage map. */
+export class FakePage {
+  readonly calls: RecordedCall[] = [];
+  readonly cookiesSet: PuppeteerCookie[] = [];
+  readonly storage = new Map<string, Map<string, string>>();
+  /** Elements `document.querySelector` should find, keyed by selector. */
+  readonly selectors = new Map<string, unknown>();
+
+  private currentUrl = "about:blank";
+  private readonly failOn: Set<string>;
+  private readonly gotoRedirects: Map<string, string>;
+
+  constructor(options: { failOn?: string[]; redirects?: Record<string, string>; cookies?: PuppeteerCookie[] } = {}) {
+    this.failOn = new Set(options.failOn ?? []);
+    this.gotoRedirects = new Map(Object.entries(options.redirects ?? {}));
+    if (options.cookies) this.cookiesSet.push(...options.cookies);
+  }
+
+  private record(method: string, ...args: unknown[]) {
+    this.calls.push({ method, args });
+  }
+
+  /** The order of operations, as method names. The assertion that matters most. */
+  get callOrder(): string[] {
+    return this.calls.map((call) => call.method);
+  }
+
+  async goto(url: string, options?: Record<string, unknown>): Promise<{ status: () => number }> {
+    this.record("goto", url, options);
+    if (this.failOn.has(url)) throw new Error(`net::ERR_CONNECTION_REFUSED at ${url}`);
+    this.currentUrl = this.gotoRedirects.get(url) ?? url;
+    return { status: () => 200 };
+  }
+
+  url(): string {
+    return this.currentUrl;
+  }
+
+  async title(): Promise<string> {
+    return "Dashboard — Example";
+  }
+
+  async setCookie(...cookies: PuppeteerCookie[]): Promise<void> {
+    this.record("setCookie", cookies);
+    this.cookiesSet.push(...cookies);
+  }
+
+  async cookies(): Promise<PuppeteerCookie[]> {
+    this.record("cookies");
+    return this.cookiesSet;
+  }
+
+  /**
+   * Run the page function against this fake's own storage.
+   *
+   * The functions under test are written to run in a browser, so the fake provides
+   * just enough `window.localStorage` and `document` for them to execute for real
+   * — which means the tests exercise the actual page code, not a description of it.
+   */
+  async evaluate<T>(fn: (...args: never[]) => T, ...args: unknown[]): Promise<T> {
+    this.record("evaluate", ...args);
+
+    // `new URL("about:blank").origin` is the string "null", which is exactly what a
+    // browser reports for an opaque origin — and writing storage there throws.
+    const origin = originOf(this.currentUrl);
+    if (this.currentUrl === "about:blank" || origin === "null") {
+      throw new Error("SecurityError: localStorage is not available on an opaque origin");
+    }
+
+    const map = this.storage.get(origin) ?? new Map<string, string>();
+    this.storage.set(origin, map);
+
+    const previousWindow = (globalThis as Record<string, unknown>).window;
+    const previousDocument = (globalThis as Record<string, unknown>).document;
+
+    // A Proxy rather than a plain object, because the real `localStorage` exposes
+    // its keys as enumerable own properties while `setItem`/`getItem` live on the
+    // prototype. Spreading the methods onto the object would make
+    // `Object.keys(localStorage)` return "setItem" — and `extractStorageState`
+    // would faithfully capture it.
+    const fakeLocalStorage = new Proxy({} as Record<string, unknown>, {
+      get(_target, property: string) {
+        switch (property) {
+          case "setItem":
+            return (key: string, value: string) => map.set(key, String(value));
+          case "getItem":
+            return (key: string) => map.get(key) ?? null;
+          case "removeItem":
+            return (key: string) => map.delete(key);
+          case "clear":
+            return () => map.clear();
+          case "length":
+            return map.size;
+          case "key":
+            return (index: number) => [...map.keys()][index] ?? null;
+          default:
+            return map.get(property);
+        }
+      },
+      has: (_target, property: string) => map.has(property),
+      ownKeys: () => [...map.keys()],
+      getOwnPropertyDescriptor: (_target, property: string) =>
+        map.has(property)
+          ? { value: map.get(property), enumerable: true, configurable: true, writable: true }
+          : undefined,
+    });
+
+    (globalThis as Record<string, unknown>).window = { localStorage: fakeLocalStorage };
+    (globalThis as Record<string, unknown>).document = {
+      querySelector: (selector: string) => (this.selectors.has(selector) ? this.selectors.get(selector) : null),
+    };
+
+    try {
+      return (fn as (...a: unknown[]) => T)(...args);
+    } finally {
+      (globalThis as Record<string, unknown>).window = previousWindow;
+      (globalThis as Record<string, unknown>).document = previousDocument;
+    }
+  }
+
+  async screenshot(): Promise<Uint8Array> {
+    this.record("screenshot");
+    return new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+  }
+
+  async close(): Promise<void> {
+    this.record("close");
+  }
+
+  localStorageFor(origin: string): Record<string, string> {
+    return Object.fromEntries(this.storage.get(origin) ?? new Map());
+  }
+}
+
+/**
+ * A recording stand-in for a DOM element, enough for the page functions in
+ * `worker.ts` to run for real: `click`, `focus`, `value` and `dispatchEvent`.
+ *
+ * `onClick` is where a test models what the click does to the page — a Google
+ * sign-in is several navigations, and the condition `waitForUrlContaining` polls
+ * for is the last one of them.
+ */
+export function fakeElement(onClick?: () => void) {
+  const element = {
+    value: "",
+    clicks: 0,
+    focused: 0,
+    events: [] as string[],
+    click() {
+      element.clicks += 1;
+      onClick?.();
+    },
+    focus() {
+      element.focused += 1;
+    },
+    dispatchEvent(event: { type: string }) {
+      element.events.push(event.type);
+      return true;
+    },
+  };
+
+  return element;
+}
+
+function originOf(url: string): string {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return url;
+  }
+}
+
+/** A Durable Object storage that also records alarm scheduling. */
+export class FakeStorage {
+  readonly map = new Map<string, unknown>();
+  readonly alarms: number[] = [];
+
+  async get<T>(key: string): Promise<T | undefined> {
+    return this.map.get(key) as T | undefined;
+  }
+
+  async put(key: string, value: unknown): Promise<void> {
+    // Structured-clone like the real thing, so a test cannot accidentally assert
+    // against an object the DO still holds a reference to.
+    this.map.set(key, JSON.parse(JSON.stringify(value)));
+  }
+
+  async delete(key: string): Promise<boolean> {
+    return this.map.delete(key);
+  }
+
+  async setAlarm(time: number): Promise<void> {
+    this.alarms.push(time);
+  }
+}
+
+/** A browser that hands out one page and records closing. */
+export class FakeBrowser {
+  closed = false;
+  readonly pages: FakePage[] = [];
+
+  constructor(private readonly pageFactory: () => FakePage = () => new FakePage()) {}
+
+  async newPage(): Promise<FakePage> {
+    const page = this.pageFactory();
+    this.pages.push(page);
+    return page;
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+  }
+
+  isConnected(): boolean {
+    return !this.closed;
+  }
+}

--- a/packages/test-google-login/test/google-login.test.ts
+++ b/packages/test-google-login/test/google-login.test.ts
@@ -1,0 +1,331 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ALLOW_REAL_LOGIN_ENV,
+  BOOTSTRAP_HEADER,
+  bootstrapAppSession,
+  loadStorageStateFor,
+  realGoogleLoginEnabled,
+  requireStoredSession,
+  signInWithGoogle,
+} from "../src/google-login.js";
+import { MissingStorageStateError, writeStorageState } from "../src/storage-state.js";
+import { NOW_MS, NOW_SECONDS, sampleState } from "./fixtures.js";
+
+let cwd: string;
+
+beforeEach(() => {
+  cwd = fs.mkdtempSync(path.join(os.tmpdir(), "tgl-login-"));
+});
+
+afterEach(() => {
+  fs.rmSync(cwd, { recursive: true, force: true });
+});
+
+/** A Playwright `context` that writes the state file the way Playwright does. */
+function fakeContext(state: unknown = sampleState(), extra: Record<string, unknown> = {}) {
+  const calls: { path?: string; indexedDB?: boolean }[] = [];
+
+  return {
+    calls,
+    async storageState(options: { path?: string; indexedDB?: boolean } = {}) {
+      calls.push(options);
+      if (options.path) {
+        fs.mkdirSync(path.dirname(options.path), { recursive: true });
+        // Playwright writes 0644 and, with indexedDB: true, an extra top-level key.
+        fs.writeFileSync(options.path, JSON.stringify({ ...(state as object), ...extra }), { mode: 0o644 });
+        fs.chmodSync(options.path, 0o644);
+      }
+      return state;
+    },
+  };
+}
+
+function fakePage() {
+  const visited: string[] = [];
+  const clicks: unknown[] = [];
+  const fills: [unknown, string][] = [];
+  let current = "http://localhost:3000/login";
+
+  const locator = (label: unknown) => ({
+    async click() {
+      clicks.push(label);
+      // The app's button hands off to Google; Google hands back. Modelled so the
+      // URL wait in signInWithGoogle has something real to observe.
+      current = clicks.length === 1 ? "https://accounts.google.com/o/oauth2/auth" : current;
+    },
+    async fill(value: string) {
+      fills.push([label, value]);
+    },
+  });
+
+  return {
+    visited,
+    clicks,
+    fills,
+    waited: [] as (string | RegExp)[],
+    async goto(url: string) {
+      visited.push(url);
+      current = url;
+      return null;
+    },
+    url: () => current,
+    async waitForURL(url: string | RegExp) {
+      this.waited.push(url);
+      current = "http://localhost:3000/dashboard";
+    },
+    getByRole: (_role: string, options?: { name?: string | RegExp }) => locator(options?.name),
+    getByLabel: (text: string | RegExp) => locator(text),
+  };
+}
+
+describe("requireStoredSession", () => {
+  it("returns a summary for a usable session", () => {
+    const file = path.join(cwd, "playwright/.auth/google-test-user.json");
+    writeStorageState(file, sampleState());
+
+    const summary = requireStoredSession({ cwd, file, now: NOW_MS });
+
+    expect(summary.cookieCount).toBe(3);
+    expect(summary.usable).toBe(true);
+  });
+
+  it("throws the codegen command when no session has been captured yet", () => {
+    expect(() => requireStoredSession({ cwd, baseUrl: "http://localhost:5173" })).toThrow(
+      MissingStorageStateError,
+    );
+    expect(() => requireStoredSession({ cwd, baseUrl: "http://localhost:5173" })).toThrow(
+      /playwright codegen --save-storage=/,
+    );
+  });
+
+  it("throws with the age of the lapse when the session has expired", () => {
+    const file = path.join(cwd, "state.json");
+    writeStorageState(file, {
+      cookies: [{ ...sampleState().cookies[0], expires: NOW_SECONDS - 2 * 3600 }],
+      origins: [],
+    });
+
+    expect(() => requireStoredSession({ cwd, file, now: NOW_MS })).toThrow(/expired 120 minutes ago/);
+  });
+});
+
+describe("bootstrapAppSession", () => {
+  const okResponse = { ok: () => true, status: () => 200, text: async () => "" };
+
+  it("posts the secret in the documented header and never in the URL or body", async () => {
+    const post = vi.fn(async () => okResponse);
+    const page = fakePage();
+    const context = fakeContext();
+    const file = path.join(cwd, "playwright/.auth/state.json");
+
+    await bootstrapAppSession({
+      request: { post },
+      page,
+      context,
+      cwd,
+      file,
+      secret: "super-secret",
+    } as never);
+
+    const [url, options] = post.mock.calls[0] as unknown as [string, { headers: Record<string, string>; data: unknown }];
+    expect(url).toBe("/api/test-auth/google-user");
+    expect(options.headers[BOOTSTRAP_HEADER]).toBe("super-secret");
+    // A secret in a query string lands in access logs and in browser history.
+    expect(url).not.toContain("super-secret");
+    expect(JSON.stringify(options.data)).not.toContain("super-secret");
+  });
+
+  it("navigates the page so the app's origin is in the context before capturing", async () => {
+    const page = fakePage();
+    const context = fakeContext();
+
+    await bootstrapAppSession({
+      request: { post: async () => okResponse },
+      page,
+      context,
+      cwd,
+      file: path.join(cwd, "state.json"),
+      secret: "s",
+      landingPath: "/app/home",
+    } as never);
+
+    expect(page.visited).toEqual(["/app/home"]);
+    expect(context.calls[0]).toMatchObject({ path: path.join(cwd, "state.json"), indexedDB: true });
+  });
+
+  it("leaves the file Playwright wrote intact but tightens it to 0600", async () => {
+    const file = path.join(cwd, "state.json");
+    const context = fakeContext(sampleState(), { indexedDB: [{ name: "keyval" }] });
+
+    await bootstrapAppSession({
+      request: { post: async () => okResponse },
+      page: fakePage(),
+      context,
+      cwd,
+      file,
+      secret: "s",
+    } as never);
+
+    expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+    // Round-tripping through this package's own writer would have dropped this —
+    // and with it whatever the auth library keeps in IndexedDB.
+    expect(JSON.parse(fs.readFileSync(file, "utf8")).indexedDB).toEqual([{ name: "keyval" }]);
+  });
+
+  it("refuses to run without a secret rather than calling the endpoint open", async () => {
+    const post = vi.fn(async () => okResponse);
+
+    await expect(
+      bootstrapAppSession({
+        request: { post },
+        page: fakePage(),
+        context: fakeContext(),
+        cwd,
+      } as never),
+    ).rejects.toThrow(/needs the shared secret/);
+
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("explains a 401 and a 404 differently, because they mean different things", async () => {
+    for (const [status, expected] of [
+      [401, /401/],
+      [404, /404/],
+    ] as const) {
+      await expect(
+        bootstrapAppSession({
+          request: {
+            post: async () => ({ ok: () => false, status: () => status, text: async () => "nope" }),
+          },
+          page: fakePage(),
+          context: fakeContext(),
+          cwd,
+          secret: "s",
+        } as never),
+      ).rejects.toThrow(expected);
+    }
+  });
+
+  it("includes the response body, truncated, so the failure is debuggable", async () => {
+    await expect(
+      bootstrapAppSession({
+        request: {
+          post: async () => ({ ok: () => false, status: () => 500, text: async () => "x".repeat(900) }),
+        },
+        page: fakePage(),
+        context: fakeContext(),
+        cwd,
+        secret: "s",
+      } as never),
+    ).rejects.toThrow(/x{400}(?!x)/);
+  });
+});
+
+describe("realGoogleLoginEnabled", () => {
+  const credentials = { GOOGLE_TEST_EMAIL: "e2e@example.test", GOOGLE_TEST_PASSWORD: "pw" };
+
+  it.each(["1", "true", "TRUE"])("is on for %j with credentials present", (flag) => {
+    expect(realGoogleLoginEnabled({ [ALLOW_REAL_LOGIN_ENV]: flag, ...credentials })).toBe(true);
+  });
+
+  it.each(["0", "false", "yes", ""])("stays off for %j", (flag) => {
+    expect(realGoogleLoginEnabled({ [ALLOW_REAL_LOGIN_ENV]: flag, ...credentials })).toBe(false);
+  });
+
+  it("stays off when the flag is set but credentials are missing", () => {
+    expect(realGoogleLoginEnabled({ [ALLOW_REAL_LOGIN_ENV]: "1" })).toBe(false);
+    expect(realGoogleLoginEnabled({ [ALLOW_REAL_LOGIN_ENV]: "1", GOOGLE_TEST_EMAIL: "e@x.test" })).toBe(false);
+  });
+
+  it("stays off for an empty environment", () => {
+    expect(realGoogleLoginEnabled({})).toBe(false);
+  });
+});
+
+describe("signInWithGoogle", () => {
+  const env = {
+    [ALLOW_REAL_LOGIN_ENV]: "1",
+    GOOGLE_TEST_EMAIL: "e2e@example.test",
+    GOOGLE_TEST_PASSWORD: "correct horse battery staple",
+  };
+
+  it("refuses without the opt-in, and points at the safer path", async () => {
+    await expect(
+      signInWithGoogle({ page: fakePage(), context: fakeContext(), env: {}, cwd } as never),
+    ).rejects.toThrow(/not enabled/);
+
+    await expect(
+      signInWithGoogle({ page: fakePage(), context: fakeContext(), env: {}, cwd } as never),
+    ).rejects.toThrow(/playwright codegen/);
+  });
+
+  it("does not touch the page when it refuses", async () => {
+    const page = fakePage();
+
+    await expect(
+      signInWithGoogle({ page, context: fakeContext(), env: {}, cwd } as never),
+    ).rejects.toThrow();
+
+    expect(page.visited).toEqual([]);
+    expect(page.clicks).toEqual([]);
+  });
+
+  it("drives the flow and captures the state when opted in", async () => {
+    const page = fakePage();
+    const context = fakeContext();
+    const file = path.join(cwd, "state.json");
+
+    const written = await signInWithGoogle({ page, context, env, cwd, file } as never);
+
+    expect(written).toBe(file);
+    expect(page.visited).toEqual(["/login"]);
+    // app sign-in button, then Next twice.
+    expect(page.clicks).toHaveLength(3);
+    expect(page.fills.map(([, value]) => value)).toEqual([env.GOOGLE_TEST_EMAIL, env.GOOGLE_TEST_PASSWORD]);
+    expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+  });
+
+  it("waits for its own origin rather than clicking through a consent screen", async () => {
+    const page = fakePage();
+
+    await signInWithGoogle({
+      page,
+      context: fakeContext(),
+      env,
+      cwd,
+      file: path.join(cwd, "state.json"),
+      expectUrl: /my-app/,
+    } as never);
+
+    expect(page.waited).toEqual([/my-app/]);
+  });
+
+  it("lets Google's labels be overridden, because Google changes them", async () => {
+    const page = fakePage();
+
+    await signInWithGoogle({
+      page,
+      context: fakeContext(),
+      env,
+      cwd,
+      file: path.join(cwd, "state.json"),
+      googleSelectors: { email: /correo/i, password: /contraseña/i, next: /siguiente/i },
+    } as never);
+
+    expect(page.fills.map(([label]) => String(label))).toEqual(["/correo/i", "/contraseña/i"]);
+  });
+});
+
+describe("loadStorageStateFor", () => {
+  it("reads the state for passing to browser.newContext", () => {
+    const file = path.join(cwd, "state.json");
+    writeStorageState(file, sampleState());
+
+    expect(loadStorageStateFor({ cwd, file })).toEqual(sampleState());
+  });
+});

--- a/packages/test-google-login/test/puppeteer-state.test.ts
+++ b/packages/test-google-login/test/puppeteer-state.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyLocalStorage,
+  applyStorageState,
+  extractStorageState,
+  fromPuppeteerCookies,
+  storageStateOrigins,
+  toPuppeteerCookies,
+} from "../src/puppeteer-state.js";
+import { SESSION_COOKIE_EXPIRES } from "../src/state-core.js";
+import type { PageLike } from "../src/types.js";
+import { FakePage, NOW_SECONDS, sampleState } from "./fixtures.js";
+
+const asPage = (page: FakePage) => page as unknown as PageLike;
+
+describe("toPuppeteerCookies", () => {
+  it("omits the expiry of a session cookie instead of sending -1", () => {
+    const converted = toPuppeteerCookies(sampleState());
+    const session = converted.find((cookie) => cookie.name === "csrf");
+
+    // CDP reads `expires: -1` as an expiry in 1969 and silently drops the cookie.
+    // The key must be absent, not negative.
+    expect(session).not.toHaveProperty("expires");
+    expect(Object.keys(session!)).not.toContain("expires");
+  });
+
+  it("keeps a real expiry", () => {
+    const converted = toPuppeteerCookies(sampleState());
+
+    expect(converted.find((cookie) => cookie.name === "app_session")!.expires).toBe(NOW_SECONDS + 12 * 3600);
+  });
+
+  it("carries domain, path, flags and sameSite through unchanged", () => {
+    const converted = toPuppeteerCookies(sampleState());
+
+    expect(converted.find((cookie) => cookie.name === "SID")).toMatchObject({
+      domain: ".google.com",
+      path: "/",
+      httpOnly: true,
+      secure: true,
+      sameSite: "None",
+    });
+  });
+});
+
+describe("fromPuppeteerCookies", () => {
+  it("turns a session cookie back into -1", () => {
+    const [cookie] = fromPuppeteerCookies([
+      { name: "csrf", value: "v", domain: "app.test", path: "/", httpOnly: false, secure: true, session: true },
+    ]);
+
+    expect(cookie.expires).toBe(SESSION_COOKIE_EXPIRES);
+  });
+
+  it("treats a missing expiry as a session cookie", () => {
+    const [cookie] = fromPuppeteerCookies([
+      { name: "csrf", value: "v", domain: "app.test", path: "/", httpOnly: false, secure: false },
+    ]);
+
+    expect(cookie.expires).toBe(SESSION_COOKIE_EXPIRES);
+  });
+
+  it("normalises the sameSite values CDP actually returns", () => {
+    const cookies = fromPuppeteerCookies([
+      { name: "a", value: "v", domain: "d", path: "/", httpOnly: false, secure: false, sameSite: "lax" as never },
+      {
+        name: "b",
+        value: "v",
+        domain: "d",
+        path: "/",
+        httpOnly: false,
+        secure: false,
+        sameSite: "unspecified" as never,
+      },
+      { name: "c", value: "v", domain: "d", path: "/", httpOnly: false, secure: false },
+    ]);
+
+    expect(cookies.map((cookie) => cookie.sameSite)).toEqual(["Lax", "Lax", "Lax"]);
+  });
+
+  it("defaults an empty path to /", () => {
+    const [cookie] = fromPuppeteerCookies([
+      { name: "a", value: "v", domain: "d", path: "", httpOnly: false, secure: false },
+    ]);
+
+    expect(cookie.path).toBe("/");
+  });
+
+  it("round-trips a whole state without losing anything", () => {
+    const state = sampleState();
+
+    expect(fromPuppeteerCookies(toPuppeteerCookies(state))).toEqual(state.cookies);
+  });
+});
+
+describe("storageStateOrigins", () => {
+  it("lists the origins in file order", () => {
+    expect(storageStateOrigins(sampleState())).toEqual(["https://app.example.test"]);
+  });
+});
+
+describe("applyStorageState", () => {
+  it("sets every cookie in one call, before any navigation", async () => {
+    const page = new FakePage();
+
+    await applyStorageState(asPage(page), sampleState());
+
+    // One round trip, not three — and cookies first, or the first navigation
+    // happens signed out and the app may respond with a redirect chain.
+    expect(page.callOrder).toEqual(["setCookie", "goto", "evaluate"]);
+    expect(page.calls.filter((call) => call.method === "setCookie")).toHaveLength(1);
+    expect(page.cookiesSet).toHaveLength(3);
+  });
+
+  it("restores localStorage for the origin that owns it", async () => {
+    const page = new FakePage();
+
+    const result = await applyStorageState(asPage(page), sampleState());
+
+    expect(result.originsRestored).toEqual(["https://app.example.test"]);
+    expect(page.localStorageFor("https://app.example.test")).toEqual({
+      access_token: "ya29.a0AfH6SMB-token",
+      theme: "dark",
+    });
+  });
+
+  it("navigates only as far as a document, not a full load", async () => {
+    const page = new FakePage();
+
+    await applyStorageState(asPage(page), sampleState());
+
+    const goto = page.calls.find((call) => call.method === "goto");
+    expect(goto!.args[1]).toMatchObject({ waitUntil: "domcontentloaded" });
+  });
+
+  it("costs no navigation when the state is cookies only", async () => {
+    const page = new FakePage();
+
+    await applyStorageState(asPage(page), sampleState({ origins: [] }));
+
+    expect(page.callOrder).toEqual(["setCookie"]);
+  });
+
+  it("restores only the origins asked for", async () => {
+    const page = new FakePage();
+    const state = sampleState({
+      origins: [
+        ...sampleState().origins,
+        { origin: "https://accounts.google.com", localStorage: [{ name: "g", value: "1" }] },
+      ],
+    });
+
+    const result = await applyStorageState(asPage(page), state, { origins: ["https://app.example.test"] });
+
+    // Navigating a test browser to accounts.google.com is slow and is exactly the
+    // traffic that trips Google's own bot checks. Narrowing must actually narrow.
+    expect(result.originsRestored).toEqual(["https://app.example.test"]);
+    expect(page.calls.filter((call) => call.method === "goto").map((call) => call.args[0])).toEqual([
+      "https://app.example.test",
+    ]);
+  });
+
+  it("keeps the cookies it already set when one origin is unreachable", async () => {
+    const page = new FakePage({ failOn: ["https://app.example.test"] });
+
+    const result = await applyStorageState(asPage(page), sampleState());
+
+    expect(result.cookiesSet).toBe(3);
+    expect(result.originsRestored).toEqual([]);
+    expect(result.skipped[0]).toMatchObject({ origin: "https://app.example.test" });
+    expect(result.skipped[0].reason).toMatch(/ERR_CONNECTION_REFUSED/);
+  });
+
+  it("skips an origin with nothing stored for it, without navigating", async () => {
+    const page = new FakePage();
+
+    const result = await applyStorageState(asPage(page), {
+      cookies: [],
+      origins: [{ origin: "https://app.example.test", localStorage: [] }],
+    });
+
+    expect(result.skipped).toEqual([{ origin: "https://app.example.test", reason: "no localStorage entries" }]);
+    expect(page.callOrder).toEqual([]);
+  });
+
+  it("explains the Puppeteer 23 cookie API move rather than failing obscurely", async () => {
+    const page = new FakePage();
+    const withoutSetCookie = { ...asPage(page), setCookie: undefined } as unknown as PageLike;
+
+    await expect(applyStorageState(withoutSetCookie, sampleState())).rejects.toThrow(
+      /browserContext\.setCookie/,
+    );
+  });
+});
+
+describe("applyLocalStorage", () => {
+  it("does nothing at all for an empty list", async () => {
+    const page = new FakePage();
+
+    await applyLocalStorage(asPage(page), []);
+
+    expect(page.callOrder).toEqual([]);
+  });
+
+  it("surfaces the SecurityError from writing storage on about:blank", async () => {
+    const page = new FakePage();
+
+    await expect(applyLocalStorage(asPage(page), [{ name: "a", value: "1" }])).rejects.toThrow(/SecurityError/);
+  });
+});
+
+describe("extractStorageState", () => {
+  it("captures cookies and the current origin's localStorage", async () => {
+    const page = new FakePage();
+    await applyStorageState(asPage(page), sampleState());
+
+    const captured = await extractStorageState(asPage(page));
+
+    expect(captured.cookies).toEqual(sampleState().cookies);
+    expect(captured.origins).toEqual([
+      {
+        origin: "https://app.example.test",
+        localStorage: [
+          { name: "access_token", value: "ya29.a0AfH6SMB-token" },
+          { name: "theme", value: "dark" },
+        ],
+      },
+    ]);
+  });
+
+  it("captures no origin when the page never left about:blank", async () => {
+    const page = new FakePage();
+
+    const captured = await extractStorageState(asPage(page));
+
+    expect(captured.origins).toEqual([]);
+  });
+
+  it("does not re-navigate when already on the requested origin", async () => {
+    const page = new FakePage();
+    await page.goto("https://app.example.test/dashboard");
+    const before = page.calls.filter((call) => call.method === "goto").length;
+
+    await extractStorageState(asPage(page), { origins: ["https://app.example.test"] });
+
+    expect(page.calls.filter((call) => call.method === "goto")).toHaveLength(before);
+  });
+
+  it("still returns the cookies when an origin cannot be reached", async () => {
+    const page = new FakePage({ failOn: ["https://gone.example.test"], cookies: toPuppeteerCookies(sampleState()) });
+
+    const captured = await extractStorageState(asPage(page), { origins: ["https://gone.example.test"] });
+
+    expect(captured.cookies).toHaveLength(3);
+    expect(captured.origins).toEqual([]);
+  });
+
+  it("refuses a page that cannot read cookies", async () => {
+    const page = new FakePage();
+    const withoutCookies = { ...asPage(page), cookies: undefined } as unknown as PageLike;
+
+    await expect(extractStorageState(withoutCookies)).rejects.toThrow(/cannot read cookies/);
+  });
+});
+
+describe("a state captured by Playwright, replayed by Puppeteer", () => {
+  it("survives the whole round trip unchanged", async () => {
+    const original = sampleState();
+
+    const first = new FakePage();
+    await applyStorageState(asPage(first), original);
+
+    const captured = await extractStorageState(asPage(first));
+
+    const second = new FakePage();
+    await applyStorageState(asPage(second), captured);
+
+    expect(await extractStorageState(asPage(second))).toEqual(captured);
+    expect(captured.cookies).toEqual(original.cookies);
+  });
+});

--- a/packages/test-google-login/test/secret.test.ts
+++ b/packages/test-google-login/test/secret.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { AUTH_HEADER, constantTimeEqual, isAuthorized } from "../src/secret.js";
+
+describe("constantTimeEqual", () => {
+  it("matches identical secrets", () => {
+    expect(constantTimeEqual("s3cret-value", "s3cret-value")).toBe(true);
+  });
+
+  it.each([
+    ["s3cret-valuE", "a single differing byte"],
+    ["s3cret-valu", "a shorter value"],
+    ["s3cret-value-more", "a longer value"],
+    ["", "an empty value"],
+  ])("rejects %j (%s)", (supplied) => {
+    expect(constantTimeEqual(supplied, "s3cret-value")).toBe(false);
+  });
+
+  it.each([null, undefined])("rejects %s without throwing", (supplied) => {
+    expect(constantTimeEqual(supplied, "s3cret-value")).toBe(false);
+  });
+
+  it.each([null, undefined, ""])("never matches when the expected secret is %j", (expected) => {
+    // A Worker deployed without its secret set must refuse everything, including
+    // a request that presents the empty string.
+    expect(constantTimeEqual("", expected)).toBe(false);
+    expect(constantTimeEqual("anything", expected)).toBe(false);
+  });
+
+  it("compares bytes, so a multi-byte character is not a partial match", () => {
+    expect(constantTimeEqual("café", "café")).toBe(true);
+    expect(constantTimeEqual("cafe", "café")).toBe(false);
+  });
+});
+
+describe("isAuthorized", () => {
+  const headers = (value?: string) => ({
+    get: (name: string) => (name === AUTH_HEADER && value !== undefined ? value : null),
+  });
+
+  it("accepts the configured secret in the documented header", () => {
+    expect(isAuthorized(headers("abc123"), "abc123")).toBe(true);
+  });
+
+  it("rejects a missing header", () => {
+    expect(isAuthorized(headers(), "abc123")).toBe(false);
+  });
+
+  it("rejects everything when no secret is configured", () => {
+    expect(isAuthorized(headers("abc123"), undefined)).toBe(false);
+  });
+});

--- a/packages/test-google-login/test/storage-state.test.ts
+++ b/packages/test-google-login/test/storage-state.test.ts
@@ -1,0 +1,326 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  InvalidStorageStateError,
+  MissingStorageStateError,
+  SESSION_COOKIE_EXPIRES,
+  assertStorageStateUsable,
+  findExpiringCookies,
+  hardenStorageStateFile,
+  isGoogleDomain,
+  normalizeStorageState,
+  parseStorageState,
+  readStorageState,
+  redactStorageState,
+  summarizeStorageState,
+  writeStorageState,
+} from "../src/storage-state.js";
+import { HOUR, NOW_MS, NOW_SECONDS, sampleState } from "./fixtures.js";
+
+let cwd: string;
+
+beforeEach(() => {
+  cwd = fs.mkdtempSync(path.join(os.tmpdir(), "tgl-state-"));
+});
+
+afterEach(() => {
+  fs.rmSync(cwd, { recursive: true, force: true });
+});
+
+describe("normalizeStorageState", () => {
+  it("fills in the fields an older or hand-edited file may omit", () => {
+    const state = normalizeStorageState({
+      cookies: [{ name: "s", value: "v", domain: "app.test" }],
+    });
+
+    expect(state.cookies[0]).toMatchObject({
+      path: "/",
+      expires: SESSION_COOKIE_EXPIRES,
+      httpOnly: false,
+      secure: false,
+      sameSite: "Lax",
+    });
+    expect(state.origins).toEqual([]);
+  });
+
+  it("re-capitalises a lowercase sameSite rather than passing it to CDP", () => {
+    const state = normalizeStorageState({
+      cookies: [{ name: "s", value: "v", domain: "app.test", sameSite: "strict" }],
+    });
+
+    expect(state.cookies[0].sameSite).toBe("Strict");
+  });
+
+  it("falls back to Lax for a sameSite CDP does not accept", () => {
+    const state = normalizeStorageState({
+      cookies: [{ name: "s", value: "v", domain: "app.test", sameSite: "unspecified" }],
+    });
+
+    expect(state.cookies[0].sameSite).toBe("Lax");
+  });
+
+  it("drops malformed localStorage entries instead of failing the whole file", () => {
+    const state = normalizeStorageState({
+      origins: [{ origin: "https://app.test", localStorage: [{ name: "ok", value: "1" }, null, { value: "no name" }] }],
+    });
+
+    expect(state.origins[0].localStorage).toEqual([{ name: "ok", value: "1" }]);
+  });
+
+  it.each([
+    [null, "top level is not an object"],
+    [[], "top level is not an object"],
+    [{}, "neither `cookies` nor `origins` is present"],
+    [{ cookies: "nope" }, "`cookies` is present but not an array"],
+    [{ origins: {} }, "`origins` is present but not an array"],
+    [{ cookies: [{ name: "s" }] }, "cookies[0] has no name/value pair"],
+    [{ cookies: [{ name: "s", value: "v" }] }, "cookies[0] (s) has no domain"],
+    [{ origins: [{ localStorage: [] }] }, "origins[0] has no origin"],
+  ])("rejects %j", (input, message) => {
+    expect(() => normalizeStorageState(input)).toThrow(InvalidStorageStateError);
+    expect(() => normalizeStorageState(input)).toThrow(message);
+  });
+});
+
+describe("parseStorageState", () => {
+  it("names JSON as the problem when the file is not JSON", () => {
+    expect(() => parseStorageState("<html>login</html>")).toThrow(/not valid JSON/);
+  });
+});
+
+describe("summarizeStorageState", () => {
+  it("describes the state without exposing a single value", () => {
+    const state = sampleState();
+    const summary = summarizeStorageState(state, { now: NOW_MS });
+
+    const serialized = JSON.stringify(summary);
+    for (const cookie of state.cookies) expect(serialized).not.toContain(cookie.value);
+    for (const entry of state.origins[0].localStorage) expect(serialized).not.toContain(entry.value);
+  });
+
+  it("counts session cookies separately and reports the earliest real expiry", () => {
+    const summary = summarizeStorageState(sampleState(), { now: NOW_MS });
+
+    expect(summary.cookieCount).toBe(3);
+    expect(summary.sessionCookies).toBe(1);
+    expect(summary.earliestExpiry).toBe(NOW_SECONDS + 12 * HOUR);
+    expect(summary.expiresInSeconds).toBe(12 * HOUR);
+    expect(summary.expired).toBe(false);
+    expect(summary.usable).toBe(true);
+  });
+
+  it("lists domains, cookie names and localStorage keys, sorted", () => {
+    const summary = summarizeStorageState(sampleState(), { now: NOW_MS });
+
+    expect(summary.domains).toEqual([".google.com", "app.example.test"]);
+    expect(summary.cookieNames).toEqual(["SID", "app_session", "csrf"]);
+    expect(summary.localStorageKeys).toEqual({ "https://app.example.test": ["access_token", "theme"] });
+  });
+
+  it("spots Google cookies", () => {
+    expect(summarizeStorageState(sampleState(), { now: NOW_MS }).hasGoogleCookies).toBe(true);
+
+    const appOnly = sampleState({ cookies: sampleState().cookies.filter((c) => c.domain !== ".google.com") });
+    expect(summarizeStorageState(appOnly, { now: NOW_MS }).hasGoogleCookies).toBe(false);
+  });
+
+  it("reports expired once every cookie with an expiry has passed it", () => {
+    const stale = sampleState({
+      cookies: sampleState().cookies.map((cookie) =>
+        cookie.expires > 0 ? { ...cookie, expires: NOW_SECONDS - HOUR } : cookie,
+      ),
+    });
+
+    const summary = summarizeStorageState(stale, { now: NOW_MS });
+
+    expect(summary.expired).toBe(true);
+    expect(summary.expiresInSeconds).toBe(-HOUR);
+    // The session-only cookie survives, so something is still sendable — but the
+    // state is expired all the same, and `expired` is what callers gate on.
+    expect(summary.usable).toBe(true);
+  });
+
+  it("does not call a session-only state expired — it has no expiry to have passed", () => {
+    const sessionOnly = sampleState({
+      cookies: [{ ...sampleState().cookies[2] }],
+      origins: [],
+    });
+
+    const summary = summarizeStorageState(sessionOnly, { now: NOW_MS });
+
+    expect(summary.expired).toBe(false);
+    expect(summary.earliestExpiry).toBeNull();
+    expect(summary.expiresInSeconds).toBeNull();
+    expect(summary.usable).toBe(true);
+  });
+
+  it("is unusable when there are no cookies at all", () => {
+    expect(summarizeStorageState({ cookies: [], origins: [] }, { now: NOW_MS }).usable).toBe(false);
+  });
+});
+
+describe("findExpiringCookies", () => {
+  it("warns before the failure rather than after it", () => {
+    const state = sampleState({
+      cookies: [{ ...sampleState().cookies[0], name: "soon", expires: NOW_SECONDS + 30 * 60 }],
+    });
+
+    const soon = findExpiringCookies(state, { now: NOW_MS, withinMs: 60 * 60 * 1000 });
+
+    expect(soon.map((cookie) => cookie.name)).toEqual(["soon"]);
+  });
+
+  it("never reports a session cookie, which has no expiry to be near", () => {
+    const sessionOnly = sampleState({ cookies: [sampleState().cookies[2]] });
+
+    expect(findExpiringCookies(sessionOnly, { now: NOW_MS, withinMs: 10 ** 12 })).toEqual([]);
+  });
+
+  it("defaults to a one-hour window", () => {
+    const state = sampleState({
+      cookies: [{ ...sampleState().cookies[0], expires: Math.floor(Date.now() / 1000) + 20 * 60 }],
+    });
+
+    expect(findExpiringCookies(state)).toHaveLength(1);
+  });
+});
+
+describe("redactStorageState", () => {
+  it("keeps the shape and loses every secret", () => {
+    const state = sampleState();
+    const redacted = redactStorageState(state);
+    const serialized = JSON.stringify(redacted);
+
+    expect(redacted.cookies.map((c) => c.name)).toEqual(state.cookies.map((c) => c.name));
+    expect(redacted.cookies[0].domain).toBe(state.cookies[0].domain);
+    expect(redacted.cookies[0].expires).toBe(state.cookies[0].expires);
+
+    for (const cookie of state.cookies) expect(serialized).not.toContain(cookie.value);
+    for (const entry of state.origins[0].localStorage) expect(serialized).not.toContain(entry.value);
+  });
+
+  it("says how long each value was, which is all you need to tell two apart", () => {
+    const redacted = redactStorageState(sampleState());
+
+    expect(redacted.cookies[0].value).toBe("«redacted 21 chars»");
+    expect(redacted.origins[0].localStorage[0].value).toBe("«redacted 20 chars»");
+  });
+
+  it("does not mutate the state it was given", () => {
+    const state = sampleState();
+    redactStorageState(state);
+
+    expect(state.cookies[0].value).toBe("sess_abcdef0123456789");
+  });
+});
+
+describe("writeStorageState", () => {
+  it("writes owner-read-write only", () => {
+    const file = path.join(cwd, "playwright/.auth/state.json");
+    writeStorageState(file, sampleState());
+
+    expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+  });
+
+  it("tightens a file that already existed as 0644", () => {
+    const file = path.join(cwd, "state.json");
+    fs.writeFileSync(file, "{}", { mode: 0o644 });
+    fs.chmodSync(file, 0o644);
+
+    writeStorageState(file, sampleState());
+
+    expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+  });
+
+  it("round-trips through readStorageState", () => {
+    const file = path.join(cwd, "state.json");
+    writeStorageState(file, sampleState());
+
+    expect(readStorageState(file)).toEqual(sampleState());
+  });
+});
+
+describe("readStorageState", () => {
+  it("tells you how to create the file it could not find", () => {
+    const file = path.join(cwd, "playwright/.auth/google-test-user.json");
+
+    try {
+      readStorageState(file, { cwd, baseUrl: "http://localhost:4000" });
+      expect.unreachable("should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(MissingStorageStateError);
+      expect((error as Error).message).toContain("playwright codegen --save-storage=");
+      expect((error as Error).message).toContain("http://localhost:4000");
+      expect((error as MissingStorageStateError).file).toBe(file);
+    }
+  });
+
+  it("propagates a non-ENOENT read failure rather than blaming a missing file", () => {
+    const dir = path.join(cwd, "a-directory");
+    fs.mkdirSync(dir);
+
+    expect(() => readStorageState(dir)).toThrow(/EISDIR|illegal operation/i);
+  });
+});
+
+describe("hardenStorageStateFile", () => {
+  it("chmods a file Playwright wrote and reports what is in it", () => {
+    const file = path.join(cwd, "state.json");
+    // What `context.storageState({ path, indexedDB: true })` leaves behind: an
+    // extra key this package has no type for, which must survive untouched.
+    fs.writeFileSync(file, JSON.stringify({ ...sampleState(), indexedDB: [{ name: "db" }] }), { mode: 0o644 });
+    fs.chmodSync(file, 0o644);
+
+    const summary = hardenStorageStateFile(file);
+
+    expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+    expect(summary.cookieCount).toBe(3);
+    expect(JSON.parse(fs.readFileSync(file, "utf8")).indexedDB).toEqual([{ name: "db" }]);
+  });
+
+  it("throws on a file that is not a storage state", () => {
+    const file = path.join(cwd, "state.json");
+    fs.writeFileSync(file, '{"hello":"world"}');
+
+    expect(() => hardenStorageStateFile(file)).toThrow(InvalidStorageStateError);
+  });
+});
+
+describe("assertStorageStateUsable", () => {
+  it("returns the summary when the session is good", () => {
+    expect(assertStorageStateUsable(sampleState(), { now: NOW_MS, cwd }).cookieCount).toBe(3);
+  });
+
+  it("explains how long ago it lapsed, and how to fix it", () => {
+    const stale = sampleState({
+      cookies: [{ ...sampleState().cookies[0], expires: NOW_SECONDS - 90 * 60 }],
+      origins: [],
+    });
+
+    expect(() => assertStorageStateUsable(stale, { now: NOW_MS, cwd })).toThrow(/expired 90 minutes ago/);
+    expect(() => assertStorageStateUsable(stale, { now: NOW_MS, cwd })).toThrow(/playwright codegen/);
+  });
+
+  it("rejects a state with nothing in it", () => {
+    expect(() => assertStorageStateUsable({ cookies: [], origins: [] }, { now: NOW_MS, cwd })).toThrow(
+      /no usable cookie/,
+    );
+  });
+});
+
+describe("isGoogleDomain", () => {
+  it.each([
+    [".google.com", true],
+    ["accounts.google.com", true],
+    ["lh3.googleusercontent.com", true],
+    ["app.example.test", false],
+    ["notgoogle.com", false],
+    ["google.com.evil.test", false],
+  ])("%s → %s", (domain, expected) => {
+    expect(isGoogleDomain(domain)).toBe(expected);
+  });
+});

--- a/packages/test-google-login/test/worker.test.ts
+++ b/packages/test-google-login/test/worker.test.ts
@@ -1,0 +1,506 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AUTH_HEADER } from "../src/secret.js";
+import {
+  GoogleLoginBrowser,
+  handleRequest,
+  setPuppeteer,
+  type BrowserLike,
+  type Env,
+} from "../src/worker.js";
+import { FakeBrowser, FakePage, FakeStorage, fakeElement, sampleState } from "./fixtures.js";
+
+const SECRET = "a-long-random-shared-secret";
+
+function request(url: string, init: RequestInit & { secret?: string | null } = {}) {
+  const headers = new Headers(init.headers);
+  if (init.secret !== null) headers.set(AUTH_HEADER, init.secret ?? SECRET);
+  return new Request(`https://tgl.example.workers.dev${url}`, { ...init, headers });
+}
+
+function env(overrides: Partial<Env> = {}): Env {
+  const stub = { fetch: vi.fn(async () => new Response("from the DO")) };
+
+  return {
+    BROWSER: { binding: true },
+    BROWSER_SESSION: {
+      idFromName: vi.fn((name: string) => ({ name })),
+      get: vi.fn(() => stub),
+    },
+    TEST_AUTH_SECRET: SECRET,
+    ...overrides,
+  } as Env;
+}
+
+describe("handleRequest", () => {
+  it("refuses every request when TEST_AUTH_SECRET is not configured", async () => {
+    const response = await handleRequest(request("/health"), env({ TEST_AUTH_SECRET: undefined }));
+
+    // The alternative is a Worker that serves an anonymous browser to anyone who
+    // finds the URL, which is strictly worse than being broken.
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({ error: "not_configured" });
+  });
+
+  it("401s a missing or wrong secret, and says which header to use", async () => {
+    for (const secret of [null, "wrong-secret"]) {
+      const response = await handleRequest(request("/health", { secret }), env());
+
+      expect(response.status).toBe(401);
+      expect(response.headers.get("x-required-header")).toBe(AUTH_HEADER);
+      // No hint about length, prefix, or which half was wrong.
+      expect(await response.text()).toBe("Unauthorized");
+    }
+  });
+
+  it("answers /health without waking a browser", async () => {
+    const bindings = env();
+
+    const response = await handleRequest(request("/health"), bindings);
+
+    expect(await response.json()).toEqual({ ok: true });
+    expect(bindings.BROWSER_SESSION.get).not.toHaveBeenCalled();
+  });
+
+  it("routes to the Durable Object named by ?session=", async () => {
+    const bindings = env();
+
+    await handleRequest(request("/check?session=signed-in", { method: "POST" }), bindings);
+
+    expect(bindings.BROWSER_SESSION.idFromName).toHaveBeenCalledWith("signed-in");
+  });
+
+  it("defaults to one session named 'default'", async () => {
+    const bindings = env();
+
+    await handleRequest(request("/check", { method: "POST" }), bindings);
+
+    expect(bindings.BROWSER_SESSION.idFromName).toHaveBeenCalledWith("default");
+  });
+});
+
+describe("GoogleLoginBrowser", () => {
+  let storage: FakeStorage;
+  let browser: FakeBrowser;
+  let page: FakePage;
+
+  beforeEach(() => {
+    storage = new FakeStorage();
+    page = new FakePage();
+    browser = new FakeBrowser(() => page);
+    setPuppeteer({ launch: async () => browser as unknown as BrowserLike });
+  });
+
+  afterEach(() => {
+    setPuppeteer(undefined);
+  });
+
+  const build = (overrides: Partial<Env> = {}) =>
+    new GoogleLoginBrowser({ storage }, { ...env(overrides), ...overrides } as Env);
+
+  const call = (object: GoogleLoginBrowser, url: string, init: RequestInit = {}) =>
+    object.fetch(request(url, init));
+
+  describe("POST /state", () => {
+    it("validates on the way in and reports a summary, not the state", async () => {
+      const response = await call(build(), "/state", { method: "POST", body: JSON.stringify(sampleState()) });
+      const body = (await response.json()) as Record<string, unknown>;
+
+      expect(response.status).toBe(200);
+      expect(body).toMatchObject({ stored: true });
+
+      const serialized = JSON.stringify(body);
+      for (const cookie of sampleState().cookies) expect(serialized).not.toContain(cookie.value);
+    });
+
+    it("rejects a malformed upload with the reason, not a CDP error later", async () => {
+      const response = await call(build(), "/state", {
+        method: "POST",
+        body: JSON.stringify({ cookies: [{ name: "s", value: "v" }] }),
+      });
+
+      expect(response.status).toBe(500);
+      expect(await response.json()).toMatchObject({ message: expect.stringContaining("has no domain") });
+    });
+  });
+
+  describe("GET /state", () => {
+    it("404s when nothing is stored", async () => {
+      const response = await call(build(), "/state");
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual({ present: false });
+    });
+
+    it("never returns a live cookie value — only a redacted copy", async () => {
+      const object = build();
+      await call(object, "/state", { method: "POST", body: JSON.stringify(sampleState()) });
+
+      const response = await call(object, "/state");
+      const text = await response.text();
+
+      // The single most important assertion in this file. There is no route that
+      // reads the session back out, and adding one would turn this Worker into a
+      // credential-exfiltration endpoint with a test-shaped name.
+      for (const cookie of sampleState().cookies) expect(text).not.toContain(cookie.value);
+      for (const entry of sampleState().origins[0].localStorage) expect(text).not.toContain(entry.value);
+
+      expect(text).toContain("«redacted");
+      expect(text).toContain("app_session");
+    });
+  });
+
+  describe("DELETE /state", () => {
+    it("removes the session and closes the browser with it", async () => {
+      const object = build();
+      await call(object, "/state", { method: "POST", body: JSON.stringify(sampleState()) });
+      await call(object, "/check", {
+        method: "POST",
+        body: JSON.stringify({ url: "https://app.example.test/dashboard" }),
+      });
+
+      const response = await call(object, "/state", { method: "DELETE" });
+
+      expect(await response.json()).toEqual({ cleared: true });
+      expect(browser.closed).toBe(true);
+      expect(await storage.get("storage-state")).toBeUndefined();
+    });
+  });
+
+  describe("POST /check", () => {
+    const checkBody = (extra: Record<string, unknown> = {}) =>
+      JSON.stringify({ url: "https://app.example.test/dashboard", ...extra });
+
+    it("requires a url", async () => {
+      const response = await call(build(), "/check", { method: "POST", body: "{}" });
+
+      expect(response.status).toBe(400);
+    });
+
+    it("409s with what to do when no session has been stored", async () => {
+      const response = await call(build(), "/check", { method: "POST", body: checkBody() });
+
+      expect(response.status).toBe(409);
+      expect(await response.json()).toMatchObject({ error: "no_state" });
+    });
+
+    it("replays the session, then reports where it landed", async () => {
+      const object = build();
+      await call(object, "/state", { method: "POST", body: JSON.stringify(sampleState()) });
+
+      const response = await call(object, "/check", { method: "POST", body: checkBody() });
+      const body = (await response.json()) as Record<string, unknown>;
+
+      expect(body).toMatchObject({
+        authenticated: true,
+        status: 200,
+        url: "https://app.example.test/dashboard",
+        title: "Dashboard — Example",
+      });
+      expect(page.cookiesSet).toHaveLength(3);
+    });
+
+    it("calls a redirect to the login page what it is", async () => {
+      const object = build();
+      await call(object, "/state", { method: "POST", body: JSON.stringify(sampleState()) });
+      page = new FakePage({ redirects: { "https://app.example.test/dashboard": "https://app.example.test/login" } });
+      browser = new FakeBrowser(() => page);
+      setPuppeteer({ launch: async () => browser as unknown as BrowserLike });
+
+      const fresh = build();
+      const response = await call(fresh, "/check", { method: "POST", body: checkBody({ rejectUrl: "/login" }) });
+
+      // A 200 on the login page is the failure that otherwise reads as a pass.
+      expect(await response.json()).toMatchObject({ authenticated: false, reason: expect.stringContaining("/login") });
+    });
+
+    it("checks the selector you name", async () => {
+      const object = build();
+      await call(object, "/state", { method: "POST", body: JSON.stringify(sampleState()) });
+
+      const missing = await call(object, "/check", {
+        method: "POST",
+        body: checkBody({ expectSelector: "[data-testid=user-menu]" }),
+      });
+      expect(await missing.json()).toMatchObject({ authenticated: false });
+
+      page.selectors.set("[data-testid=user-menu]", { tagName: "BUTTON" });
+      const found = await call(object, "/check", {
+        method: "POST",
+        body: checkBody({ expectSelector: "[data-testid=user-menu]" }),
+      });
+      expect(await found.json()).toMatchObject({ authenticated: true, reason: expect.stringContaining("found") });
+    });
+
+    it("returns a screenshot only when asked", async () => {
+      const object = build();
+      await call(object, "/state", { method: "POST", body: JSON.stringify(sampleState()) });
+
+      const without = (await (await call(object, "/check", { method: "POST", body: checkBody() })).json()) as Record<
+        string,
+        unknown
+      >;
+      expect(without).not.toHaveProperty("screenshot");
+
+      const withShot = (await (
+        await call(object, "/check", { method: "POST", body: checkBody({ screenshot: true }) })
+      ).json()) as { screenshot: string };
+      expect(withShot.screenshot).toBe("iVBORw==");
+    });
+
+    it("closes the page but keeps the browser — the whole point of the DO", async () => {
+      const object = build();
+      await call(object, "/state", { method: "POST", body: JSON.stringify(sampleState()) });
+
+      await call(object, "/check", { method: "POST", body: checkBody() });
+      await call(object, "/check", { method: "POST", body: checkBody() });
+
+      expect(browser.closed).toBe(false);
+      expect(page.callOrder.filter((method) => method === "close")).toHaveLength(2);
+    });
+
+    it("launches the browser once across several checks", async () => {
+      const launch = vi.fn(async () => browser as unknown as BrowserLike);
+      setPuppeteer({ launch });
+
+      const object = build();
+      await call(object, "/state", { method: "POST", body: JSON.stringify(sampleState()) });
+      await call(object, "/check", { method: "POST", body: checkBody() });
+      await call(object, "/check", { method: "POST", body: checkBody() });
+
+      expect(launch).toHaveBeenCalledTimes(1);
+    });
+
+    it("pushes the idle alarm out after every check", async () => {
+      const object = build();
+      await call(object, "/state", { method: "POST", body: JSON.stringify(sampleState()) });
+
+      await call(object, "/check", { method: "POST", body: checkBody() });
+      const count = storage.alarms.length;
+      await call(object, "/check", { method: "POST", body: checkBody() });
+
+      expect(storage.alarms.length).toBeGreaterThan(count);
+    });
+  });
+
+  describe("the idle alarm", () => {
+    it("closes the browser, because an open session is billed", async () => {
+      const object = build();
+      await call(object, "/state", { method: "POST", body: JSON.stringify(sampleState()) });
+      await call(object, "/check", {
+        method: "POST",
+        body: JSON.stringify({ url: "https://app.example.test/dashboard" }),
+      });
+
+      await object.alarm();
+
+      expect(browser.closed).toBe(true);
+    });
+
+    it("is scheduled from BROWSER_IDLE_MINUTES", async () => {
+      const object = new GoogleLoginBrowser({ storage }, { ...env(), BROWSER_IDLE_MINUTES: "10" } as Env);
+      await call(object, "/state", { method: "POST", body: JSON.stringify(sampleState()) });
+      await call(object, "/check", {
+        method: "POST",
+        body: JSON.stringify({ url: "https://app.example.test/dashboard" }),
+      });
+
+      expect(storage.alarms.at(-1)! - Date.now()).toBeGreaterThan(9 * 60_000);
+    });
+
+    it("falls back to 3 minutes for a nonsense value", async () => {
+      const object = new GoogleLoginBrowser({ storage }, { ...env(), BROWSER_IDLE_MINUTES: "soon" } as Env);
+      await call(object, "/state", { method: "POST", body: JSON.stringify(sampleState()) });
+      await call(object, "/check", {
+        method: "POST",
+        body: JSON.stringify({ url: "https://app.example.test/dashboard" }),
+      });
+
+      const delay = storage.alarms.at(-1)! - Date.now();
+      expect(delay).toBeGreaterThan(2.5 * 60_000);
+      expect(delay).toBeLessThan(3.5 * 60_000);
+    });
+
+    it("survives a browser that is already gone", async () => {
+      const object = build();
+      await call(object, "/state", { method: "POST", body: JSON.stringify(sampleState()) });
+      await call(object, "/check", {
+        method: "POST",
+        body: JSON.stringify({ url: "https://app.example.test/dashboard" }),
+      });
+      browser.close = async () => {
+        throw new Error("Browser session not found");
+      };
+
+      await expect(object.alarm()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("POST /login", () => {
+    it("is disabled unless ALLOW_REAL_GOOGLE_LOGIN is exactly 'true'", async () => {
+      for (const flag of [undefined, "1", "yes", "TRUE"]) {
+        const response = await call(build({ ALLOW_REAL_GOOGLE_LOGIN: flag }), "/login", {
+          method: "POST",
+          body: JSON.stringify({ loginUrl: "https://app.example.test/login" }),
+        });
+
+        expect(response.status).toBe(403);
+        expect(await response.json()).toMatchObject({ error: "disabled" });
+      }
+    });
+
+    it("stays disabled with the flag on but no credentials", async () => {
+      const response = await call(build({ ALLOW_REAL_GOOGLE_LOGIN: "true" }), "/login", {
+        method: "POST",
+        body: JSON.stringify({ loginUrl: "https://app.example.test/login" }),
+      });
+
+      expect(response.status).toBe(403);
+    });
+
+    it("never reveals the credentials it refuses to use", async () => {
+      const response = await call(
+        build({ ALLOW_REAL_GOOGLE_LOGIN: "false", GOOGLE_TEST_PASSWORD: "correct-horse" }),
+        "/login",
+        { method: "POST", body: JSON.stringify({ loginUrl: "https://app.example.test/login" }) },
+      );
+
+      expect(await response.text()).not.toContain("correct-horse");
+    });
+  });
+
+  it("404s an unknown route with the method and path", async () => {
+    const response = await call(build(), "/nope");
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({ message: expect.stringContaining("GET /nope") });
+  });
+
+  it("POST /close shuts the browser down on demand", async () => {
+    const object = build();
+    await call(object, "/state", { method: "POST", body: JSON.stringify(sampleState()) });
+    await call(object, "/check", {
+      method: "POST",
+      body: JSON.stringify({ url: "https://app.example.test/dashboard" }),
+    });
+
+    expect(await (await call(object, "/close", { method: "POST" })).json()).toEqual({ closed: true });
+    expect(browser.closed).toBe(true);
+  });
+});
+
+describe("POST /login, with the flag on", () => {
+  let storage: FakeStorage;
+  let page: FakePage;
+  let browser: FakeBrowser;
+
+  const enabled = {
+    ALLOW_REAL_GOOGLE_LOGIN: "true",
+    GOOGLE_TEST_EMAIL: "e2e@example.test",
+    GOOGLE_TEST_PASSWORD: "correct-horse-battery-staple",
+  };
+
+  const loginBody = (extra: Record<string, unknown> = {}) =>
+    JSON.stringify({ loginUrl: "https://app.example.test/login", expectUrl: "/dashboard", ...extra });
+
+  beforeEach(() => {
+    storage = new FakeStorage();
+    page = new FakePage();
+
+    // Google's form, modelled just enough for the page functions to run: the
+    // app's button hands off, and the final Next lands back on our own origin.
+    page.selectors.set('a[href*="google"], button[data-provider="google"]', fakeElement());
+    page.selectors.set("input[type=email]", fakeElement());
+    page.selectors.set('input[type="email"]', fakeElement());
+    page.selectors.set('input[type="password"]', fakeElement());
+    page.selectors.set("#identifierNext button, #identifierNext", fakeElement());
+    page.selectors.set(
+      "#passwordNext button, #passwordNext",
+      fakeElement(() => {
+        void page.goto("https://app.example.test/dashboard");
+      }),
+    );
+
+    browser = new FakeBrowser(() => page);
+    setPuppeteer({ launch: async () => browser as unknown as BrowserLike });
+  });
+
+  afterEach(() => setPuppeteer(undefined));
+
+  const object = () => new GoogleLoginBrowser({ storage }, { ...env(), ...enabled } as Env);
+
+  it("requires a loginUrl", async () => {
+    const response = await object().fetch(request("/login", { method: "POST", body: "{}" }));
+
+    expect(response.status).toBe(400);
+  });
+
+  it("requires an expectUrl, and says why it is not defaulted", async () => {
+    const response = await object().fetch(
+      request("/login", { method: "POST", body: JSON.stringify({ loginUrl: "https://app.example.test/login" }) }),
+    );
+
+    // Defaulting it to the login page's origin would make every login "succeed":
+    // the flow starts on that origin.
+    expect(response.status).toBe(400);
+    expect(await response.text()).toMatch(/login page is on that origin too/);
+  });
+
+  it("signs in, captures the session and stores it", async () => {
+    const response = await object().fetch(request("/login", { method: "POST", body: loginBody() }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ stored: true });
+    expect(await storage.get("storage-state")).toBeTruthy();
+  });
+
+  it("types the password through the element rather than into evaluate's source", async () => {
+    await object().fetch(request("/login", { method: "POST", body: loginBody() }));
+
+    // A password interpolated into a `page.evaluate` source string ends up in CDP
+    // logs and in a trace. It must travel as an argument.
+    const sources = page.calls
+      .filter((call) => call.method === "evaluate")
+      .map((call) => JSON.stringify(call.args));
+    expect(sources.some((source) => source.includes(enabled.GOOGLE_TEST_PASSWORD))).toBe(true);
+
+    const password = page.selectors.get('input[type="password"]') as { value: string; events: string[] };
+    expect(password.value).toBe(enabled.GOOGLE_TEST_PASSWORD);
+    // Frameworks that bind the field need these, or the form submits empty.
+    expect(password.events).toEqual(["input", "change"]);
+  });
+
+  it("closes the page and pushes the alarm out even when the flow fails", async () => {
+    page.selectors.delete('input[type="password"]');
+
+    const response = await object().fetch(request("/login", { method: "POST", body: loginBody() }));
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toMatchObject({ message: expect.stringContaining("No element matched") });
+    expect(page.callOrder).toContain("close");
+    expect(storage.alarms).not.toHaveLength(0);
+  });
+
+  it("times out rather than clicking through a consent screen", async () => {
+    page.selectors.set("#passwordNext button, #passwordNext", fakeElement());
+
+    const response = await object().fetch(
+      request("/login", { method: "POST", body: loginBody({ timeoutMs: 250 }) }),
+    );
+
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as { message: string };
+    expect(body.message).toMatch(/Timed out waiting for a URL containing/);
+    expect(body.message).toMatch(/capture the session by hand/);
+  });
+
+  it("never leaks the password into the timeout message", async () => {
+    page.selectors.set("#passwordNext button, #passwordNext", fakeElement());
+
+    const response = await object().fetch(
+      request("/login", { method: "POST", body: loginBody({ timeoutMs: 250 }) }),
+    );
+
+    expect(await response.text()).not.toContain(enabled.GOOGLE_TEST_PASSWORD);
+  });
+});

--- a/packages/test-google-login/tsconfig.json
+++ b/packages/test-google-login/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": ["@cloudflare/workers-types", "node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": false,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": false
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "vite.config.ts", "vitest.config.ts"],
+  "exclude": ["node_modules", "dist", ".wrangler", "examples"]
+}

--- a/packages/test-google-login/vite.config.ts
+++ b/packages/test-google-login/vite.config.ts
@@ -1,0 +1,36 @@
+import { resolve } from "node:path";
+
+import { defineConfig } from "vite";
+import dts from "vite-plugin-dts";
+
+// Two entries, not one. `index` is the Node/Playwright half and runs in a test
+// process; `worker` is the Cloudflare half and runs in a Worker isolate. Bundling
+// them together would drag `node:fs` into the Worker build, which does not start.
+export default defineConfig({
+  build: {
+    lib: {
+      entry: {
+        index: resolve(__dirname, "src/index.ts"),
+        worker: resolve(__dirname, "src/worker.ts"),
+      },
+      formats: ["es"],
+    },
+    rollupOptions: {
+      // Everything the package expects its host to supply: node builtins for the
+      // Playwright half, `@cloudflare/puppeteer` for the Worker half. Both are
+      // peer dependencies, so neither may be inlined.
+      external: [/^node:/, "@cloudflare/puppeteer"],
+    },
+    target: "es2022",
+    outDir: "dist",
+    emptyOutDir: true,
+    minify: false,
+  },
+  plugins: [
+    dts({
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts"],
+      outDir: "dist",
+    }),
+  ],
+});

--- a/packages/test-google-login/vitest.config.ts
+++ b/packages/test-google-login/vitest.config.ts
@@ -1,0 +1,31 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from "vitest/config";
+
+// Per-package Vitest setup. Coverage is written to this package's own
+// ./coverage/lcov.info so Codecov can flag it under "test-google-login".
+//
+// The suite never launches a browser: every function that touches a Playwright
+// or Puppeteer object takes it as an argument, so the tests drive fakes. That is
+// what keeps this package's own CI free of a browser download.
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["{test,tests,src}/**/*.{test,spec}.{js,mjs,ts,tsx}"],
+    exclude: ["**/node_modules/**", "**/dist/**"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "lcov"],
+      reportsDirectory: "./coverage",
+      reportOnFailure: true,
+      include: ["src/**/*.ts"],
+      exclude: [
+        "**/node_modules/**",
+        "**/dist/**",
+        "**/coverage/**",
+        "**/*.d.ts",
+        "**/*.config.*",
+        "**/*.{test,spec}.*",
+      ],
+    },
+  },
+});

--- a/packages/test-google-login/wrangler.jsonc
+++ b/packages/test-google-login/wrangler.jsonc
@@ -1,0 +1,55 @@
+{
+  // ── Core ────────────────────────────────────────────────────────────────────
+  // The Worker half: a Durable Object that holds one Browser Rendering session
+  // and replays a persisted storageState against your app. Deploying this is
+  // optional — the Playwright half of the package needs none of it.
+  "name": "test-google-login",
+  "main": "src/worker.ts",
+  "compatibility_date": "2025-11-01",
+  "compatibility_flags": ["nodejs_compat"],
+  // Wrangler deletes plaintext Variables set in the dashboard on every deploy
+  // unless keep_vars is set. Secrets are never deleted either way.
+  "keep_vars": true,
+
+  // ── Browser Rendering ───────────────────────────────────────────────────────
+  // Requires the Workers Paid plan. The binding is what `@cloudflare/puppeteer`
+  // launches against; there is no Chromium in the bundle.
+  "browser": {
+    "binding": "BROWSER",
+  },
+
+  // ── The session holder ──────────────────────────────────────────────────────
+  // One Durable Object per named session. A browser takes seconds to start, so
+  // the DO keeps it alive between requests and an alarm closes it once idle —
+  // without that, a cold launch is paid on every single check.
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "BROWSER_SESSION",
+        "class_name": "GoogleLoginBrowser",
+      },
+    ],
+  },
+
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["GoogleLoginBrowser"],
+    },
+  ],
+
+  // ── Secrets ─────────────────────────────────────────────────────────────────
+  // Set these with `wrangler secret put <NAME>` — never hardcode values here.
+  //
+  // TEST_AUTH_SECRET   — required. Every request must present it as
+  //                      `x-test-auth-secret`; without it set, the Worker 503s
+  //                      rather than serving an unauthenticated browser.
+  // ALLOW_REAL_GOOGLE_LOGIN — "true" to enable POST /login. Leave unset.
+  // GOOGLE_TEST_EMAIL  — dedicated test account, only with the flag above.
+  // GOOGLE_TEST_PASSWORD — same.
+  "vars": {
+    // Minutes of inactivity before the DO closes its browser. Cheap to raise if
+    // your suite is slow, but an idle browser is billed.
+    "BROWSER_IDLE_MINUTES": "3",
+  },
+}

--- a/skills/README.md
+++ b/skills/README.md
@@ -44,6 +44,7 @@ the package.
 | [repo-badges](./repo-badges/SKILL.md) | `template-git-repo` | The README badge template: which badges, which rows, what each needs set up outside the repo |
 | [server-shell-setup](./server-shell-setup/SKILL.md) | `server-shell-setup` | The bootstrap installer, components, fish aliases |
 | [template-git-repo](./template-git-repo/SKILL.md) | `template-git-repo` | One-command repo setup: workflows, helper scripts, turbo.json, codecov.yml, badge block |
+| [test-google-login](./test-google-login/SKILL.md) | `test-google-login` | Persisting a Google sign-in as a Playwright storageState, the setup-project guard, app-minted sessions, and the Workers Browser Rendering Durable Object |
 | [verify-phone-sms](./verify-phone-sms/SKILL.md) | `verify-phone-sms` | SNS-backed SMS verification, endpoints, auth, VoIP blocking |
 | [web2mobile](./web2mobile/SKILL.md) | `web2mobile-wrapper` | Website → Expo WebView app, asset generation, EAS build/submit |
 

--- a/skills/test-google-login/API.md
+++ b/skills/test-google-login/API.md
@@ -1,0 +1,402 @@
+# test-google-login — API
+
+Exact signatures. Narrative, recipes and troubleshooting are in
+[SKILL.md](SKILL.md).
+
+Two entry points:
+
+```ts
+import { /* … */ } from "test-google-login";          // Node / Playwright
+import { /* … */ } from "test-google-login/worker";   // Cloudflare Workers
+```
+
+## Types
+
+```ts
+type SameSite = "Strict" | "Lax" | "None";
+
+interface StorageStateCookie {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  expires: number;   // Unix SECONDS; -1 for a session cookie
+  httpOnly: boolean;
+  secure: boolean;
+  sameSite: SameSite;
+}
+
+interface StorageStateOrigin {
+  origin: string;
+  localStorage: { name: string; value: string }[];
+}
+
+interface StorageState {
+  cookies: StorageStateCookie[];
+  origins: StorageStateOrigin[];
+}
+
+interface PuppeteerCookie {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  expires?: number;   // ABSENT for a session cookie, never -1
+  httpOnly: boolean;
+  secure: boolean;
+  sameSite?: SameSite;
+  session?: boolean;  // CDP sets this on read
+}
+
+interface StorageStateSummary {
+  cookieCount: number;
+  originCount: number;
+  domains: string[];                            // deduped, sorted
+  cookieNames: string[];                        // deduped, sorted
+  localStorageKeys: Record<string, string[]>;   // origin -> keys; values omitted
+  sessionCookies: number;
+  earliestExpiry: number | null;                // Unix seconds; null if none carry one
+  expiresInSeconds: number | null;              // negative once passed
+  expired: boolean;                             // every expiring cookie has passed
+  usable: boolean;                              // at least one cookie a browser would send
+  hasGoogleCookies: boolean;
+}
+```
+
+`StorageStateSummary` contains **no value** from the state. It is safe to print,
+log and return.
+
+## Paths and bootstrap
+
+```ts
+const DEFAULT_AUTH_DIR = "playwright/.auth";
+const DEFAULT_AUTH_FILE = "playwright/.auth/google-test-user.json";
+const STATE_PATH_ENV = "TEST_GOOGLE_LOGIN_STATE";
+const GITIGNORE_LINES: readonly ["playwright/.auth/", ".env", ".env.*", "!.env.example"];
+
+interface AuthFileOptions {
+  cwd?: string;    // default process.cwd()
+  file?: string;   // absolute, or relative to cwd
+  env?: Record<string, string | undefined>;   // default process.env
+}
+
+resolveAuthFile(options?: AuthFileOptions): string
+```
+
+Resolution order: `options.file` → `$TEST_GOOGLE_LOGIN_STATE` → `DEFAULT_AUTH_FILE`.
+Always returns an absolute path.
+
+```ts
+ensureAuthDir(file: string): string          // mkdir -p, mode 0700, chmods an existing dir too
+writeAuthDirGitignore(file: string): string   // writes <dir>/.gitignore containing "*"
+isIgnored(gitignore: string, pattern: string): boolean
+
+ensureGitignored(options?: { cwd?: string; patterns?: readonly string[] }): {
+  file: string;
+  added: string[];
+  alreadyIgnored: string[];
+}
+
+codegenCommand(options?: { file?: string; baseUrl?: string; cwd?: string }): string
+```
+
+`ensureGitignored` is idempotent and only ever appends — it never rewrites or
+reorders existing lines. `isIgnored` compares ignore *lines*, not paths: it
+recognises `playwright/.auth`, `playwright/.auth/`, `/playwright/.auth/` and a
+parent `playwright/`, and treats a `!` negation as not covered. An unrecognised
+pattern costs a duplicate line, which is harmless.
+
+`codegenCommand` defaults `baseUrl` to `http://localhost:3000` and emits the path
+relative to `cwd`.
+
+## Reading, writing, inspecting
+
+```ts
+const SESSION_COOKIE_EXPIRES = -1;
+
+class InvalidStorageStateError extends Error {}              // message: "Not a Playwright storage state: <reason>"
+class MissingStorageStateError extends Error { file: string } // message carries the codegen command
+
+normalizeStorageState(raw: unknown): StorageState
+parseStorageState(text: string): StorageState
+readStorageState(file: string, options?: { baseUrl?: string; cwd?: string }): StorageState
+writeStorageState(file: string, state: StorageState): string      // absolute path; mode 0600
+hardenStorageStateFile(file: string): StorageStateSummary         // chmod 0600 + validate, in place
+```
+
+`normalizeStorageState` fills in what a hand-edited or older file omits (`path`
+→ `/`, missing `expires` → `-1`, `httpOnly`/`secure` → `false`), re-capitalises
+`sameSite`, falls back to `Lax` for a value CDP would reject, and drops malformed
+`localStorage` entries. It throws `InvalidStorageStateError` for a non-object top
+level, a non-array `cookies`/`origins`, neither key present, a cookie without a
+name/value pair or a domain, or an origin without an `origin`.
+
+`readStorageState` throws `MissingStorageStateError` on `ENOENT` — carrying the
+`codegen` command — and rethrows anything else unchanged.
+
+`hardenStorageStateFile` is for files **Playwright** wrote: `storageState({ path,
+indexedDB: true })` adds a top-level key this package has no type for, so the
+file is validated and chmodded in place rather than re-serialised (which would
+drop it).
+
+```ts
+summarizeStorageState(state: StorageState, options?: { now?: number }): StorageStateSummary
+findExpiringCookies(state: StorageState, options?: { now?: number; withinMs?: number }): StorageStateCookie[]
+assertStorageStateUsable(state, options?: { now?: number; file?: string; baseUrl?: string; cwd?: string }): StorageStateSummary
+redactStorageState(state: StorageState): StorageState
+isGoogleDomain(domain: string): boolean
+```
+
+`now` is milliseconds since epoch (default `Date.now()`); it exists so expiry
+assertions are deterministic. `findExpiringCookies` defaults to a one-hour window
+and never reports a session cookie. `assertStorageStateUsable` returns the summary
+when good and otherwise throws with how long ago it lapsed plus the `codegen`
+command. `redactStorageState` returns a new state — it does not mutate — with
+every cookie and `localStorage` value replaced by `«redacted N chars»`.
+
+## Playwright flows
+
+```ts
+const ALLOW_REAL_LOGIN_ENV = "TEST_GOOGLE_LOGIN_ALLOW_REAL";
+const BOOTSTRAP_HEADER = "x-e2e-auth-secret";
+
+interface StoredSessionOptions { file?: string; cwd?: string; baseUrl?: string; now?: number }
+
+requireStoredSession(options?: StoredSessionOptions): StorageStateSummary
+loadStorageStateFor(options?: StoredSessionOptions): StorageState
+realGoogleLoginEnabled(env?: Record<string, string | undefined>): boolean
+```
+
+`requireStoredSession` = read + `assertStorageStateUsable`. It never *creates* a
+session. `realGoogleLoginEnabled` is true only for `TEST_GOOGLE_LOGIN_ALLOW_REAL`
+of `1`/`true` (case-insensitive) **and** both `GOOGLE_TEST_EMAIL` and
+`GOOGLE_TEST_PASSWORD` set.
+
+```ts
+interface BootstrapAppSessionOptions extends StoredSessionOptions {
+  request: RequestLike;          // Playwright's `request` fixture
+  page: PlaywrightPageLike;      // Playwright's `page` fixture
+  context: ContextLike;          // Playwright's `context` fixture
+  endpoint?: string;             // default "/api/test-auth/google-user"
+  secret?: string;               // REQUIRED — never defaulted
+  landingPath?: string;          // default "/dashboard"
+  user?: Record<string, unknown>;// posted as the body
+  indexedDB?: boolean;           // default true
+}
+
+bootstrapAppSession(options: BootstrapAppSessionOptions): Promise<string>   // the state file path
+```
+
+POSTs to `endpoint` with the secret in the `x-e2e-auth-secret` **header** (never
+the URL or body), navigates `page` to `landingPath` so the app's origin is in the
+context, writes the state via Playwright, then chmods it to 0600. Throws without a
+`secret` *before* making any request. A non-OK response throws with the status and
+the first 400 bytes of the body.
+
+```ts
+interface GoogleSignInOptions extends StoredSessionOptions {
+  page: PlaywrightPageLike;
+  context: ContextLike;
+  env?: Record<string, string | undefined>;
+  loginPath?: string;                  // default "/login"
+  signInButton?: string | RegExp;      // default /continue with google|sign in with google/i
+  expectUrl?: RegExp;                  // default /dashboard|app/
+  indexedDB?: boolean;                 // default true
+  googleSelectors?: { email?: RegExp; password?: RegExp; next?: RegExp };
+}
+
+signInWithGoogle(options: GoogleSignInOptions): Promise<string>
+```
+
+Throws — touching nothing — unless `realGoogleLoginEnabled(env)`. Google's own
+labels default to `/email or phone/i`, `/enter your password/i` and `/^next$/i`
+and are overridable, because Google changes them. It waits for `expectUrl` rather
+than clicking through a consent screen or device check; those time out by design.
+
+### Structural fixture types
+
+Declared structurally so nothing imports Playwright:
+
+```ts
+interface ContextLike { storageState(options?: { path?: string; indexedDB?: boolean }): Promise<unknown> }
+interface RequestLike {
+  post(url: string, options?: { headers?: Record<string, string>; data?: unknown }):
+    Promise<{ ok(): boolean; status(): number; text(): Promise<string> }>;
+}
+interface LocatorLike { click(o?: Record<string, unknown>): Promise<void>; fill(v: string, o?: Record<string, unknown>): Promise<void> }
+interface PlaywrightPageLike {
+  goto(url: string, o?: Record<string, unknown>): Promise<unknown>;
+  waitForURL(url: string | RegExp, o?: Record<string, unknown>): Promise<void>;
+  url(): string;
+  getByRole(role: string, o?: { name?: string | RegExp }): LocatorLike;
+  getByLabel(text: string | RegExp, o?: Record<string, unknown>): LocatorLike;
+}
+```
+
+## Puppeteer bridge
+
+```ts
+toPuppeteerCookies(state: StorageState): PuppeteerCookie[]
+fromPuppeteerCookies(cookies: PuppeteerCookie[]): StorageStateCookie[]
+storageStateOrigins(state: StorageState): string[]
+applyLocalStorage(page: PageLike, entries: { name: string; value: string }[]): Promise<void>
+
+interface ApplyStorageStateOptions {
+  origins?: string[];                        // default: every origin in the state
+  gotoOptions?: Record<string, unknown>;
+}
+
+interface ApplyStorageStateResult {
+  cookiesSet: number;
+  originsRestored: string[];
+  skipped: { origin: string; reason: string }[];
+}
+
+applyStorageState(page: PageLike, state: StorageState, options?: ApplyStorageStateOptions): Promise<ApplyStorageStateResult>
+extractStorageState(page: PageLike, options?: { origins?: string[]; gotoOptions?: Record<string, unknown> }): Promise<StorageState>
+```
+
+`toPuppeteerCookies` **omits** `expires` for a session cookie rather than sending
+`-1`. `fromPuppeteerCookies` maps `session: true` or a missing expiry back to `-1`,
+normalises `sameSite` (including CDP's `"unspecified"` → `Lax`) and defaults an
+empty `path` to `/`. Round-tripping a state leaves it unchanged.
+
+`applyStorageState` sets every cookie in **one** `setCookie` call, before any
+navigation, then navigates once per origin (`waitUntil: "domcontentloaded"`) to
+restore `localStorage`. An origin with no entries is skipped without navigating; an
+unreachable one lands in `skipped` rather than losing the cookies already set. A
+cookie-only state performs no navigation. Throws a `TypeError` naming
+`browserContext.setCookie` when the page has no `setCookie` (Puppeteer 23+).
+
+`extractStorageState` defaults `origins` to the page's current origin (none on
+`about:blank`), skips re-navigating when already there, and returns the cookies
+even when an origin cannot be reached. Throws a `TypeError` when the page cannot
+read cookies.
+
+```ts
+interface PageLike {
+  goto(url: string, options?: Record<string, unknown>): Promise<unknown>;
+  evaluate<T>(fn: (...args: never[]) => T, ...args: unknown[]): Promise<T>;
+  url(): string;
+  setCookie?(...cookies: PuppeteerCookie[]): Promise<void>;
+  cookies?(...urls: string[]): Promise<PuppeteerCookie[]>;
+  deleteCookie?(...cookies: { name: string; domain?: string; path?: string }[]): Promise<void>;
+}
+```
+
+## Secrets
+
+```ts
+const AUTH_HEADER = "x-test-auth-secret";
+
+constantTimeEqual(supplied: string | null | undefined, expected: string | null | undefined): boolean
+isAuthorized(headers: { get(name: string): string | null }, expected: string | null | undefined): boolean
+```
+
+Hand-rolled rather than `node:crypto.timingSafeEqual`, so the Worker half needs no
+`nodejs_compat`. Both return `false` whenever `expected` is empty or unset — a
+Worker without its secret configured matches nothing, including `""`.
+
+## Worker entry (`test-google-login/worker`)
+
+```ts
+interface Env {
+  BROWSER: unknown;                      // Browser Rendering binding
+  BROWSER_SESSION: DurableObjectNamespaceLike;
+  TEST_AUTH_SECRET?: string;             // unset => 503 for everything
+  ALLOW_REAL_GOOGLE_LOGIN?: string;      // exactly "true" to enable POST /login
+  GOOGLE_TEST_EMAIL?: string;
+  GOOGLE_TEST_PASSWORD?: string;
+  BROWSER_IDLE_MINUTES?: string;         // default "3"
+}
+
+handleRequest(request: Request, env: Env): Promise<Response>
+export default { fetch: handleRequest }
+
+class GoogleLoginBrowser {
+  constructor(state: { storage: DurableObjectStorageLike }, env: Env);
+  fetch(request: Request): Promise<Response>;
+  alarm(): Promise<void>;
+}
+
+setPuppeteer(implementation: PuppeteerLike | undefined): void
+```
+
+`handleRequest` returns `503 {error:"not_configured"}` when `TEST_AUTH_SECRET` is
+unset, `401 "Unauthorized"` (with `x-required-header`) on a bad secret, answers
+`/health` without waking a browser, and otherwise routes to the DO named by
+`?session=` (default `"default"`).
+
+`setPuppeteer` overrides the lazily-imported `@cloudflare/puppeteer` — for tests
+and bring-your-own builds.
+
+### Routes (on the Durable Object)
+
+| Route | Body | Returns |
+| --- | --- | --- |
+| `POST /state` | a `StorageState` | `{ stored: true, summary }` — validated in; never echoed |
+| `GET /state` | — | `{ present, summary, redacted }`, or `404 { present: false }` |
+| `DELETE /state` | — | `{ cleared: boolean }`; also closes the browser |
+| `POST /check` | `{ url, expectSelector?, rejectUrl?, origins?, screenshot? }` | `CheckResult` |
+| `POST /login` | `{ loginUrl, expectUrl, signInSelector?, origins?, timeoutMs? }` | `{ stored, summary }`, or `403 { error: "disabled" }` |
+| `POST /close` | — | `{ closed: true }` |
+
+```ts
+interface CheckResult {
+  authenticated: boolean;
+  status: number | null;
+  url: string;
+  title: string;
+  reason: string;                       // why it concluded that — the useful half on false
+  applied: ApplyStorageStateResult;
+  screenshot?: string;                  // base64 PNG, only when requested
+}
+```
+
+`/check` returns `400` without a `url` and `409 { error: "no_state" }` when nothing
+is stored. `authenticated` is `false` if `rejectUrl` appears in the landing URL, or
+if `expectSelector` is not found; with neither, it only reports that navigation
+happened — **always pass `rejectUrl`**, since a login redirect is still a `200`.
+
+`/login` requires **both** `loginUrl` and `expectUrl` (a substring of the URL you
+land on once signed in, e.g. `"/dashboard"`). `expectUrl` is deliberately not
+defaulted to the login page's origin — the flow *starts* there, so an origin match
+would pass before Google was involved and every login would "succeed".
+`timeoutMs` defaults to 30 s and is clamped to 250 ms–2 min, so a caller cannot pin
+a billed browser session open indefinitely.
+
+The browser is launched once and reused; each request closes only its page. Every
+browser-using request pushes an alarm `BROWSER_IDLE_MINUTES` out (non-numeric
+values fall back to 3), and the alarm closes the browser — an open Browser
+Rendering session is billed.
+
+```ts
+interface DurableObjectStorageLike {
+  get<T>(key: string): Promise<T | undefined>;
+  put(key: string, value: unknown): Promise<void>;
+  delete(key: string): Promise<boolean>;
+  setAlarm(time: number): Promise<void>;
+}
+```
+
+## CLI
+
+```ts
+parseArgs(argv: string[]): { command: string; flags: Record<string, string | true> }
+runCli(argv: string[], io?: { out?: (line: string) => void; err?: (line: string) => void; cwd?: string }): Promise<number>
+```
+
+`runCli` returns an exit code rather than calling `process.exit`, and takes its
+writers as arguments, so the whole CLI is testable in-process. `bin/cli.js` is a
+three-line wrapper over it.
+
+| Command | Exit codes |
+| --- | --- |
+| `init [--file <path>] [--url <baseUrl>]` | `0` |
+| `check [--file <path>] [--within <mins>] [--json]` | `0` healthy · `1` missing or expired · `2` present but malformed |
+| `redact [--file <path>]` | `0` · `1` unreadable |
+| `clear [--file <path>]` | `0` (also when there was nothing to delete) |
+| `help` | `0` · `1` for an unknown command |
+
+`parseArgs` accepts `--flag value` and `--flag=value`, treats a trailing flag as
+`true`, and does not swallow a following `--flag` as a value.

--- a/skills/test-google-login/SKILL.md
+++ b/skills/test-google-login/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: test-google-login
+description: Guide to test-google-login (packages/test-google-login), the Google sign-in test harness — persisting a Playwright storageState under playwright/.auth/, the requireStoredSession setup-project guard, bootstrapAppSession against a test-only endpoint, the opt-in signInWithGoogle real-Google path, the storageState↔Puppeteer cookie conversion, and the Cloudflare Browser Rendering Durable Object that replays a session. Use when working with test-google-login or troubleshooting Google-login E2E tests — a suite that suddenly redirects to /login, "Missing persisted auth state", an expired or stale state file, cookies that restore but localStorage that does not, session cookies vanishing in Puppeteer, a CDP "invalid cookie fields" error, a Worker returning 503 or 401, real Google sign-in hitting a consent screen or CAPTCHA, or deciding where a storage-state file may safely go.
+---
+
+# Working With test-google-login
+
+The package in `packages/test-google-login`, published as **`test-google-login`**.
+Two entry points from one session file: `test-google-login` (Node/Playwright) and
+`test-google-login/worker` (Cloudflare Browser Rendering Durable Object). Zero
+runtime dependencies — Playwright and `@cloudflare/puppeteer` are optional peers,
+and every function takes the `page` / `context` / `request` it needs as an
+argument. Exact signatures in [API.md](API.md).
+
+## The thing to get right before anything else
+
+`playwright/.auth/google-test-user.json` **is a live credential**, not a config
+file. It can hold the app's session cookie, Google's `accounts.google.com`
+cookies, OAuth tokens in `localStorage`/IndexedDB, and sometimes something
+refresh-capable. A password in `.env` protects none of that.
+
+The package enforces what it can — `0700` directory, `0600` file, two gitignore
+rules, a redacted-only read path — and the rest is process:
+
+- dedicated Google test account, nothing sensitive on it
+- never committed, never a public CI artifact, never pasted into a log or issue
+- `test-google-login redact` is the shareable form
+- regenerate rather than repair when it stops working
+
+If a change would log a value, return one over HTTP, or loosen a file mode, that
+is the thing to push back on.
+
+## Setup
+
+```bash
+bun add -d test-google-login
+npx test-google-login init          # 0700 dir + both gitignore rules + the codegen command
+```
+
+Then capture once, by hand:
+
+```bash
+npx playwright codegen --save-storage=playwright/.auth/google-test-user.json http://localhost:3000
+```
+
+Sign in with the dedicated account, finish the redirect back to **your** app,
+confirm an authenticated page, close the window. Playwright writes on exit.
+
+Manual on purpose: Google may require MFA, a CAPTCHA or a device check, and
+scripting its password form is the brittle part of every other approach.
+
+## Picking the right call
+
+| You want | Call |
+| --- | --- |
+| A setup project that fails usefully on the first run | `requireStoredSession({ baseUrl })` |
+| CI to create the session itself, no Google involved | `bootstrapAppSession({ request, page, context, secret })` |
+| To actually drive Google's form (smoke test only) | `signInWithGoogle({ page, context })` — refuses unless opted in |
+| The state for `browser.newContext()` | `loadStorageStateFor()` |
+| To know if a state is still good, in code | `summarizeStorageState(state)` → `.usable`, `.expired`, `.expiresInSeconds` |
+| To fail a run early on a stale state | `assertStorageStateUsable(state)` |
+| To warn before a long run | `findExpiringCookies(state, { withinMs })` |
+| Something printable | `redactStorageState(state)`, or `summarizeStorageState` (values never in it) |
+| To write a state yourself | `writeStorageState(file, state)` — 0600 |
+| To tighten a file Playwright wrote | `hardenStorageStateFile(file)` — keeps its `indexedDB` key |
+| To restore a session into a Puppeteer page | `applyStorageState(page, state, { origins })` |
+| To capture one out of a Puppeteer page | `extractStorageState(page, { origins })` |
+| Just the cookie conversion | `toPuppeteerCookies` / `fromPuppeteerCookies` |
+| To compare a secret in a Worker | `constantTimeEqual(supplied, expected)` |
+| The Worker half | `GoogleLoginBrowser`, `handleRequest` from `test-google-login/worker` |
+
+## Recipes
+
+**The setup-project layout.** Two projects, so the check runs once per run rather
+than once per file:
+
+```ts
+// playwright.config.ts
+import { DEFAULT_AUTH_FILE } from "test-google-login";
+
+projects: [
+  { name: "auth-setup", testMatch: /.*\.setup\.ts/ },
+  { name: "chromium", dependencies: ["auth-setup"], use: { storageState: DEFAULT_AUTH_FILE } },
+]
+```
+
+```ts
+// tests/auth.setup.ts
+import { requireStoredSession } from "test-google-login";
+
+setup("an authenticated session is available", () => {
+  requireStoredSession({ baseUrl: process.env.E2E_BASE_URL });
+});
+```
+
+Import `DEFAULT_AUTH_FILE` rather than retyping the path — a config and a CLI on
+different paths present identically to an expired session.
+
+**CI: let the app mint it.** Never make a Google password a repo secret a fork's
+PR can reach. Add a test-only endpoint on staging that creates *the same session*
+the real Google callback creates, and hold one secret of your own:
+
+```ts
+await bootstrapAppSession({
+  request, page, context,
+  secret: process.env.E2E_TEST_AUTH_SECRET,   // required; never defaulted
+  endpoint: "/api/test-auth/google-user",
+  landingPath: "/dashboard",
+});
+```
+
+The endpoint must 404 in production (ideally not be in the bundle at all),
+compare its secret in constant time, and produce the identical session format,
+claims, roles and cookie attributes. An endpoint that mints a subtly different
+session turns the suite into a test of a code path that never ships. Worked
+example: `packages/test-google-login/examples/test-auth-endpoint.ts`.
+
+**Narrow the origins when restoring.** A state captured through a real Google
+sign-in also carries `accounts.google.com` storage. Restoring it means navigating
+the test browser to Google — slow, and exactly the traffic its risk checks look
+for:
+
+```ts
+await applyStorageState(page, state, { origins: ["https://app.example.test"] });
+```
+
+A cookie-only state costs no navigation at all.
+
+**The Worker.** One Durable Object per named session, holding one browser:
+
+```ts
+import { GoogleLoginBrowser, handleRequest } from "test-google-login/worker";
+export { GoogleLoginBrowser };
+export default { fetch: handleRequest };
+```
+
+```bash
+wrangler secret put TEST_AUTH_SECRET && wrangler deploy
+```
+
+`POST /state` stores, `GET /state` returns a **redacted** summary, `POST /check`
+replays and reports, `POST /close` closes now. Every request carries
+`x-test-auth-secret`; `?session=<name>` picks the DO.
+
+Always pass `rejectUrl` to `/check`. A redirect to `/login` returns `200`, so
+without it a signed-out check reads as a pass:
+
+```json
+{ "url": "https://app.example.test/dashboard", "expectSelector": "[data-testid=user-menu]", "rejectUrl": "/login" }
+```
+
+**Real Google, if you must.** `signInWithGoogle` needs
+`TEST_GOOGLE_LOGIN_ALLOW_REAL=1` plus `GOOGLE_TEST_EMAIL` and
+`GOOGLE_TEST_PASSWORD`; the Worker's `POST /login` needs
+`ALLOW_REAL_GOOGLE_LOGIN="true"` plus the same two secrets, and `POST /login`
+requires an explicit `expectUrl` — it is not defaulted to the login page's origin,
+because the flow starts there and the wait would pass before sign-in ever
+happened. Manually triggered,
+protected branch, environment-scoped secrets, and expect failures that are not
+the app's fault. It waits for your own origin rather than clicking through
+whatever appears — a consent screen or device check times out, which is correct.
+
+## The three format differences that lose a session silently
+
+Each has a test in `test/puppeteer-state.test.ts` naming the failure it prevents.
+If you are hand-rolling any of this, these are the bugs you will hit:
+
+| Difference | What happens if you miss it |
+| --- | --- |
+| Playwright writes `expires: -1` for a session cookie | CDP reads `-1` as an expiry in 1969 and drops the cookie. The key must be **omitted**, not negative |
+| CDP wants `sameSite` as exactly `Strict` / `Lax` / `None` | One lowercase value rejects the whole `setCookie` batch |
+| `localStorage` can only be written through a document on its origin | There is no blind write; restoring costs one `goto` per origin, before the app's own code runs |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `Missing persisted auth state: …` | No session captured yet | Run the `playwright codegen` command in the error verbatim |
+| Suite redirects to `/login`, selectors time out | The stored session expired | `npx test-google-login check` — exits 1 and tells you how long ago. Re-capture |
+| `Not a Playwright storage state: not valid JSON` | Something else wrote to that path (often an HTML error page) | `test-google-login clear`, re-capture. `check` exits **2** here, not 1 |
+| Cookies restore but the app is still signed out | The session lives in `localStorage`/IndexedDB, not a cookie | Pass `indexedDB: true` when capturing; confirm `summarizeStorageState().originCount > 0` |
+| Works on the first navigation, fails after a reload | `localStorage` was not restored — usually `origins` narrowed too far | Include your app's origin in `applyStorageState`'s `origins` |
+| CDP error about invalid cookie fields | A lowercase `sameSite`, or `expires: -1` passed straight through | Use `toPuppeteerCookies`, or `normalizeStorageState` on a hand-edited file |
+| Session cookies missing after `applyStorageState` | `expires: -1` was sent instead of omitted | `toPuppeteerCookies` already handles it — don't build the cookie list by hand |
+| `page.setCookie is not a function` | Puppeteer 23+ moved it to `browserContext.setCookie` | The thrown error says so; set them on the context, or use an older page API |
+| Worker returns `503 not_configured` | `TEST_AUTH_SECRET` is unset — it refuses everything by design | `wrangler secret put TEST_AUTH_SECRET` |
+| Worker returns `401 Unauthorized` | Missing or wrong `x-test-auth-secret` | Check the header name; the response names it in `x-required-header` |
+| Worker `/check` returns `409 no_state` | Nothing stored for that session name | `POST /state` first — and check `?session=` matches |
+| `/check` says `authenticated: true` on the login page | No `rejectUrl` passed; a login redirect is still a `200` | Pass `rejectUrl: "/login"` and/or `expectSelector` |
+| `POST /login` returns `403 disabled` | `ALLOW_REAL_GOOGLE_LOGIN` is not exactly `"true"`, or credentials are missing | Intentional. Prefer capturing locally instead |
+| Real Google sign-in times out mid-flow | Consent screen, device check, CAPTCHA or MFA | Do not automate around it. Capture by hand with `codegen` |
+| Browser Rendering concurrency errors | More than a few concurrent sessions per account | Route through one DO per session name; the DO serialises and reuses its browser |
+| A surprise Browser Rendering bill | A session left open | The idle alarm closes it (`BROWSER_IDLE_MINUTES`, default 3); `POST /close` closes now |
+| `bun run build` then the Worker fails to start | A `node:` import reached `src/state-core.ts` | `grep -n "node:" dist/worker.js` must print nothing. Keep fs in `storage-state.ts` |
+| Something that worked in a test fails in the app | `sessionStorage` is **not** in `storageState` | Restore it yourself with an init script |
+
+## Repo conventions
+
+- Runner **Vitest**, build **Vite** with two entries. `bun run test` launches no
+  browser: the suite drives fakes for the page, browser and DO storage.
+- Several tests are negative assertions — "this value does not appear in the
+  output". Do not weaken one to accommodate a new field; that is the feature.
+- `src/state-core.ts` is the Worker-safe half and must stay free of Node builtins;
+  `src/storage-state.ts` is the filesystem layer and re-exports it.
+- Update `README.md`, this skill and `packages/test-google-login/CLAUDE.md` when
+  public behaviour changes.


### PR DESCRIPTION
A new package for end-to-end testing of Google sign-in. Sign in by hand once, persist the Playwright `storageState`, and every test after that starts already signed in — locally, in CI, and from a Cloudflare Worker.

```bash
npx test-google-login init     # 0700 dir + both gitignore rules + the codegen command
npx playwright codegen --save-storage=playwright/.auth/google-test-user.json http://localhost:3000
```

## The state file is the credential, not the password

That is what the whole design is built around. A password in `.env` protects nothing once `playwright/.auth/google-test-user.json` exists, because that file can hold the app's session cookie, Google's `accounts.google.com` cookies, OAuth tokens in `localStorage`/IndexedDB, and sometimes something refresh-capable.

- `init` creates `playwright/.auth/` at **0700** and gitignores it **twice** — the root `.gitignore`, plus a nested `playwright/.auth/.gitignore` containing `*` that travels with the directory even if the root file gets reverted or replaced by tooling. Writes are **0600**, and re-chmod a state file that already existed as 0644.
- **Nothing prints, logs or returns a value.** `summarizeStorageState` reports counts, domains, names and expiries only; `redactStorageState` replaces every value with `«redacted 21 chars»`; the Worker's `GET /state` serves the redacted copy, and there is deliberately **no route that reads the session back out**.
- **Real Google sign-in is opt-in and off by default, twice over** (`TEST_GOOGLE_LOGIN_ALLOW_REAL` plus credentials on the Playwright side, `ALLOW_REAL_GOOGLE_LOGIN="true"` plus credentials in the Worker). It waits for your own origin rather than clicking through a consent screen, CAPTCHA or device check — those time out by design, because they are the controls protecting the account.

## Three ways to get a signed-in browser

In the order to prefer them:

| | For | Secrets held |
| --- | --- | --- |
| `requireStoredSession` | local development | none |
| `bootstrapAppSession` | every PR check | `E2E_TEST_AUTH_SECRET` |
| `signInWithGoogle` | occasional manual smoke test | a dedicated account's, environment-scoped |

`requireStoredSession` is the body of a Playwright setup project, and it earns its keep by turning the expensive failure mode into a readable one. An expired session otherwise presents as a selector timeout on a login page:

```text
The persisted session is no longer usable — it expired 380 minutes ago.

Re-capture it:
  npx playwright codegen --save-storage=playwright/.auth/google-test-user.json http://localhost:3000
```

`bootstrapAppSession` has the app mint its own session through a test-only endpoint, so CI holds one secret of yours instead of a Google password that every fork's PR could reach. State is regenerated each run and no Google traffic is involved, so a check cannot fail because Google showed a consent screen. The endpoint itself is worked through in `examples/test-auth-endpoint.ts`.

## The Cloudflare half

A Browser Rendering **Durable Object** holding one browser across a whole suite. Not an optimisation: a launch costs seconds and is billed, Browser Rendering caps concurrent sessions per account (which a parallel run would trip), and an *unclosed* session is billed too — hence the idle alarm that closes it.

| Route | Does |
| --- | --- |
| `POST /state` | Store a state. Validated in; the response summarises, never echoes |
| `GET /state` | A **redacted** summary. No route returns live cookies |
| `POST /check` | Replay against a URL; reports `authenticated`, landing URL, title, optional screenshot |
| `POST /login` | Real Google sign-in, off unless explicitly enabled |
| `POST /close` | Close the browser now |

Every request must carry `x-test-auth-secret`. With `TEST_AUTH_SECRET` unset the Worker returns `503` to **everything** rather than serving an anonymous browser to whoever finds the URL.

Two sharp edges the API forces you past rather than defaulting around:

- `/check` wants `rejectUrl` — a redirect to `/login` is still a `200`, so without it a signed-out check reads as a pass.
- `/login` **requires** `expectUrl`. Defaulting it to the login page's origin would make every login "succeed", since the flow starts on that origin. (Caught by a test while writing this.)

## Carrying one state file between Playwright and Puppeteer

Three differences, each of which loses a session silently, so each has a test naming the failure it prevents:

| Difference | Without handling it |
| --- | --- |
| Playwright writes `expires: -1` for a session cookie | CDP reads `-1` as an expiry in 1969 and drops the cookie — the key must be **omitted** |
| CDP wants `sameSite` as exactly `Strict`/`Lax`/`None` | One lowercase value rejects the whole `setCookie` batch |
| `localStorage` needs a document on its origin | No blind write exists; restoring costs one navigation per origin, before the app's code runs |

`applyStorageState` sets every cookie in one call before any navigation, and takes an `origins` filter — a state captured through a real Google sign-in also carries `accounts.google.com` storage, and navigating a datacentre browser to Google to restore it is slow and is exactly the traffic its risk checks look for. A cookie-only state costs no navigation at all.

## Tests

**184 tests, no browser launched, under a second.** Every function takes the `page` / `context` / `request` it needs as an argument, so the suite drives fakes for the page, the browser and the DO's storage — which is also why the package has **zero runtime dependencies** (Playwright and `@cloudflare/puppeteer` are optional peers).

Coverage is 97% of statements / 98.5% of lines; the remainder is the dynamic `@cloudflare/puppeteer` import, which cannot be exercised in a Node process. Several assertions are deliberately negative — that a given value does **not** appear in a log, a response or a summary. Those are the feature, not incidental.

```
bun run test       → 184 passed
bun run typecheck  → clean
bun run build      → dist/index.js + dist/worker.js
bun run readmes:check → up to date
```

## Layout note

`src/state-core.ts` is the Worker-safe half and must stay free of Node builtins — one `node:fs` there and the Worker bundle fails at **deploy** rather than in a test. `src/storage-state.ts` is the filesystem layer and re-exports it, so Node callers still see one surface. `grep -n "node:" dist/worker.js` prints nothing; `dist/index.js` has the two it should.

## Also in this PR

Registering the package the way this repo expects: a Codecov flag, a `tests.yml` matrix entry, `SKILLS_BY_PACKAGE` in the README-header generator, the skills index, the architecture catalog, the root README and its tests table, the per-workspace notes table, and `skills/test-google-login/{SKILL,API}.md`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnG8ocxQxwoq9rL5NSgNSZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnG8ocxQxwoq9rL5NSgNSZ)_