### PR TITLE
📝 docs(apps): give every app a README with env vars, setup and deploy

### DIFF
--- a/apps/Cloud-Computer-Control-Panel/README.md
+++ b/apps/Cloud-Computer-Control-Panel/README.md
@@ -62,7 +62,7 @@ starter template, which supplies the auth, database and theming layers.
 
 ## Prerequisites
 
-- Node.js 18+ and npm/yarn/pnpm
+- [Bun](https://bun.sh) 1.3+ — the monorepo pins `bun@1.3.11`; do not use npm or yarn
 - AWS Account with IAM credentials (Access Key ID + Secret Access Key)
 - Required AWS IAM permissions for EC2 operations:
   - `ec2:DescribeInstances`
@@ -83,59 +83,102 @@ Follow these guides to create programmatic access credentials:
 
 ## Getting Started
 
-### Installation
-
-1. Clone the repository:
-
-```bash
-git clone https://github.com/yourusername/aws-manager.git
-cd aws-manager
-```
-
-2. Install dependencies:
+This app is a workspace in the [dev-tools-starter-agent](../../) monorepo, which
+installs with **Bun** — not npm or yarn.
 
 ```bash
-npm install
-# or
-yarn install
-# or
-pnpm install
-```
+git clone https://github.com/OpenSourceAGI/dev-tools-starter-agent.git
+cd dev-tools-starter-agent
+bun install                                    # from the repo root
 
-3. Configure the environment:
-
-```bash
+cd apps/Cloud-Computer-Control-Panel
 cp .env.example .env
-# BETTER_AUTH_SECRET is required — it signs sessions and, unless you set
-# CREDENTIALS_ENCRYPTION_KEY separately, encrypts stored AWS secret keys.
-openssl rand -base64 32
+openssl rand -base64 32                        # paste into BETTER_AUTH_SECRET
+bun run db:push                                # applies lib/db/schema.ts
+bun run dev                                    # http://localhost:3000
 ```
 
-4. Create the database schema:
+`BETTER_AUTH_SECRET` is the only variable you must set. With `DATABASE_URL`
+unset the app writes a local SQLite file at `./data/cccp.db`, so nothing else
+is needed to sign in and start managing instances — AWS keys are entered in
+the UI, not in `.env`.
+
+Then, in the browser:
+
+1. Click **Sign in** and create an account with an email and password.
+2. In the dashboard, enter your AWS Access Key ID and Secret Access Key.
+3. CCCP verifies them against AWS, encrypts the secret, and stores it against
+   your account.
+
+## Environment variables
+
+Values are read in [`env.ts`](./env.ts) and `lib/`. Put them in
+`apps/Cloud-Computer-Control-Panel/.env` locally, and in your host's
+environment-variable settings in production. Only `BETTER_AUTH_SECRET` is
+required; each of the others turns on one more feature.
+
+### App identity
+
+| Variable | Enables | Where to get it |
+| --- | --- | --- |
+| `NEXT_PUBLIC_APP_NAME` | The name shown in the header and page titles. | Your own value; defaults to `CCCP`. |
+| `NEXT_PUBLIC_APP_URL` | Absolute URLs, and the OAuth callback origin. | Your own origin — `http://localhost:3000` in development. |
+| `NEXT_PUBLIC_APP_EMAIL`, `NEXT_PUBLIC_APP_DESCRIPTION` | Contact address and meta description. | Your own values. |
+
+### Database — libSQL / Turso
+
+| Variable | Enables | Where to get it |
+| --- | --- | --- |
+| `DATABASE_URL` (alias `TURSO_DATABASE_URL`) | A hosted database instead of the local file. Leave empty for `./data/cccp.db`. | Run `npm create cloud-db`, or create a database at [turso.tech](https://turso.tech) and copy its libSQL URL. |
+| `DATABASE_AUTH_TOKEN` (alias `TURSO_AUTH_TOKEN`) | Authenticating to that database. | Turso dashboard → your database → **Create Token**, or `turso db tokens create <name>`. |
+
+### Auth
+
+| Variable | Enables | Where to get it |
+| --- | --- | --- |
+| `BETTER_AUTH_SECRET` | **Required.** Signs sessions, and — unless `CREDENTIALS_ENCRYPTION_KEY` is set — encrypts stored AWS secret keys. | Generate one: `openssl rand -base64 32`. See [better-auth installation](https://www.better-auth.com/docs/installation). |
+| `CREDENTIALS_ENCRYPTION_KEY` | A separate key for credential encryption at rest, so session-secret rotation does not invalidate stored AWS keys. | Generate one: `openssl rand -base64 32`. Rotating it makes already-stored secret keys unreadable — users must re-enter them. |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | "Sign in with Google". | [Google Cloud Console → Credentials](https://console.cloud.google.com/apis/credentials) → OAuth client ID (Web application). Authorized redirect URI: `<APP_URL>/api/auth/callback/google`. |
+| `NEXT_PUBLIC_GOOGLE_CLIENT_ID` | The same client ID, for the browser. | Same value as `GOOGLE_CLIENT_ID`. |
+| `RESEND_API_KEY` (alias `AUTH_RESEND_KEY`) | Magic-link sign-in. Without it, only password and OAuth sign-in work. | [resend.com/api-keys](https://resend.com/api-keys) |
+| `AUTH_TRUSTED_ORIGINS` | Extra comma-separated origins allowed to call the auth endpoints — needed when the VS Code extension webview signs in against a deployed instance. | Your own origins. |
+
+### AWS fallback credentials
+
+Optional, and only for single-tenant installs. A user's own saved credentials
+always take priority over these; see
+[How credentials are stored](#how-credentials-are-stored).
+
+| Variable | Enables | Where to get it |
+| --- | --- | --- |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | Server-side fallback credentials when the signed-in user has stored none. | [AWS IAM console](https://console.aws.amazon.com/iam/home#/users) → your user → Security credentials → Create access key. The permissions needed are listed under [Prerequisites](#prerequisites). |
+| `AWS_REGION` | The default region. Defaults to `us-east-1`. | Any [AWS region code](https://docs.aws.amazon.com/general/latest/gr/rande.html). |
+
+## Deploying
+
+The app is a stock Next.js 16 build with a Node server runtime — the AWS SDK,
+`ssh2` and `node-forge` are marked external in
+[`next.config.mjs`](./next.config.mjs), so it needs Node, not an edge runtime.
 
 ```bash
-npm run db:push       # applies lib/db/schema.ts to DATABASE_URL
-npm run db:studio     # optional: browse the data
+bun run build
+bun run start        # serves the production build on :3000
 ```
 
-With `DATABASE_URL` unset, the app uses a local SQLite file at `./data/cccp.db`.
-For a hosted database, run `npm create cloud-db` (or point `DATABASE_URL` /
-`DATABASE_AUTH_TOKEN` at a Turso database).
+To deploy from this monorepo, point your host at the repository root, set the
+root directory to `apps/Cloud-Computer-Control-Panel`, and use `bun install` as
+the install command. Then:
 
-5. Run the development server:
-
-```bash
-npm run dev
-```
-
-6. Open [http://localhost:3000](http://localhost:3000) in your browser
-
-### Configuration
-
-1. Click **Sign in** and create an account with an email and password
-   (or configure `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` for Google sign-in)
-2. In the dashboard, enter your AWS Access Key ID and Secret Access Key
-3. CCCP verifies them against AWS, encrypts the secret, and stores it against your account
+1. Provision a hosted database and set `DATABASE_URL` / `DATABASE_AUTH_TOKEN` —
+   the default local SQLite file does not survive a container restart.
+2. Run `bun run db:push` once against it to create the schema.
+3. Set `BETTER_AUTH_SECRET` and `CREDENTIALS_ENCRYPTION_KEY` as secrets, and
+   keep them stable across deploys: rotating either signs everyone out, and
+   rotating the second one orphans every stored AWS credential.
+4. Set `NEXT_PUBLIC_APP_URL` to the deployed origin, and add that origin to the
+   Google OAuth client's authorized redirect URIs if you use Google sign-in.
+5. Add `AUTH_TRUSTED_ORIGINS` if the VS Code extension will sign in against
+   this instance.
 
 ### How credentials are stored
 

--- a/apps/cccp-vscode-ext/README.md
+++ b/apps/cccp-vscode-ext/README.md
@@ -85,13 +85,28 @@ deployment and sign in with a password you set there.
 | `CCCP: Open the Web Dashboard in a Browser` | Opens `/dashboard` on the configured server |
 | `CCCP: Reload Panel` | Re-renders the webview |
 
-## Settings
+## Configuration
+
+An extension has no `.env` — **this extension reads no environment variables at
+all.** Everything it needs is either a VS Code setting or a secret VS Code holds
+for it:
 
 | Setting | Default | Description |
 | --- | --- | --- |
 | `cccp.serverUrl` | `http://localhost:3000` | Base URL of your CCCP deployment |
 | `cccp.followVsCodeTheme` | `true` | Match the panel's light/dark mode to the editor theme |
 | `cccp.requestTimeoutMs` | `60000` | How long to wait on the server; provisioning calls are slow |
+
+Change them in **Settings → Extensions → CCCP**, or with
+`CCCP: Set Server URL`.
+
+The session cookie lives in VS Code's
+[SecretStorage](https://code.visualstudio.com/api/references/vscode-api#SecretStorage)
+(`AuthManager` in `src/`), not in a setting file, and your AWS keys never live
+here at all — they are encrypted and stored by the CCCP server you sign in to.
+Every key CCCP itself needs (`BETTER_AUTH_SECRET`, the database URL, Google
+OAuth, Resend) is configured on that deployment; see
+[its README](../Cloud-Computer-Control-Panel/README.md#environment-variables).
 
 ## Development
 
@@ -110,6 +125,32 @@ Then press <kbd>F5</kbd> in VS Code to launch an Extension Development Host.
 its own `node_modules` — see `resolveCccpImportsHere()` in `webview-ui/vite.config.ts` and the `"*"`
 path fallback in `webview-ui/tsconfig.json` — so the Next.js app does not need to be installed to
 build the panel.
+
+## Packaging and publishing
+
+```bash
+bun run package                      # production bundle: webview-ui/dist + dist/extension.js
+bunx @vscode/vsce package            # → cccp-vscode-<version>.vsix
+```
+
+Install the result locally with **Extensions → … → Install from VSIX**, or
+`code --install-extension cccp-vscode-<version>.vsix`.
+
+To publish to the Marketplace under the `opensourceagi` publisher, you need a
+Personal Access Token with the **Marketplace → Manage** scope from an Azure
+DevOps organization — see
+[Publishing Extension](https://code.visualstudio.com/api/working-with-extensions/publishing-extension)
+for the walkthrough and
+[dev.azure.com](https://dev.azure.com) to create the token. Then:
+
+```bash
+bunx @vscode/vsce login opensourceagi   # paste the PAT once
+bunx @vscode/vsce publish               # bump "version" in package.json first
+```
+
+`vscode:prepublish` runs `bun run package` for you, so the bundle is always
+rebuilt before it ships. The PAT is a credential: keep it in `vsce`'s own
+keychain entry, never in the repository.
 
 ## Notes
 

--- a/apps/dev-tools-help-docs/README.md
+++ b/apps/dev-tools-help-docs/README.md
@@ -1,0 +1,135 @@
+<!-- template-git-repo:badges:start -->
+<p align="center">
+    <a href="https://starterdocs.vtempest.workers.dev/docs/apps/dev-tools-help-docs"><img src="https://img.shields.io/badge/Docs-blue?logo=ReadTheDocs&logoColor=white" alt="Documentation" /></a>
+    <a href="https://stackblitz.com/github/OpenSourceAGI/dev-tools-starter-agent/tree/master/apps/dev-tools-help-docs"><img height="20px" src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt="Open in StackBlitz" /></a>
+    <br />
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/stargazers"><img src="https://img.shields.io/github/stars/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Stars" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/issues"><img src="https://img.shields.io/github/issues/OpenSourceAGI/dev-tools-starter-agent?logo=github" alt="GitHub Issues" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls"><img src="https://img.shields.io/github/issues-pr/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs" alt="Open Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/pulls?q=is%3Apr+is%3Aclosed"><img src="https://img.shields.io/github/issues-pr-closed/OpenSourceAGI/dev-tools-starter-agent?logo=github&label=PRs%20merged&color=8957e5" alt="Merged Pull Requests" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/discussions"><img src="https://img.shields.io/github/discussions/OpenSourceAGI/dev-tools-starter-agent" alt="GitHub Discussions" /></a>
+    <a href="https://github.com/OpenSourceAGI/dev-tools-starter-agent/commits/master/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/dev-tools-starter-agent.svg" alt="GitHub last commit" /></a>
+    <br />
+    <img src="https://img.shields.io/badge/Bun-14151A?logo=bun&logoColor=white" alt="Bun" /> <img src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white" alt="TypeScript" /> <img src="https://img.shields.io/badge/Next.js-black?logo=nextdotjs&logoColor=white" alt="Next.js" /> <img src="https://img.shields.io/badge/React-20232A?logo=react&logoColor=white" alt="React" /> <img src="https://img.shields.io/badge/Tailwind%20CSS-06B6D4?logo=tailwindcss&logoColor=white" alt="Tailwind CSS" /> <img src="https://img.shields.io/badge/shadcn%2Fui-000000?logo=shadcnui&logoColor=white" alt="shadcn/ui" /> <img src="https://img.shields.io/badge/Vercel%20AI%20SDK-black?logo=vercel&logoColor=white" alt="Vercel AI SDK" /> <img src="https://img.shields.io/badge/Zod-3E67B1?logo=zod&logoColor=white" alt="Zod" /> <img src="https://img.shields.io/badge/Fumadocs-000000" alt="Fumadocs" />
+</p>
+<!-- template-git-repo:badges:end -->
+
+# dev-tools-help-docs
+
+The documentation site for the whole catalog —
+[starterdocs.vtempest.workers.dev](https://starterdocs.vtempest.workers.dev/).
+Next.js + [Fumadocs](https://fumadocs.dev), with an AI chat assistant,
+full-text search, and an API reference generated from TypeScript types and
+OpenAPI specs.
+
+## What it does
+
+| Area | Route | What you get |
+| --- | --- | --- |
+| Docs | `/docs/**` | Every page under `content/docs`, with Fumadocs' sidebar, search and TOC. |
+| Package pages | `/docs/(index)/**` | One page per package and app, synced from its `README.md`. |
+| API reference | `/docs/**` | Type tables, dependency graphs and file trees rendered by `packages/code-tree-graph`, generated at build time. |
+| Chat assistant | `/api/chat` | Answers questions against the docs corpus, with Groq for generation and OpenAI for embeddings. |
+| Search | `/api/search` | Fumadocs' full-text index over the same corpus. |
+| Machine-readable | `/llms.txt`, `/llms-full.txt`, `/docs/**.mdx` | The same content for agents; `/docs/:path*.mdx` rewrites to `/llms.mdx/:path*`. |
+| Feeds and cards | `/rss.xml`, `/sitemap.xml`, `/og/**` | Syndication and generated Open Graph images. |
+
+## Content comes from two places
+
+- **`content/docs/`** — pages written here by hand.
+- **Package READMEs**, copied in by `bun run docs:sync` (or
+  `bun ./scripts/sync-readme-docs.ts`), which also runs as part of
+  `build:pre`.
+
+**Synced pages are generated.** Editing the copy under
+`content/docs/(index)/` is lost on the next sync — edit the package's own
+`README.md` instead. And that README's header row is itself generated, so the
+full chain is:
+
+```plaintext
+package.json → scripts/sync-package-readmes.mjs → packages/<x>/README.md
+             → apps/dev-tools-help-docs/scripts/sync-readme-docs.ts → this site
+```
+
+## Quick start
+
+```bash
+bun install          # from the repo root — never npm or yarn
+cd apps/dev-tools-help-docs
+bun run dev          # http://localhost:3000
+```
+
+No environment variables are needed to browse or build the site. `postinstall`
+runs `fumadocs-mdx`; a missing content type or a "cannot find `.source`" error
+after a fresh clone almost always means it did not — re-run `bun install` or
+`bunx fumadocs-mdx` rather than hand-writing the type.
+
+## Environment variables
+
+Everything here is optional: the site builds and serves with none of it set,
+and the providers are constructed lazily so a missing key fails the one request
+that needs it rather than the build (see
+[`src/lib/ai/providers.ts`](./src/lib/ai/providers.ts)).
+
+Put values in a `.env` in this directory, or in `.env` at the repo root — the
+`with-env` script reads `../../.env`.
+
+| Variable | Enables | Where to get it |
+| --- | --- | --- |
+| `GROQ_API_KEY` | The docs chat assistant at `/api/chat`. Without it the route returns a `MissingApiKeyError`; the rest of the site is unaffected. Model: `llama-3.3-70b-versatile`. | [console.groq.com/keys](https://console.groq.com/keys) |
+| `OPENAI_API_KEY` | Embeddings for the assistant's retrieval step (`text-embedding-3-small`). Needed alongside `GROQ_API_KEY`. | [platform.openai.com/api-keys](https://platform.openai.com/api-keys) |
+| `NEXT_PUBLIC_BASE_URL` | The absolute base for canonical links, Open Graph images and the sitemap. Falls back to a relative base in development. | Your own deployed origin, e.g. `https://starterdocs.vtempest.workers.dev`. |
+| `SOURCE_MAPS` | `"true"` emits production browser source maps. Off by default. | — |
+
+## Scripts
+
+| Script | What it does |
+| --- | --- |
+| `dev` | `next dev` on port 3000. |
+| `build` | `next build` only — assumes the generated content is current. |
+| `build:full` | `build:pre` → `next build` → `build:post`. **This is the one to deploy.** |
+| `build:pre` | Regenerates the API reference and re-syncs package READMEs. |
+| `docs:sync` | Just the README sync. |
+| `typegen` / `typecheck` | `fumadocs-mdx` + `next typegen`, then `tsc --noEmit`. |
+| `check` / `lint` / `format` | Biome. |
+| `check:spelling` | cspell over the content. |
+
+## Biome stays here
+
+**This is the only Biome workspace in the repository.** `check`, `lint`,
+`format` and `check:write` are Biome, and nothing outside
+`apps/dev-tools-help-docs` is formatted by it — there is no repo-wide
+formatter. Never run Biome over the rest of the monorepo; it rewrites files
+nobody formats that way. The app's `commitlint.config.ts`, `.cspell.jsonc` and
+`bunfig.toml` are scoped here for the same reason.
+
+## Deploying
+
+```bash
+bun run build:full       # generate content, then build
+bun run start            # serve the production build locally
+```
+
+No host configuration is committed in this directory — there is no
+`wrangler.jsonc` or `vercel.json` here, so the deployment at
+`starterdocs.vtempest.workers.dev` is configured on the host side, from a
+Git connection. To point a new host at it:
+
+| Setting | Value |
+| --- | --- |
+| Root directory | `apps/dev-tools-help-docs` |
+| Install command | `bun install` (run from the repo root) |
+| Build command | `bun run build:full` |
+| Output | `.next` — a Node server build, not a static export |
+| Node/Bun | Bun 1.3+ |
+
+Then set `NEXT_PUBLIC_BASE_URL` to the deployed origin, and add `GROQ_API_KEY`
+and `OPENAI_API_KEY` as secrets if you want the chat assistant live. Use
+`build:full`, not `build`: plain `build` skips the pre-build step, so the API
+reference and the synced package pages ship stale.
+
+## Renders `code-tree-graph`
+
+The dependency graphs, file trees and type tables on this site come from
+`packages/code-tree-graph`. A change to that package's props breaks the docs
+build, not its own tests.

--- a/apps/vscode-cloud/README.md
+++ b/apps/vscode-cloud/README.md
@@ -367,26 +367,31 @@ Extension failures during image build are non-fatal — the IDE still launches.
 
 ### Environment variables (`wrangler.jsonc` vars)
 
-| Variable | Default | Description |
-|---|---|---|
-| `SLEEP_AFTER` | `"30m"` | Container idle timeout. `"30s"`, `"1h"`, etc. Max 24h |
-| `TEAM_DOMAIN` | `""` | Auth A — CF Access team URL |
-| `POLICY_AUD` | `""` | Auth A — CF Access AUD tag |
-| `GOOGLE_CLIENT_ID` | `""` | Auth B — Google OAuth client ID |
-| `ADMIN_EMAILS` | `""` | Comma-separated emails with platform-wide `/admin` access |
-| `WAKATIME_API_KEY` | `""` | Auto-configure WakaTime in every container |
-| `R2_BUCKET_NAME` | `"vscode-cloud-workspaces"` | R2 bucket name |
-| `GITHUB_REPOS` | `""` | Comma-separated `owner/repo` list to auto-clone |
+Non-secret values, edited in [`wrangler.jsonc`](./wrangler.jsonc) → `vars` and
+shipped with the next `wrangler deploy`. `keep_vars: true` stops Wrangler from
+deleting variables you added in the dashboard.
+
+| Variable | Default | Enables | Where to get it |
+|---|---|---|---|
+| `SLEEP_AFTER` | `"2m"` | Container idle timeout before hibernation. `"30s"`, `"5m"`, `"1h"`; max ~24h. | Your own choice — it trades cold starts against cost. |
+| `TEAM_DOMAIN` | `""` | Auth A — validates Cloudflare Access JWTs. | [Cloudflare One](https://one.dash.cloudflare.com) → Settings → Custom Pages; it is `https://<your-team-name>.cloudflareaccess.com`. |
+| `POLICY_AUD` | `""` | Auth A — the audience the JWT must carry. | Cloudflare One → Access → Applications → your app → **AUD tag**. |
+| `GOOGLE_CLIENT_ID` | `""` | Auth B — Google OAuth sign-in. | [Google Cloud Console → Credentials](https://console.cloud.google.com/apis/credentials) → OAuth client ID (Web application). Redirect URI: `https://<your-worker>.workers.dev/auth/callback`. |
+| `ADMIN_EMAILS` | `""` | Comma-separated addresses with platform-wide `/admin` access. | Your own addresses. |
+| `WAKATIME_API_KEY` | `""` | Writes `~/.wakatime.cfg` in every container so users skip setup. | [wakatime.com/settings/account](https://wakatime.com/settings/account), or a team API key. |
+| `R2_BUCKET_NAME` | `"vscode-cloud-workspaces"` | Which bucket workspaces persist to. | The name you passed to `wrangler r2 bucket create`. |
+| `GITHUB_REPOS` | `""` | Comma-separated `owner/repo` list auto-cloned into `/workspace` on start. | Your own repositories. |
 
 ### Secrets (`wrangler secret put`)
 
-| Secret | Description |
-|---|---|
-| `R2_ACCESS_KEY_ID` | R2 API token key |
-| `R2_SECRET_ACCESS_KEY` | R2 API token secret |
-| `R2_ACCOUNT_ID` | Cloudflare account ID |
-| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret (auth option B) |
-| `GITHUB_TOKEN` | GitHub PAT with `repo` scope (private repos only) |
+Never put these in `wrangler.jsonc` — it is committed.
+
+| Secret | Enables | Where to get it |
+|---|---|---|
+| `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` | The FUSE mount inside the container, over R2's S3-compatible endpoint. | [Cloudflare dashboard](https://dash.cloudflare.com) → R2 → **Manage R2 API Tokens** → Create token with *Object Read & Write* on the bucket. |
+| `R2_ACCOUNT_ID` | The S3 endpoint host for that account. | Cloudflare dashboard → any zone → Account ID in the right-hand sidebar, or `wrangler whoami`. |
+| `GOOGLE_CLIENT_SECRET` | Auth option B, alongside `GOOGLE_CLIENT_ID`. | The same [Google Cloud Console credential](https://console.cloud.google.com/apis/credentials) that issued the client ID. |
+| `GITHUB_TOKEN` | Cloning private repos listed in `GITHUB_REPOS`. | [github.com/settings/tokens](https://github.com/settings/tokens) — a PAT with the `repo` scope. |
 
 ### Cloudflare resources
 


### PR DESCRIPTION
Part of a pass across all five repos making every `apps/*/README.md` describe what the app does, how to set it up and deploy it, and which environment variables it needs — with a link to the page that issues each one.

## What changed

`apps/dev-tools-help-docs` had no README at all. The three that existed documented setup unevenly: none said where to obtain the keys they name, and two had no deploy section.

**New — `apps/dev-tools-help-docs/README.md`**
What the site serves (docs, synced package pages, API reference, chat assistant, `llms.txt`), the two-source content pipeline and why synced pages must not be hand-edited, the optional `GROQ_API_KEY` / `OPENAI_API_KEY` / `NEXT_PUBLIC_BASE_URL` / `SOURCE_MAPS` variables, why Biome is scoped to this workspace alone, and the `build:full` deploy path — including why plain `build` ships a stale API reference.

**`apps/Cloud-Computer-Control-Panel`**
- Replaced the getting-started section: it told readers to `npm install` (the repo pins `bun@1.3.11`) and to clone `github.com/yourusername/aws-manager.git`.
- Added a grouped environment-variable reference — app identity, libSQL/Turso, auth, AWS fallback credentials — with a "where to get it" link per row.
- Added a Deploying section covering the hosted database, running `db:push` once against it, the two keys that must stay stable across deploys (rotating `CREDENTIALS_ENCRYPTION_KEY` orphans every stored AWS credential), and OAuth origins.

**`apps/cccp-vscode-ext`**
- States plainly that the extension reads no environment variables, and where configuration actually lives (VS Code settings, SecretStorage), pointing at CCCP's own table for the server side.
- Added packaging and Marketplace publishing, including the Azure DevOps PAT scope needed.

**`apps/vscode-cloud`**
- Added a "where to get it" column to the vars and secrets tables (Cloudflare One AUD tag, R2 API tokens, Google credentials, WakaTime, GitHub PAT).
- Corrected the documented `SLEEP_AFTER` default from `30m` to `2m` to match `wrangler.jsonc`.

## Verification

`bun run readmes:check` passes — the new README's generated header was produced by `bun run readmes` rather than hand-written, since the generator covers `apps/` as well as `packages/`.

Documentation only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017kjFYq4o9xD5UQdZ16XctF

---
_Generated by [Claude Code](https://claude.ai/code/session_017kjFYq4o9xD5UQdZ16XctF)_