### PR TITLE
🔧 fix(template-git-repo): point tests and docs at .github/scripts

### DIFF
--- a/packages/template-git-repo/README.md
+++ b/packages/template-git-repo/README.md
@@ -52,7 +52,7 @@ is overwritten without `--force`, and `--dry-run` prints the exact plan.
 | `.github/workflows/auto-merge-claude.yml` | Auto-merges agent PRs once their checks pass |
 | `.github/workflows/auto-merge-and-create-prs.yml` | Twice-daily sweep: merges green PRs, opens PRs for orphan branches |
 | `.github/workflows/deploy-test-reports.yml` | Publishes the HTML test report to Cloudflare Workers |
-| `scripts/*.mjs` | The five helpers those workflows call |
+| `.github/scripts/*.mjs` | The five helpers those workflows call |
 | `turbo.json` | Pipeline whose task names the workflows use |
 | `codecov.yml` | Per-package flags with `carryforward` |
 | `README.md` | The badge block, between markers |
@@ -86,7 +86,7 @@ Run `bunx template-git-repo --help` for the rest.
 
 ## The parts worth knowing
 
-**The test matrix is discovered, not written.** `scripts/list-test-packages.mjs`
+**The test matrix is discovered, not written.** `.github/scripts/list-test-packages.mjs`
 reads the `workspaces` globs and emits one matrix entry per package with a test
 script. A hand-maintained matrix fails silently — a package added to the repo but
 not to the matrix is never tested, and nothing goes red to say so.

--- a/packages/template-git-repo/bin/template-git-repo.js
+++ b/packages/template-git-repo/bin/template-git-repo.js
@@ -31,7 +31,7 @@ Usage
 
 What it writes
   .github/workflows/   tests, npm publish, auto-merge, hosted test reports
-  scripts/*.mjs        the helpers those workflows call
+  .github/scripts/     the helpers those workflows call
   turbo.json           pipeline whose task names the workflows use
   codecov.yml          per-package flags with carryforward
   README.md            the badge block, between markers
@@ -159,7 +159,7 @@ export async function main(argv = process.argv.slice(2)) {
 
   // ── Workflows, scripts, turbo.json, codecov.yml ───────────────────────────
   if (!badgesOnly) {
-    const include = actionsOnly ? ['.github', 'scripts'] : undefined;
+    const include = actionsOnly ? ['.github'] : undefined;
     const filePlan = planFiles({ context, force, include }).filter(
       (entry) => !(skipTurbo && entry.path === 'turbo.json'),
     );

--- a/packages/template-git-repo/docs/ACTIONS.md
+++ b/packages/template-git-repo/docs/ACTIONS.md
@@ -37,7 +37,7 @@ Analytics, which tracks per-test run time and flakiness and comments failures on
 the PR.
 
 **The matrix is discovered, not written.** A `discover` job runs
-`scripts/list-test-packages.mjs`, which reads the `workspaces` globs from the root
+`.github/scripts/list-test-packages.mjs`, which reads the `workspaces` globs from the root
 `package.json` and emits one entry per package with a `test:coverage`, `test:ci`
 or `test` script. A hand-maintained matrix fails silently — a package added to
 the repo but not to the matrix is simply never tested, and nothing goes red to
@@ -91,16 +91,16 @@ Five rules are encoded in it, each learned from a specific failure:
    it`, which reads like a missing package — and it arrives *after* every package
    has been built, with a provenance statement already signed into the public
    sigstore transparency log for each failed attempt.
-3. **Walk the workspace in dependency order** (`scripts/workspace-build-order.mjs`).
+3. **Walk the workspace in dependency order** (`.github/scripts/workspace-build-order.mjs`).
    Package managers link workspace siblings as symlinks; a sibling that has not
    been built has no `dist/`, and its `exports` → `types` entries point at files
    that do not exist. Alphabetical order produces
    `Cannot find module '<sibling>' or its corresponding type declarations`.
 4. **Never publish the literal `workspace:*` protocol** — no consumer outside the
-   monorepo can resolve it. `scripts/pin-workspace-deps.mjs` substitutes real
-   ranges at pack time; `scripts/restore-pinned-deps.mjs` takes them back out
+   monorepo can resolve it. `.github/scripts/pin-workspace-deps.mjs` substitutes real
+   ranges at pack time; `.github/scripts/restore-pinned-deps.mjs` takes them back out
    afterwards, so only the version bump gets committed.
-5. **The registry decides which versions are spent** (`scripts/next-free-version.mjs`).
+5. **The registry decides which versions are spent** (`.github/scripts/next-free-version.mjs`).
    npm refuses a PUT for any version it has *ever* seen, including ones staged by
    an interrupted publish that the `latest` dist-tag cannot show you:
    `E409 ... Cannot publish over previously staged version`. The union of

--- a/packages/template-git-repo/test/apply.test.js
+++ b/packages/template-git-repo/test/apply.test.js
@@ -40,11 +40,11 @@ describe('the shipped template', () => {
         '.github/workflows/auto-merge-claude.yml',
         '.github/workflows/auto-merge-and-create-prs.yml',
         '.github/workflows/deploy-test-reports.yml',
-        'scripts/workspace-build-order.mjs',
-        'scripts/next-free-version.mjs',
-        'scripts/pin-workspace-deps.mjs',
-        'scripts/restore-pinned-deps.mjs',
-        'scripts/list-test-packages.mjs',
+        '.github/scripts/workspace-build-order.mjs',
+        '.github/scripts/next-free-version.mjs',
+        '.github/scripts/pin-workspace-deps.mjs',
+        '.github/scripts/restore-pinned-deps.mjs',
+        '.github/scripts/list-test-packages.mjs',
         'turbo.json',
         'codecov.yml',
       ]),
@@ -73,8 +73,15 @@ describe('the shipped template', () => {
   it('every template script parses as JavaScript', async () => {
     // These run in CI with no install step behind them, so a syntax error
     // surfaces as a failed workflow rather than a failed test.
-    for (const file of walk(path.join(TEMPLATE_DIR, 'scripts'))) {
-      await expect(import(path.join(TEMPLATE_DIR, 'scripts', file))).resolves.toBeDefined();
+    const scriptsDir = path.join(TEMPLATE_DIR, '.github', 'scripts');
+    const scripts = walk(scriptsDir);
+
+    // A silent zero here would make the check vacuous the next time the
+    // helpers move, which is exactly how they last went unnoticed.
+    expect(scripts.length).toBeGreaterThan(0);
+
+    for (const file of scripts) {
+      await expect(import(path.join(scriptsDir, file))).resolves.toBeDefined();
     }
   });
 
@@ -133,7 +140,7 @@ describe('applyPlan', () => {
     const root = scratch();
     applyPlan(planFiles({ context: { ...context, root } }));
 
-    const mode = fs.statSync(path.join(root, 'scripts', 'next-free-version.mjs')).mode;
+    const mode = fs.statSync(path.join(root, '.github', 'scripts', 'next-free-version.mjs')).mode;
     expect(mode & 0o111).toBeTruthy();
   });
 });

--- a/packages/template-git-repo/test/cli.test.js
+++ b/packages/template-git-repo/test/cli.test.js
@@ -54,7 +54,7 @@ describe('a full run', () => {
 
     expect(exists('.github/workflows/tests.yml')).toBe(true);
     expect(exists('.github/workflows/npm-publish.yml')).toBe(true);
-    expect(exists('scripts/list-test-packages.mjs')).toBe(true);
+    expect(exists('.github/scripts/list-test-packages.mjs')).toBe(true);
     expect(exists('turbo.json')).toBe(true);
     expect(exists('codecov.yml')).toBe(true);
 
@@ -111,7 +111,7 @@ describe('scoped runs', () => {
     await main([...BASE, '--actions-only']);
 
     expect(exists('.github/workflows/tests.yml')).toBe(true);
-    expect(exists('scripts/next-free-version.mjs')).toBe(true);
+    expect(exists('.github/scripts/next-free-version.mjs')).toBe(true);
     expect(exists('turbo.json')).toBe(false);
     expect(read('README.md')).not.toContain('shields.io');
     expect(JSON.parse(read('package.json')).scripts).toBeUndefined();

--- a/packages/template-git-repo/test/template-scripts.test.js
+++ b/packages/template-git-repo/test/template-scripts.test.js
@@ -3,11 +3,11 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { TEMPLATE_DIR } from '../src/apply.js';
-import { testablePackages, workspaceDirectories, formatOutput } from '../template/scripts/list-test-packages.mjs';
-import { pinWorkspaceDeps, readSiblings } from '../template/scripts/pin-workspace-deps.mjs';
-import { patchVersion, restore } from '../template/scripts/restore-pinned-deps.mjs';
-import { nextFreeVersion, takenVersions } from '../template/scripts/next-free-version.mjs';
-import { workspaceBuildOrder } from '../template/scripts/workspace-build-order.mjs';
+import { testablePackages, workspaceDirectories, formatOutput } from '../template/.github/scripts/list-test-packages.mjs';
+import { pinWorkspaceDeps, readSiblings } from '../template/.github/scripts/pin-workspace-deps.mjs';
+import { patchVersion, restore } from '../template/.github/scripts/restore-pinned-deps.mjs';
+import { nextFreeVersion, takenVersions } from '../template/.github/scripts/next-free-version.mjs';
+import { workspaceBuildOrder } from '../template/.github/scripts/workspace-build-order.mjs';
 
 const temporaryDirectories = [];
 
@@ -183,13 +183,13 @@ describe('next-free-version', () => {
 });
 
 describe('the template ships what the workflows call', () => {
-  it('every scripts/*.mjs referenced in a workflow exists', () => {
+  it('every .github/scripts/*.mjs referenced in a workflow exists', () => {
     const workflowsDir = path.join(TEMPLATE_DIR, '.github', 'workflows');
     const referenced = new Set();
 
     for (const file of fs.readdirSync(workflowsDir)) {
       const yaml = fs.readFileSync(path.join(workflowsDir, file), 'utf8');
-      for (const match of yaml.matchAll(/node\s+(?:"\$repo_root\/")?(scripts\/[\w-]+\.mjs)/g)) {
+      for (const match of yaml.matchAll(/node\s+"?(?:\$repo_root\/)?(\.github\/scripts\/[\w-]+\.mjs)/g)) {
         referenced.add(match[1]);
       }
     }


### PR DESCRIPTION
Fixes the `template-git-repo#coverage` failure on the Tests workflow.

## What was broken

#99 moved root scripts under `.github` — including the template's five helpers, from `template/scripts/` to `template/.github/scripts/`. The workflows that call them were updated in that PR; nothing that *describes* the path was.

Four consequences, one of them silent:

| | |
| --- | --- |
| `test/template-scripts.test.js` | imported the helpers from the old path, so the file failed to load and **18 tests stopped running entirely** |
| `test/apply.test.js`, `test/cli.test.js` | asserted the old output paths — the 4 reported failures |
| "every template script parses as JavaScript" | walked a directory that no longer exists; `walk()` returns `[]` for a missing dir, so it passed over nothing |
| "every `scripts/*.mjs` referenced in a workflow exists" | lived in the suite that never loaded, and its regex only matched a bare `scripts/` prefix |

## What changed

- Test imports and path assertions updated to `.github/scripts/`.
- The parse check now asserts it actually found scripts before looping — that assertion is what would have caught this move.
- The workflow-reference regex matches the `.github/scripts/` prefix (and the `"$repo_root/…"` quoting the publish workflow uses).
- CLI `--help` listing, `README.md` and `docs/ACTIONS.md` corrected to the real output path.
- Dropped the now-dead `'scripts'` entry from the `--actions-only` include list; `.github` already covers the helpers.

**No behaviour change** — the CLI was already writing the files where the workflows expect them. Only the tests and the prose were stale.

## Verification

```
packages/template-git-repo: 7 files, 122 passed  (was 3 failed / 104 running)
bun run coverage            green — this is the job that was red
bun run test (root)         19 tasks, all successful
```

Out of scope, noted for whoever picks it up: `bun run readmes:check` reports `packages/native-app-wrapper/README.md` stale on `master` already, from the code2app rename. No workflow runs that check, so it is not what turned CI red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vu8xdPAjoHexnuxXUkYvDB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vu8xdPAjoHexnuxXUkYvDB)_